### PR TITLE
feat: 메시지 우선순위 아이콘 옆에 레이블 표시

### DIFF
--- a/webapp/channels/src/components/post_priority/post_priority_picker.tsx
+++ b/webapp/channels/src/components/post_priority/post_priority_picker.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import React, {useCallback, useState, memo, useMemo, useEffect} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useSelector} from 'react-redux';
+import styled from 'styled-components';
 
 import {AlertCircleOutlineIcon} from '@mattermost/compass-icons/components';
 import type {PostPriorityMetadata} from '@mattermost/types/posts';
@@ -23,6 +24,18 @@ import * as Keyboard from 'utils/keyboard';
 import {Header, MenuItem, StyledCheckIcon, ToggleItem, StandardIcon, ImportantIcon, UrgentIcon, AcknowledgementIcon, PersistentNotificationsIcon, Footer} from './post_priority_picker_item';
 
 import './post_priority_picker.scss';
+
+const PriorityButtonWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 4px;
+`;
+
+const PriorityLabel = styled.span`
+    font-size: 12px;
+    font-weight: 500;
+    color: currentColor;
+`;
 
 type Props = {
     settings?: PostPriorityMetadata;
@@ -50,6 +63,16 @@ function PostPriorityPicker({
     const interval = useSelector(getPersistentNotificationIntervalMinutes);
 
     const messagePriority = formatMessage({id: 'shortcuts.msgs.formatting_bar.post_priority', defaultMessage: 'Message priority'});
+
+    const getPriorityLabel = useCallback(() => {
+        if (priority === PostPriority.URGENT) {
+            return formatMessage({id: 'post_priority.priority.urgent', defaultMessage: 'Urgent'});
+        }
+        if (priority === PostPriority.IMPORTANT) {
+            return formatMessage({id: 'post_priority.priority.important', defaultMessage: 'Important'});
+        }
+        return formatMessage({id: 'post_priority.priority.standard', defaultMessage: 'Standard'});
+    }, [priority, formatMessage]);
 
     const handleClose = useCallback(() => {
         setPickerOpen(false);
@@ -240,18 +263,21 @@ function PostPriorityPicker({
                 id: 'messagePriority',
                 as: 'div',
                 children: (
-                    <IconContainer
-                        id='messagePriority'
-                        className={classNames({control: true, active: pickerOpen})}
-                        disabled={disabled}
-                        type='button'
-                        aria-label={messagePriority}
-                    >
-                        <AlertCircleOutlineIcon
-                            size={18}
-                            color='currentColor'
-                        />
-                    </IconContainer>),
+                    <PriorityButtonWrapper>
+                        <IconContainer
+                            id='messagePriority'
+                            className={classNames({control: true, active: pickerOpen})}
+                            disabled={disabled}
+                            type='button'
+                            aria-label={messagePriority}
+                        >
+                            <AlertCircleOutlineIcon
+                                size={18}
+                                color='currentColor'
+                            />
+                        </IconContainer>
+                        <PriorityLabel>{getPriorityLabel()}</PriorityLabel>
+                    </PriorityButtonWrapper>),
             }}
             menu={{
                 id: 'post.priority.dropdown',


### PR DESCRIPTION
## 개요
메시지 우선순위 아이콘 옆에 현재 선택된 우선순위 값을 텍스트로 표시합니다.

## 변경사항

### UI 개선
- 우선순위 아이콘 옆에 레이블 추가
- 표시되는 값: **일반** / **중요** / **긴급**
- 모든 우선순위 상태에서 항상 표시

### 구현 내용
- `PriorityButtonWrapper`: 아이콘과 레이블을 감싸는 컨테이너
- `PriorityLabel`: 우선순위 텍스트 레이블 스타일
- `getPriorityLabel()`: 현재 우선순위에 따라 적절한 레이블 반환

### 다국어 지원
- 기존 번역 키 활용
  - 한글: 일반, 중요, 긴급
  - 영어: Standard, Important, Urgent

## 스타일링
- 폰트 크기: 12px
- 폰트 굵기: 500
- 아이콘-레이블 간격: 4px
- 색상: 부모 색상 상속

## 테스트 방법
1. 메시지 작성 창 열기
2. 우선순위 버튼 확인
3. 기본 상태에서 "일반" 표시 확인
4. 중요로 변경 후 "중요" 표시 확인
5. 긴급으로 변경 후 "긴급" 표시 확인