### PR TITLE
feat: 멤버 필터링 기능 구현

### DIFF
--- a/webapp/channels/src/actions/views/channel.ts
+++ b/webapp/channels/src/actions/views/channel.ts
@@ -50,7 +50,7 @@ import {loadCustomStatusEmojisForPostList} from 'actions/emoji_actions';
 import {closeRightHandSide} from 'actions/views/rhs';
 import {markThreadAsRead} from 'actions/views/threads';
 import {getLastViewedChannelName} from 'selectors/local_storage';
-import {getSelectedPost, getSelectedPostId} from 'selectors/rhs';
+import {getMemberFilterUserIds, getSelectedPost, getSelectedPostId} from 'selectors/rhs';
 import {getLastPostsApiTimeForChannel} from 'selectors/views/channel';
 import {getSelectedThreadIdInCurrentTeam} from 'selectors/views/threads';
 import {getSocketStatus} from 'selectors/views/websocket';
@@ -247,7 +247,10 @@ export function autocompleteUsersInChannel(prefix: string, channelId: string): A
 }
 
 export function loadUnreads(channelId: string, prefetch = false): ActionFuncAsync<{atLatestMessage: boolean; atOldestMessage: boolean}> {
-    return async (dispatch) => {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const filterUserIds = getMemberFilterUserIds(state, channelId);
+
         const time = Date.now();
         if (prefetch) {
             dispatch({
@@ -256,7 +259,12 @@ export function loadUnreads(channelId: string, prefetch = false): ActionFuncAsyn
                 status: RequestStatus.STARTED,
             });
         }
-        const {data, error} = await dispatch(PostActions.getPostsUnread(channelId));
+        const {data, error} = await dispatch(PostActions.getPostsUnread(
+            channelId,
+            true,
+            false,
+            filterUserIds.length > 0 ? filterUserIds : undefined,
+        ));
         if (error) {
             if (prefetch) {
                 dispatch({
@@ -375,7 +383,10 @@ export function loadPosts({
     perPage,
 }: LoadPostsParameters): ThunkActionFunc<Promise<LoadPostsReturnValue>> {
     //type here can be BEFORE_ID or AFTER_ID
-    return async (dispatch) => {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const filterUserIds = getMemberFilterUserIds(state, channelId);
+
         dispatch({
             type: ActionTypes.LOADING_POSTS,
             data: true,
@@ -385,9 +396,25 @@ export function loadPosts({
         const page = 0;
         let result;
         if (type === PostRequestTypes.BEFORE_ID) {
-            result = await dispatch(PostActions.getPostsBefore(channelId, postId, page, perPage));
+            result = await dispatch(PostActions.getPostsBefore(
+                channelId,
+                postId,
+                page,
+                perPage,
+                true,
+                false,
+                filterUserIds.length > 0 ? filterUserIds : undefined,
+            ));
         } else {
-            result = await dispatch(PostActions.getPostsAfter(channelId, postId, page, perPage));
+            result = await dispatch(PostActions.getPostsAfter(
+                channelId,
+                postId,
+                page,
+                perPage,
+                true,
+                false,
+                filterUserIds.length > 0 ? filterUserIds : undefined,
+            ));
         }
 
         const {data} = result;
@@ -425,6 +452,7 @@ export function syncPostsInChannel(channelId: string, since: number, prefetch = 
         const time = Date.now();
         const state = getState();
         const socketStatus = getSocketStatus(state);
+        const filterUserIds = getMemberFilterUserIds(state, channelId);
         let sinceTimeToGetPosts = since;
         const lastPostsApiCallForChannel = getLastPostsApiTimeForChannel(state, channelId);
         const actions = [];
@@ -441,7 +469,13 @@ export function syncPostsInChannel(channelId: string, since: number, prefetch = 
             });
         }
 
-        const {data, error} = await dispatch(PostActions.getPostsSince(channelId, sinceTimeToGetPosts));
+        const {data, error} = await dispatch(PostActions.getPostsSince(
+            channelId,
+            sinceTimeToGetPosts,
+            true,
+            false,
+            filterUserIds.length > 0 ? filterUserIds : undefined,
+        ));
         if (data) {
             actions.push({
                 type: ActionTypes.RECEIVED_POSTS_FOR_CHANNEL_AT_TIME,

--- a/webapp/channels/src/actions/views/rhs.ts
+++ b/webapp/channels/src/actions/views/rhs.ts
@@ -497,6 +497,7 @@ export function closeRightHandSide(): ActionFunc {
                 channelId: '',
                 timestamp: 0,
             },
+            clearMemberFilterUserIds(),
         ];
 
         dispatch(batchActions(actionsBatch));
@@ -671,5 +672,20 @@ export function measureRhsOpened() {
         });
 
         performance.clearMarks(Mark.PostSelected);
+    };
+}
+
+export function setMemberFilterUserIds(channelId: string, userIds: string[]): {type: string; channelId: string; userIds: string[]} {
+    return {
+        type: ActionTypes.SET_MEMBER_FILTER_USER_IDS,
+        channelId,
+        userIds,
+    };
+}
+
+export function clearMemberFilterUserIds(channelId?: string): {type: string; channelId?: string} {
+    return {
+        type: ActionTypes.CLEAR_MEMBER_FILTER_USER_IDS,
+        channelId,
     };
 }

--- a/webapp/channels/src/actions/websocket_actions.jsx
+++ b/webapp/channels/src/actions/websocket_actions.jsx
@@ -119,7 +119,7 @@ import {openModal} from 'actions/views/modals';
 import {closeRightHandSide} from 'actions/views/rhs';
 import {incrementWsErrorCount, resetWsErrorCount} from 'actions/views/system';
 import {updateThreadLastOpened} from 'actions/views/threads';
-import {getSelectedChannelId, getSelectedPost} from 'selectors/rhs';
+import {getMemberFilterUserIds, getSelectedChannelId, getSelectedPost} from 'selectors/rhs';
 import {isThreadOpen, isThreadManuallyUnread} from 'selectors/views/threads';
 import store from 'stores/redux_store';
 
@@ -768,11 +768,21 @@ const handleNewPostEventDebounced = debouncePostEvent(100);
 
 export function handleNewPostEvent(msg) {
     return (myDispatch, myGetState) => {
+        const state = myGetState();
         const post = JSON.parse(msg.data.post);
 
         if (window.logPostEvents) {
             // eslint-disable-next-line no-console
             console.log('handleNewPostEvent - new post received', post);
+        }
+
+        // Check member filter
+        const filterUserIds = getMemberFilterUserIds(state, post.channel_id);
+        if (filterUserIds && filterUserIds.length > 0) {
+            if (!filterUserIds.includes(post.user_id)) {
+                // Post is filtered out - skip processing
+                return;
+            }
         }
 
         myDispatch(handleNewPost(post, msg));
@@ -824,6 +834,15 @@ export function handleNewPostEvents(queue) {
                 if (isBot || isWebhook || isSystemMessage) {
                     return false;
                 }
+            }
+            return true;
+        });
+
+        // Filter by member filter if enabled
+        posts = posts.filter((post) => {
+            const filterUserIds = getMemberFilterUserIds(state, post.channel_id);
+            if (filterUserIds && filterUserIds.length > 0) {
+                return filterUserIds.includes(post.user_id);
             }
             return true;
         });

--- a/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.scss
+++ b/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.scss
@@ -38,6 +38,18 @@
         }
     }
 
+    &__filter-checkbox {
+        display: flex;
+        align-items: center;
+        margin-right: 8px;
+
+        input[type='checkbox'] {
+            width: 16px;
+            height: 16px;
+            cursor: pointer;
+        }
+    }
+
     &__member {
         display: flex;
         flex-direction: row;

--- a/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.tsx
+++ b/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.tsx
@@ -43,6 +43,7 @@ export interface Props {
     channelMembers: ChannelMember[];
     canManageMembers: boolean;
     editing: boolean;
+    filterUserIds: string[];
 
     actions: {
         openModal: <P>(modalData: ModalData<P>) => void;
@@ -55,6 +56,7 @@ export interface Props {
         setEditChannelMembers: (active: boolean) => void;
         searchProfilesAndChannelMembers: (term: string, options: any) => Promise<{data: UserProfile[]}>;
         fetchRemoteClusterInfo: (remoteId: string, forceRefresh?: boolean) => void;
+        setMemberFilterUserIds: (channelId: string, userIds: string[]) => void;
     };
 }
 
@@ -68,6 +70,7 @@ export default function ChannelMembersRHS({
     channelMembers,
     canManageMembers,
     editing = false,
+    filterUserIds,
     actions,
 }: Props) {
     const history = useHistory();
@@ -212,6 +215,12 @@ export default function ChannelMembersRHS({
         await actions.closeRightHandSide();
     }, [actions.openDirectChannelToUserId, history, teamUrl, actions.closeRightHandSide]);
 
+    const handleToggleMemberFilter = useCallback((userId: string, checked: boolean) => {
+        const newFilterUserIds = checked ? [...filterUserIds, userId] : filterUserIds.filter((id) => id !== userId);
+
+        actions.setMemberFilterUserIds(channel.id, newFilterUserIds);
+    }, [filterUserIds, channel.id, actions]);
+
     const loadMore = useCallback(async () => {
         setIsNextPageLoading(true);
 
@@ -312,6 +321,8 @@ export default function ChannelMembersRHS({
                         members={list}
                         editing={editing}
                         channel={channel}
+                        filterUserIds={filterUserIds}
+                        onToggleMemberFilter={handleToggleMemberFilter}
                         openDirectMessage={openDirectMessage}
                         fetchRemoteClusterInfo={actions.fetchRemoteClusterInfo}
                         loadMore={loadMore}

--- a/webapp/channels/src/components/channel_members_rhs/index.ts
+++ b/webapp/channels/src/components/channel_members_rhs/index.ts
@@ -33,9 +33,9 @@ import {displayUsername} from 'mattermost-redux/utils/user_utils';
 import {openDirectChannelToUserId} from 'actions/channel_actions';
 import {loadProfilesAndReloadChannelMembers, searchProfilesAndChannelMembers} from 'actions/user_actions';
 import {openModal} from 'actions/views/modals';
-import {closeRightHandSide, goBack, setEditChannelMembers} from 'actions/views/rhs';
+import {closeRightHandSide, goBack, setEditChannelMembers, setMemberFilterUserIds} from 'actions/views/rhs';
 import {setChannelMembersRhsSearchTerm} from 'actions/views/search';
-import {getIsEditingMembers, getPreviousRhsState} from 'selectors/rhs';
+import {getIsEditingMembers, getMemberFilterUserIds, getPreviousRhsState} from 'selectors/rhs';
 
 import {Constants, RHSStates} from 'utils/constants';
 
@@ -120,6 +120,7 @@ function mapStateToProps(state: GlobalState) {
             canManageMembers: false,
             canGoBack: false,
             teamUrl: '',
+            filterUserIds: [],
         } as unknown as Props;
     }
 
@@ -149,6 +150,7 @@ function mapStateToProps(state: GlobalState) {
 
     const canGoBack = Boolean(hasInfoPrevState);
     const editing = getIsEditingMembers(state);
+    const filterUserIds = getMemberFilterUserIds(state, channel.id);
 
     const currentUserIsChannelAdmin = currentUser && currentUser.scheme_admin;
 
@@ -162,6 +164,7 @@ function mapStateToProps(state: GlobalState) {
         canManageMembers,
         channelMembers,
         editing,
+        filterUserIds,
     } as Props;
 }
 
@@ -178,6 +181,7 @@ function mapDispatchToProps(dispatch: Dispatch<AnyAction>) {
             setEditChannelMembers,
             searchProfilesAndChannelMembers,
             fetchRemoteClusterInfo,
+            setMemberFilterUserIds,
         }, dispatch),
     };
 }

--- a/webapp/channels/src/components/channel_members_rhs/member.tsx
+++ b/webapp/channels/src/components/channel_members_rhs/member.tsx
@@ -27,13 +27,16 @@ interface Props {
     index: number;
     totalUsers: number;
     editing: boolean;
+    isFilterable?: boolean;
+    isChecked?: boolean;
+    onToggleFilter?: (userId: string, checked: boolean) => void;
     actions: {
         openDirectMessage: (user: UserProfile) => void;
         fetchRemoteClusterInfo: (remoteId: string, forceRefresh?: boolean) => void;
     };
 }
 
-const Member = ({channel, member, index, totalUsers, editing, actions}: Props) => {
+const Member = ({channel, member, index, totalUsers, editing, isFilterable, isChecked, onToggleFilter, actions}: Props) => {
     const {formatMessage} = useIntl();
 
     // Fetch remote info when component mounts for remote users
@@ -51,6 +54,16 @@ const Member = ({channel, member, index, totalUsers, editing, actions}: Props) =
             style={{height: '48px'}}
             data-testid={`memberline-${member.user.id}`}
         >
+            {!editing && isFilterable && (
+                <div className='channel-members-rhs__filter-checkbox'>
+                    <input
+                        type='checkbox'
+                        checked={isChecked}
+                        onChange={(e) => onToggleFilter?.(member.user.id, e.target.checked)}
+                        onClick={(e) => e.stopPropagation()}
+                    />
+                </div>
+            )}
             <span className='ProfileSpan'>
                 <div className='channel-members-rhs__avatar'>
                     <ProfilePicture

--- a/webapp/channels/src/components/channel_members_rhs/member_list.tsx
+++ b/webapp/channels/src/components/channel_members_rhs/member_list.tsx
@@ -37,6 +37,8 @@ export interface Props {
     hasNextPage: boolean;
     isNextPageLoading: boolean;
     searchTerms: string;
+    filterUserIds?: string[];
+    onToggleMemberFilter?: (userId: string, checked: boolean) => void;
     openDirectMessage: (user: UserProfile) => void;
     fetchRemoteClusterInfo: (remoteId: string, forceRefresh?: boolean) => void;
     loadMore: () => void;
@@ -49,6 +51,8 @@ const MemberList = ({
     members,
     searchTerms,
     editing,
+    filterUserIds,
+    onToggleMemberFilter,
     openDirectMessage,
     fetchRemoteClusterInfo,
     loadMore,
@@ -109,6 +113,9 @@ const MemberList = ({
                             totalUsers={members.filter((l) => l.type === ListItemType.Member).length}
                             member={member}
                             editing={editing}
+                            isFilterable={!editing}
+                            isChecked={filterUserIds?.includes(member.user.id) || false}
+                            onToggleFilter={onToggleMemberFilter}
                             actions={{openDirectMessage, fetchRemoteClusterInfo}}
                         />
                     </div>

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
@@ -707,12 +707,12 @@ export function getNewestPostThread(rootId: string): ActionFuncAsync {
     };
 }
 
-export function getPosts(channelId: string, page = 0, perPage = Posts.POST_CHUNK_SIZE, fetchThreads = true, collapsedThreadsExtended = false): ActionFuncAsync<PostList> {
+export function getPosts(channelId: string, page = 0, perPage = Posts.POST_CHUNK_SIZE, fetchThreads = true, collapsedThreadsExtended = false, filterUserIds?: string[]): ActionFuncAsync<PostList> {
     return async (dispatch, getState) => {
         let posts;
         const collapsedThreadsEnabled = isCollapsedThreadsEnabled(getState());
         try {
-            posts = await Client4.getPosts(channelId, page, perPage, fetchThreads, collapsedThreadsEnabled, collapsedThreadsExtended);
+            posts = await Client4.getPosts(channelId, page, perPage, fetchThreads, collapsedThreadsEnabled, collapsedThreadsExtended, filterUserIds);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));
@@ -729,7 +729,7 @@ export function getPosts(channelId: string, page = 0, perPage = Posts.POST_CHUNK
     };
 }
 
-export function getPostsUnread(channelId: string, fetchThreads = true, collapsedThreadsExtended = false): ActionFuncAsync<PostList> {
+export function getPostsUnread(channelId: string, fetchThreads = true, collapsedThreadsExtended = false, filterUserIds?: string[]): ActionFuncAsync<PostList> {
     return async (dispatch, getState) => {
         const state = getState();
         const shouldLoadRecent = getUnreadScrollPositionPreference(state) === Preferences.UNREAD_SCROLL_POSITION_START_FROM_NEWEST;
@@ -739,10 +739,10 @@ export function getPostsUnread(channelId: string, fetchThreads = true, collapsed
         let posts;
         let recentPosts;
         try {
-            posts = await Client4.getPostsUnread(channelId, userId, DEFAULT_LIMIT_BEFORE, DEFAULT_LIMIT_AFTER, fetchThreads, collapsedThreadsEnabled, collapsedThreadsExtended);
+            posts = await Client4.getPostsUnread(channelId, userId, DEFAULT_LIMIT_BEFORE, DEFAULT_LIMIT_AFTER, fetchThreads, collapsedThreadsEnabled, collapsedThreadsExtended, filterUserIds);
 
             if (posts.next_post_id && shouldLoadRecent) {
-                recentPosts = await Client4.getPosts(channelId, 0, Posts.POST_CHUNK_SIZE / 2, fetchThreads, collapsedThreadsEnabled, collapsedThreadsExtended);
+                recentPosts = await Client4.getPosts(channelId, 0, Posts.POST_CHUNK_SIZE / 2, fetchThreads, collapsedThreadsEnabled, collapsedThreadsExtended, filterUserIds);
             }
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
@@ -771,12 +771,12 @@ export function getPostsUnread(channelId: string, fetchThreads = true, collapsed
     };
 }
 
-export function getPostsSince(channelId: string, since: number, fetchThreads = true, collapsedThreadsExtended = false): ActionFuncAsync<PostList> {
+export function getPostsSince(channelId: string, since: number, fetchThreads = true, collapsedThreadsExtended = false, filterUserIds?: string[]): ActionFuncAsync<PostList> {
     return async (dispatch, getState) => {
         let posts;
         try {
             const collapsedThreadsEnabled = isCollapsedThreadsEnabled(getState());
-            posts = await Client4.getPostsSince(channelId, since, fetchThreads, collapsedThreadsEnabled, collapsedThreadsExtended);
+            posts = await Client4.getPostsSince(channelId, since, fetchThreads, collapsedThreadsEnabled, collapsedThreadsExtended, filterUserIds);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));
@@ -793,12 +793,12 @@ export function getPostsSince(channelId: string, since: number, fetchThreads = t
     };
 }
 
-export function getPostsBefore(channelId: string, postId: string, page = 0, perPage = Posts.POST_CHUNK_SIZE, fetchThreads = true, collapsedThreadsExtended = false): ActionFuncAsync<PostList> {
+export function getPostsBefore(channelId: string, postId: string, page = 0, perPage = Posts.POST_CHUNK_SIZE, fetchThreads = true, collapsedThreadsExtended = false, filterUserIds?: string[]): ActionFuncAsync<PostList> {
     return async (dispatch, getState) => {
         let posts;
         try {
             const collapsedThreadsEnabled = isCollapsedThreadsEnabled(getState());
-            posts = await Client4.getPostsBefore(channelId, postId, page, perPage, fetchThreads, collapsedThreadsEnabled, collapsedThreadsExtended);
+            posts = await Client4.getPostsBefore(channelId, postId, page, perPage, fetchThreads, collapsedThreadsEnabled, collapsedThreadsExtended, filterUserIds);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));
@@ -815,12 +815,12 @@ export function getPostsBefore(channelId: string, postId: string, page = 0, perP
     };
 }
 
-export function getPostsAfter(channelId: string, postId: string, page = 0, perPage = Posts.POST_CHUNK_SIZE, fetchThreads = true, collapsedThreadsExtended = false): ActionFuncAsync<PostList> {
+export function getPostsAfter(channelId: string, postId: string, page = 0, perPage = Posts.POST_CHUNK_SIZE, fetchThreads = true, collapsedThreadsExtended = false, filterUserIds?: string[]): ActionFuncAsync<PostList> {
     return async (dispatch, getState) => {
         let posts;
         try {
             const collapsedThreadsEnabled = isCollapsedThreadsEnabled(getState());
-            posts = await Client4.getPostsAfter(channelId, postId, page, perPage, fetchThreads, collapsedThreadsEnabled, collapsedThreadsExtended);
+            posts = await Client4.getPostsAfter(channelId, postId, page, perPage, fetchThreads, collapsedThreadsEnabled, collapsedThreadsExtended, filterUserIds);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));

--- a/webapp/channels/src/reducers/views/rhs.ts
+++ b/webapp/channels/src/reducers/views/rhs.ts
@@ -423,6 +423,37 @@ function shouldFocusRHS(state = false, action: MMAction) {
     }
 }
 
+function memberFilterUserIds(state: Record<string, string[]> = {}, action: MMAction) {
+    switch (action.type) {
+    case ActionTypes.SET_MEMBER_FILTER_USER_IDS:
+        return {
+            ...state,
+            [action.channelId]: action.userIds,
+        };
+    case ActionTypes.CLEAR_MEMBER_FILTER_USER_IDS: {
+        if (!action.channelId) {
+            // 모든 채널의 필터 제거
+            return {};
+        }
+
+        // 특정 채널의 필터 제거
+        const newState = {...state};
+        delete newState[action.channelId];
+        return newState;
+    }
+    case ActionTypes.UPDATE_RHS_STATE:
+        // RHS가 닫힐 때 필터 초기화
+        if (!action.state) {
+            return {};
+        }
+        return state;
+    case UserTypes.LOGOUT_SUCCESS:
+        return {};
+    default:
+        return state;
+    }
+}
+
 export default combineReducers({
     selectedPostId,
     selectedPostFocussedAt,
@@ -446,4 +477,5 @@ export default combineReducers({
     isMenuOpen,
     editChannelMembers,
     shouldFocusRHS,
+    memberFilterUserIds,
 });

--- a/webapp/channels/src/selectors/rhs.ts
+++ b/webapp/channels/src/selectors/rhs.ts
@@ -240,3 +240,12 @@ export function getIsRhsExpanded(state: GlobalState): boolean {
 export function getIsEditingMembers(state: GlobalState): boolean {
     return state.views.rhs.editChannelMembers === true;
 }
+
+export function getMemberFilterUserIds(state: GlobalState, channelId: string): string[] {
+    return state.views.rhs.memberFilterUserIds?.[channelId] || [];
+}
+
+export function hasMemberFilter(state: GlobalState, channelId: string): boolean {
+    const filterUserIds = getMemberFilterUserIds(state, channelId);
+    return filterUserIds && filterUserIds.length > 0;
+}

--- a/webapp/channels/src/types/store/rhs.ts
+++ b/webapp/channels/src/types/store/rhs.ts
@@ -45,6 +45,7 @@ export type RhsViewState = {
     editChannelMembers: boolean;
     size: SidebarSize;
     shouldFocusRHS: boolean;
+    memberFilterUserIds: Record<string, string[]>;
 };
 
 export type RhsState = typeof RHSStates[keyof typeof RHSStates] | null;

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -210,6 +210,9 @@ export const ActionTypes = keyMirror({
     SET_RHS_EXPANDED: null,
     TOGGLE_RHS_EXPANDED: null,
 
+    SET_MEMBER_FILTER_USER_IDS: null,
+    CLEAR_MEMBER_FILTER_USER_IDS: null,
+
     UPDATE_MOBILE_VIEW: null,
 
     SET_NAVIGATION_BLOCKED: null,


### PR DESCRIPTION
## 개요
멤버 RHS에서 체크박스로 특정 멤버의 게시물만 필터링할 수 있는 기능 추가

## 주요 변경사항

### Redux 상태 관리
- 채널별 독립적인 필터 상태 관리
- RHS 닫을 때 모든 필터 초기화
- 채널 전환 시 각 채널의 필터 상태 유지

### UI 컴포넌트
- 멤버 목록 각 항목에 체크박스 추가 (프로필 사진 좌측)
- 편집 모드가 아닐 때만 체크박스 표시
- 체크/해제 시 즉시 필터 적용

### API 통합
- 기존 백엔드 `filterUserIds` 파라미터 활용
- `getPosts`, `getPostsUnread`, `getPostsSince`, `getPostsBefore`, `getPostsAfter` 함수에 필터 적용
- `loadUnreads`, `loadPosts`, `syncPostsInChannel` 액션에서 필터 전달

### 실시간 필터링
- Websocket 이벤트(`handleNewPostEvent`, `handleNewPostEvents`)에도 필터 적용
- 새 메시지 수신 시 실시간으로 필터링


## 테스트 시나리오

### 기본 동작
- [ ] 체크박스가 각 멤버 좌측에 표시
- [ ] 체크/해제 시 즉시 게시물 필터링
- [ ] 여러 멤버 선택 시 OR 조건으로 필터링
- [ ] 모든 해제 시 전체 게시물 표시

### 상태 관리
- [ ] RHS 닫기 → 재오픈 시 필터 초기화
- [ ] 채널 A 필터 → 채널 B 이동 → 채널 A 복귀 시 필터 유지
- [ ] 새 메시지 수신 시 실시간 필터 적용
