### PR TITLE
fix: 멤버 필터 변경 시 게시물 재로드 로직 추가

### DIFF
--- a/webapp/channels/src/components/post_view/post_list/index.tsx
+++ b/webapp/channels/src/components/post_view/post_list/index.tsx
@@ -20,6 +20,7 @@ import {
     loadLatestPosts,
 } from 'actions/views/channel';
 import {getIsMobileView} from 'selectors/views/browser';
+import {getMemberFilterUserIds} from 'selectors/rhs';
 
 import {getLatestPostId} from 'utils/post_utils';
 
@@ -101,6 +102,7 @@ function makeMapStateToProps() {
             shouldStartFromBottomWhenUnread,
             isMobileView: getIsMobileView(state),
             hasInaccessiblePosts,
+            filterUserIds: getMemberFilterUserIds(state, channelId),
         };
     };
 }

--- a/webapp/channels/src/components/post_view/post_list/post_list.tsx
+++ b/webapp/channels/src/components/post_view/post_list/post_list.tsx
@@ -120,6 +120,11 @@ export interface Props {
     shouldStartFromBottomWhenUnread: boolean;
     hasInaccessiblePosts: boolean;
 
+    /*
+     * User IDs to filter posts by (member filtering)
+     */
+    filterUserIds: string[];
+
     dispatch: DispatchFunc;
 
     actions: {
@@ -211,6 +216,12 @@ export default class PostList extends React.PureComponent<Props, State> {
         if (this.props.channelId !== prevProps.channelId) {
             this.postsOnLoad(this.props.channelId);
         }
+
+        // 멤버 필터가 변경되었을 때 게시물 재로드
+        if (this.props.filterUserIds !== prevProps.filterUserIds) {
+            this.postsOnLoad(this.props.channelId);
+        }
+
         if (this.props.postListIds != null && prevProps.postListIds == null) {
             markAndMeasureChannelSwitchEnd(true);
         }


### PR DESCRIPTION
PostList 컴포넌트에서 filterUserIds 변경 감지하여 게시물 자동 재로드

## 수정 사항
- PostList에 filterUserIds props 추가
- componentDidUpdate에서 필터 변경 감지
- 필터 변경 시 postsOnLoad 호출하여 게시물 재로드

<!-- Pull Request를 기여해 주셔서 감사합니다! 다음은 도움이 될 만한 몇 가지 팁입니다:

1. 첫 기여인 경우, 기여 체크리스트를 읽어주세요 https://developers.okrbest.com/contribute/getting-started/contribution-checklist/
2. "훌륭한 PR 제출하기"에 대한 블로그 포스트를 읽어보세요 https://developers.okrbest.com/blog/2019-01-24-submitting-great-prs
3. 저장소별 문서는 여기서 확인하세요 https://developers.okrbest.com/contribute
-->

#### 요약

<!--
이 Pull Request가 수행하는 작업에 대한 설명과 QA 테스트 단계를 작성해주세요 (해당되는 경우이며 Jira 티켓에 아직 추가되지 않은 경우).
-->

#### 티켓 링크

<!--
해당되는 경우 다음 링크 중 하나 또는 둘 다 포함해주세요:

수정: https://github.com/okrbest/okrbest/issues/XXX

-->

#### 스크린샷

<!--
PR에 UI 변경사항이 포함된 경우 스크린샷/GIF를 포함해주세요.

UI 변경사항을 쉽게 비교하기 위해 아래 템플릿과 같은 표를 사용할 수 있습니다.

|  이전  |  이후  |
|----|----|
| <이전 스크린샷 삽입> | <이후 스크린샷 삽입> |

-->

#### 릴리스 노트

<!--
다음 각 항목에 대한 릴리스 노트를 추가해주세요:

* 설정 변경사항 (추가, 삭제, 업데이트)
* API 추가 - 새로운 엔드포인트, 새로운 응답 필드 또는 새롭게 허용된 요청 파라미터
* 데이터베이스 변경사항 (모든 변경)
* 스키마 마이그레이션 변경사항. [스키마 마이그레이션 템플릿](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing)을 시작점으로 사용하여 이러한 세부사항을 릴리스 노트로 작성하세요.
* 웹소켓 추가 또는 변경사항
* OKR.BEST 인스턴스 관리자에게 주목할 만한 모든 사항 (과다 소통이 나을 수 있음)
* UI 변경, CLI 변경 등을 포함한 새로운 기능과 개선사항
* 버그 수정 및 이전 알려진 문제 수정
* 사용 중단 경고, 주요 변경사항 또는 호환성 관련 참고사항

릴리스 노트가 필요하지 않은 경우 NONE을 작성하세요. 과거 시제를 사용하세요. 줄바꿈은 제거됩니다.

예시:
