### PR TITLE
feat: 채널별 봇 메시지 필터 기능 추가

### DIFF
--- a/webapp/channels/src/components/channel_header/channel_header.tsx
+++ b/webapp/channels/src/components/channel_header/channel_header.tsx
@@ -245,12 +245,6 @@ class ChannelHeader extends React.PureComponent<Props> {
         const channelFilesIcon = <i className='icon icon-file-text-outline'/>;
 
         const isBotMessagesVisible = this.props.showBotMessages === 'true';
-        const botMessagesIconClass = classNames('channel-header__icon channel-header__icon--left btn btn-icon btn-xs', {
-            'channel-header__icon--active': !isBotMessagesVisible,
-        });
-        const hideBotMessagesLabel = this.props.intl.formatMessage({id: 'channel_header.hideBotMessages', defaultMessage: 'Hide bot messages'});
-        const showBotMessagesLabel = this.props.intl.formatMessage({id: 'channel_header.showBotMessages', defaultMessage: 'Show bot messages'});
-        const botMessagesTooltip = isBotMessagesVisible ? hideBotMessagesLabel : showBotMessagesLabel;
 
         const pinnedIconClass = classNames('channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs', {
             'channel-header__icon--active': rhsState === RHSStates.PIN,
@@ -399,19 +393,26 @@ class ChannelHeader extends React.PureComponent<Props> {
                                             {channelFilesIcon}
                                         </HeaderIconWrapper>
                                     }
-                                    <HeaderIconWrapper
-                                        buttonClass={botMessagesIconClass}
-                                        buttonId={'channelHeaderBotMessagesButton'}
-                                        onClick={this.toggleBotMessages}
-                                        tooltip={botMessagesTooltip}
+                                    <div
+                                        className='channel-header__bot-filter'
+                                        style={{display: 'flex', alignItems: 'center', gap: '4px', marginLeft: '8px'}}
                                     >
-                                        <span
-                                            aria-hidden='true'
-                                            style={{fontSize: '16px', lineHeight: '20px'}}
+                                        <input
+                                            type='checkbox'
+                                            id='channelHeaderBotMessagesCheckbox'
+                                            checked={isBotMessagesVisible}
+                                            onChange={this.toggleBotMessages}
+                                        />
+                                        <label
+                                            htmlFor='channelHeaderBotMessagesCheckbox'
+                                            style={{margin: 0, cursor: 'pointer', fontSize: '12px'}}
                                         >
-                                            {isBotMessagesVisible ? '🤖' : '🚫'}
-                                        </span>
-                                    </HeaderIconWrapper>
+                                            <FormattedMessage
+                                                id='channel_header.botMessages'
+                                                defaultMessage='봇 메세지'
+                                            />
+                                        </label>
+                                    </div>
                                 </div>
                                 <div
                                     id='channelHeaderDescription'

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -3657,6 +3657,7 @@
   "channel_bookmarks.open": "Open",
   "channel_groups": "{channel} Groups",
   "channel_header.back": "Back to channel",
+  "channel_header.botMessages": "Bot messages",
   "channel_header.channel_settings": "Channel Settings",
   "channel_header.channelFiles": "Channel files",
   "channel_header.channelHasGuests": "Channel has guests",

--- a/webapp/channels/src/i18n/ko.json
+++ b/webapp/channels/src/i18n/ko.json
@@ -3557,6 +3557,7 @@
   "channel_bookmarks.open": "열기",
   "channel_groups": "{channel} 그룹",
   "channel_header.back": "채널로 돌아가기",
+  "channel_header.botMessages": "봇 메세지",
   "channel_header.channelFiles": "채널 파일",
   "channel_header.channelHasGuests": "이 채널에는 게스트가 있습니다.",
   "channel_header.channelMembers": "구성원",


### PR DESCRIPTION
## 개요
채널별로 봇 메시지를 숨기거나 표시할 수 있는 필터링 기능을 추가했습니다.

## 주요 변경사항

### 1. UI 구현
- 채널 헤더에 \"봇 메세지\" 체크박스 추가
- 체크 시: 봇 메시지 표시 (기본값)
- 체크 해제 시: 봇 메시지 숨김
- 다국어 지원 (\`channel_header.botMessages\`)

### 2. 필터링 로직
**클라이언트 사이드 필터링 방식 적용** (멤버 필터와 동일한 패턴)
- \`post_list/index.tsx\`의 \`mapStateToProps\`에서 필터링
- Redux preference 변경 시 즉시 UI 업데이트

**필터 대상**
- \`post.props.from_webhook === 'true'\` - 웹훅 메시지
- \`post.type.startsWith('system_')\` - 시스템 메시지
- \`user.is_bot === true\` - 봇 유저가 작성한 메시지

### 3. 설정 저장
- Preference 카테고리: \`channel_bot_messages\`
- 채널별 저장 (name = channelId, value = 'true'/'false')
- 기본값: \`'true'\` (봇 메시지 표시)

## 수정된 파일
- \`platform/types/src/client4.ts\` - 타입 정의
- \`platform/client/src/client4.ts\` - API 클라이언트
- \`mattermost-redux/src/actions/posts.ts\` - Redux 액션
- \`channel_header/index.ts\` - Redux 연결
- \`channel_header/channel_header.tsx\` - UI 컴포넌트
- \`post_view/post_list/index.tsx\` - 클라이언트 사이드 필터링

## 테스트 방법
1. 채널 헤더의 \"봇 메세지\" 체크박스 확인
2. 체크 해제 → 봇/웹훅/시스템 메시지 숨김 확인
3. 다시 체크 → 봇 메시지 표시 확인
4. 채널 전환 시 각 채널별 설정 유지 확인"