### PR TITLE
fix: styled-components webpack alias 경로 수정

### DIFF
--- a/webapp/channels/webpack.config.js
+++ b/webapp/channels/webpack.config.js
@@ -136,7 +136,7 @@ var config = {
             '@mui/styled-engine': '@mui/styled-engine-sc',
 
             // This alias restricts single version of styled components across all packages
-            'styled-components': path.resolve(__dirname, '..', 'node_modules', 'styled-components'),
+            'styled-components': path.resolve(__dirname, 'node_modules', 'styled-components'),
         },
         extensions: ['.ts', '.tsx', '.js', '.jsx'],
         fallback: {


### PR DESCRIPTION
## 버그 수정

### 문제점
Webpack 빌드 시 `styled-components` 모듈을 찾을 수 없다는 오류가 여러 패키지에서 발생:
- `@giphy/react-components`
- `@mui/styled-engine-sc`
- `platform/components`

### 원인
webpack.config.js의 `styled-components` alias가 `../node_modules/styled-components` (webapp/node_modules)를 가리키고 있었으나, 실제 패키지는 `channels/node_modules/styled-components`에 설치되어 있었습니다.

### 해결 방법
webpack alias 경로를 다음과 같이 수정:
```js
// 수정 전
path.resolve(__dirname, '..', 'node_modules', 'styled-components')

// 수정 후
path.resolve(__dirname, 'node_modules', 'styled-components')