### PR TITLE
최근 멘션 조회 시 조회 안되는 오류 수정 (채널에서 검색 시 기존 Full-Text Search 방식을 LIKE 검색으로 …

### DIFF
--- a/webapp/channels/src/actions/views/rhs.ts
+++ b/webapp/channels/src/actions/views/rhs.ts
@@ -218,13 +218,8 @@ export function performSearch(terms: string, teamId: string, isMentionSearch?: b
         }
 
         if (isMentionSearch) {
-            // For mentions, perform a specific search by quoting all terms.
-            // This ensures terms split by dashes or other symbols are treated as a single unit.
-            const termsArr = searchTerms.split(' ').filter((t) => Boolean(t && t.trim()));
-            for (let i = 0; i < termsArr.length; i++) {
-                termsArr[i] = `"${termsArr[i]}"`;
-            }
-            searchTerms = termsArr.join(' ');
+            // LIKE 검색을 사용하므로 따옴표로 감싸지 않음
+            searchTerms = searchTerms.trim();
         }
 
         // timezone offset in seconds


### PR DESCRIPTION
채널에서 검색 시 기존 Full-Text Search 방식을 LIKE 검색으로 수정한 영향으로 '최근 멘션 조회' 시 나를 지정한 멘션이 있는 글목록이 조회 안되는 이슈 있어 수정함 

- 원래는 아래와 같이 파라미터가 넘어감 (이러면 LIKE 검색에서 조회되지 않음)
{"terms": "\"@myid\""

- 아래처럼 조회 파라미터가 넘어가도록 수정 
{"terms": "@myid"