### PR TITLE
Feature/markdown (#193)

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.scss
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.scss
@@ -151,6 +151,13 @@
         display: flex;
         flex-direction: column;
         vertical-align: top;
+
+        // TexteditorActions가 absolute로 하단에 겹치므로, 가로는 본문 폭을 쓰고 아래쪽만 비움
+        &:not(.AdvancedTextEditor__cell--no-editor-actions) {
+            .lexical-text-editor .lexical-content-editable {
+                padding: 12px 16px 44px 16px;
+            }
+        }
     }
 
     &__helper-text {

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -347,7 +347,10 @@ const AdvancedTextEditor = ({
     );
 
     const handleSubmitWithErrorHandling = useCallback((submittingDraft?: PostDraft, schedulingInfo?: SchedulingInfo, options?: CreatePostOptions) => {
-        handleSubmit(submittingDraft, schedulingInfo, options);
+        const base = submittingDraft ?? draftRef.current;
+        const freshMessage = lexicalEditorRef.current?.readMarkdownForSubmit?.();
+        const merged: PostDraft = freshMessage != null ? {...base, message: freshMessage} : base;
+        handleSubmit(merged, schedulingInfo, options);
         if (!errorClass) {
             const messageStatusElement = messageStatusRef.current;
             const messageStatusInnerText = messageStatusElement?.textContent;
@@ -491,10 +494,11 @@ const AdvancedTextEditor = ({
     const getCurrentValue = useCallback(() => draft.message, [draft.message]);
 
     const getCurrentSelection = useCallback(() => {
-        return {
-            start: 0,
-            end: 0,
-        };
+        const offsets = lexicalEditorRef.current?.getPlainTextSelectionOffsets();
+        if (!offsets) {
+            return {start: null, end: null};
+        }
+        return offsets;
     }, []);
 
     const prefillMessage = useCallback((message: string) => {
@@ -727,7 +731,9 @@ const AdvancedTextEditor = ({
                         data-a11y-sort-order='2'
                         aria-label={ariaLabel}
                         tabIndex={-1}
-                        className='AdvancedTextEditor__cell a11y__region'
+                        className={classNames('AdvancedTextEditor__cell a11y__region', {
+                            'AdvancedTextEditor__cell--no-editor-actions': isDisabled,
+                        })}
                     >
                         {!isInEditMode && (priorityLabels || burnOnReadLabels) && (
                             <div className='AdvancedTextEditor__labels'>

--- a/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
@@ -108,7 +108,7 @@ interface FormattingBarProps {
      *       range we should probably refactor this and only pass down the
      *       selectionStart and selectionEnd values
      */
-    getCurrentSelection: () => {start: number; end: number};
+    getCurrentSelection: () => {start: number | null; end: number | null};
 
     /**
      * the handler function that applies the markdown to the value

--- a/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_icon.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_icon.tsx
@@ -131,6 +131,10 @@ const FormattingIcon = (props: FormattingIconProps): JSX.Element => {
         <IconContainer
             type='button'
             id={props.id || `FormattingControl_${mode}`}
+            onMouseDown={(e) => {
+                // 포맷 버튼 클릭 시 contenteditable 포커스가 빠지지 않게 해야 Lexical 선택이 유지된다.
+                e.preventDefault();
+            }}
             onClick={onClick}
             aria-label={buttonAriaLabel}
             {...otherProps}

--- a/webapp/channels/src/components/advanced_text_editor/use_rewrite.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_rewrite.test.tsx
@@ -85,6 +85,8 @@ describe('useRewrite', () => {
         getEditor: () => null,
         focus: jest.fn(),
         blur: jest.fn(),
+        getPlainTextSelectionOffsets: () => null,
+        readMarkdownForSubmit: () => null,
     };
 
     beforeEach(() => {

--- a/webapp/channels/src/components/advanced_text_editor/use_submit.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_submit.tsx
@@ -32,6 +32,7 @@ import PostDeletedModal from 'components/post_deleted_modal';
 import ResetStatusModal from 'components/reset_status_modal';
 
 import Constants, {ModalIdentifiers, UserStatuses} from 'utils/constants';
+import {normalizeGfmTablesInMarkdown, unescapeUnderscoresInMarkdownUrls} from 'utils/markdown_normalize';
 import {isErrorInvalidSlashCommand, isServerError, specialMentionsInText} from 'utils/post_utils';
 
 import type {GlobalState} from 'types/store';
@@ -193,13 +194,20 @@ const useSubmit = (
             keepDraft: createPostOptions?.keepDraft,
         };
 
+        const draftForApi: PostDraft = {
+            ...submittingDraft,
+            message: unescapeUnderscoresInMarkdownUrls(
+                normalizeGfmTablesInMarkdown(submittingDraft.message),
+            ),
+        };
+
         try {
             let response;
             if (isInEditMode) {
-                response = await dispatch(editPost(submittingDraft));
+                response = await dispatch(editPost(draftForApi));
                 handleFileChange(submittingDraft);
             } else {
-                response = await dispatch(onSubmit(submittingDraft, options, schedulingInfo));
+                response = await dispatch(onSubmit(draftForApi, options, schedulingInfo));
             }
             if (response?.error) {
                 throw response.error;

--- a/webapp/channels/src/components/lexical_editor/config/markdown_transformers.ts
+++ b/webapp/channels/src/components/lexical_editor/config/markdown_transformers.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 import {
     ELEMENT_TRANSFORMERS,
     TEXT_FORMAT_TRANSFORMERS,
@@ -5,15 +8,102 @@ import {
     TRANSFORMERS,
 } from '@lexical/markdown';
 import type {Transformer} from '@lexical/markdown';
-import {TableCellNode, TableNode, TableRowNode} from '@lexical/table';
+import {
+    $createTableCellNode,
+    $createTableNode,
+    $createTableRowNode,
+    $isTableNode,
+    TableCellHeaderStates,
+    TableCellNode,
+    TableNode,
+    TableRowNode,
+} from '@lexical/table';
+import type {LexicalNode} from 'lexical';
+import {$createParagraphNode, $createTextNode, $isElementNode} from 'lexical';
 
-// GFM 테이블 Transformer
-// 마크다운 테이블 문법을 Lexical TableNode로 변환
+// @lexical/markdown 내부와 동일한 GFM 테이블 행 판별
+export const TABLE_ROW_REG_EXP = /^(?:\|)(.+)(?:\|)\s?$/;
+export const TABLE_ROW_DIVIDER_REG_EXP = /^(\| ?:?-*:? ?)+\|\s?$/;
+
+function splitMarkdownTableRow(line: string): string[] {
+    let s = line.trim();
+    if (s.startsWith('|')) {
+        s = s.slice(1);
+    }
+    if (s.endsWith('|')) {
+        s = s.slice(0, -1);
+    }
+    return s.split('|').map((c) => c.trim());
+}
+
+function appendTableCellParagraph(cell: TableCellNode, text: string): void {
+    const paragraph = $createParagraphNode();
+    paragraph.append($createTextNode(text));
+    cell.append(paragraph);
+}
+
+/**
+ * 마크다운 줄 배열에서 GFM 테이블(헤더+구분선+선택 본문 행)을 Lexical TableNode로 만든다.
+ * 붙여넣기 import와 타이핑 자동 변환에서 공통 사용.
+ */
+export function $createGfmTableFromMarkdownLines(
+    lines: string[],
+    startLineIndex: number,
+): {table: TableNode; endLineIndex: number} | null {
+    const headerLine = lines[startLineIndex]?.replace(/\r$/, '') ?? '';
+    if (!TABLE_ROW_REG_EXP.test(headerLine)) {
+        return null;
+    }
+    const dividerIndex = startLineIndex + 1;
+    if (dividerIndex >= lines.length) {
+        return null;
+    }
+    const dividerLine = lines[dividerIndex].replace(/\r$/, '');
+    if (!TABLE_ROW_DIVIDER_REG_EXP.test(dividerLine)) {
+        return null;
+    }
+
+    const headerCells = splitMarkdownTableRow(headerLine);
+    const colCount = headerCells.length;
+    if (colCount === 0) {
+        return null;
+    }
+
+    const tableNode = $createTableNode();
+
+    const headerRowNode = $createTableRowNode();
+    for (let c = 0; c < colCount; c++) {
+        const cell = $createTableCellNode(TableCellHeaderStates.ROW);
+        appendTableCellParagraph(cell, headerCells[c] ?? '');
+        headerRowNode.append(cell);
+    }
+    tableNode.append(headerRowNode);
+
+    let i = dividerIndex + 1;
+    while (i < lines.length) {
+        const line = lines[i].replace(/\r$/, '');
+        if (!TABLE_ROW_REG_EXP.test(line)) {
+            break;
+        }
+        const cells = splitMarkdownTableRow(line);
+        const bodyRow = $createTableRowNode();
+        for (let c = 0; c < colCount; c++) {
+            const cell = $createTableCellNode();
+            appendTableCellParagraph(cell, cells[c] ?? '');
+            bodyRow.append(cell);
+        }
+        tableNode.append(bodyRow);
+        i++;
+    }
+
+    return {table: tableNode, endLineIndex: i - 1};
+}
+
+// GFM 테이블 → Lexical TableNode (multiline import)
 const TABLE_TRANSFORMER: Transformer = {
     dependencies: [TableNode, TableRowNode, TableCellNode],
     export: (node) => {
-        // TableNode → 마크다운 테이블 문자열
-        if (node.getType() !== 'table') {
+        if (!$isTableNode(node)) {
             return null;
         }
 
@@ -24,16 +114,18 @@ const TABLE_TRANSFORMER: Transformer = {
 
         const lines: string[] = [];
 
-        rows.forEach((row: any, rowIndex: number) => {
+        rows.forEach((row: LexicalNode, rowIndex: number) => {
+            if (!$isElementNode(row)) {
+                return;
+            }
             const cells = row.getChildren();
-            const cellTexts = cells.map((cell: any) => {
+            const cellTexts = cells.map((cell) => {
                 const text = cell.getTextContent().trim();
                 return text || ' ';
             });
 
             lines.push('| ' + cellTexts.join(' | ') + ' |');
 
-            // 헤더 구분선 (첫 번째 행 뒤)
             if (rowIndex === 0) {
                 const separator = cells.map(() => '---').join(' | ');
                 lines.push('| ' + separator + ' |');
@@ -42,39 +134,42 @@ const TABLE_TRANSFORMER: Transformer = {
 
         return lines.join('\n');
     },
-    regExp: /^(\|.+\|)\n(\|[-| :]+\|)\n((\|.+\|\n?)+)$/m,
-    replace: (parentNode) => {
-        // 마크다운 테이블 → TableNode
-        // 간단한 테이블 파싱 → Lexical TableNode 생성
-        // 실제 구현 시 @lexical/table의 $createTableNodeWithDimensions 활용
-        // 현재는 기본 텍스트로 유지
-        return;
+    handleImportAfterStartMatch: ({lines, rootNode, startLineIndex}) => {
+        const created = $createGfmTableFromMarkdownLines(lines, startLineIndex);
+        if (!created) {
+            return null;
+        }
+        rootNode.append(created.table);
+        return [true, created.endLineIndex];
     },
-    type: 'element',
+    regExpStart: TABLE_ROW_REG_EXP,
+    replace: () => {
+        // handleImportAfterStartMatch에서 import 처리
+    },
+    type: 'multiline-element',
 };
 
 // 리스트 transformer를 제외한 element transformers (heading, code, quote만)
 // 리스트는 MarkdownShortcutPlugin의 element transformer와 ListPlugin의 indent/outdent가 충돌하므로 제외
 const ELEMENT_TRANSFORMERS_WITHOUT_LIST = ELEMENT_TRANSFORMERS.filter(
     (t) => {
-        // UNORDERED_LIST와 ORDERED_LIST의 regExp 패턴으로 식별
         const regStr = t.regExp?.toString() || '';
         return !regStr.includes('[-*+]') && !regStr.includes('\\d');
     },
 );
 
-// MarkdownShortcutPlugin용: 리스트 transformer 제외
-// (리스트는 ListShortcutPlugin에서 별도 처리)
 export const CHANNELS_SHORTCUT_TRANSFORMERS: Transformer[] = [
     ...ELEMENT_TRANSFORMERS_WITHOUT_LIST,
     ...TEXT_FORMAT_TRANSFORMERS,
     ...TEXT_MATCH_TRANSFORMERS,
 ];
 
-// 마크다운 <-> 에디터 변환용 (전체 transformer 포함)
 export const CHANNELS_TRANSFORMERS: Transformer[] = [
     TABLE_TRANSFORMER,
     ...TRANSFORMERS,
 ];
+
+/** 에디터에 Lexical TableNode를 만들지 않고 평문 줄로 유지할 때(import·붙여넣기) 사용 */
+export const CHANNELS_MARKDOWN_IMPORT_WITHOUT_TABLE: Transformer[] = [...TRANSFORMERS];
 
 export {TRANSFORMERS};

--- a/webapp/channels/src/components/lexical_editor/lexical_text_editor.scss
+++ b/webapp/channels/src/components/lexical_editor/lexical_text_editor.scss
@@ -31,6 +31,7 @@
         font-size: 14px;
         line-height: 22px;
         color: var(--center-channel-color);
+        overflow-wrap: anywhere;
         word-wrap: break-word;
         white-space: pre-wrap;
         caret-color: var(--button-bg);

--- a/webapp/channels/src/components/lexical_editor/lexical_text_editor.tsx
+++ b/webapp/channels/src/components/lexical_editor/lexical_text_editor.tsx
@@ -19,7 +19,7 @@ import {ListPlugin} from '@lexical/react/LexicalListPlugin';
 import {TablePlugin} from '@lexical/react/LexicalTablePlugin';
 
 import editorTheme from './config/editor_theme';
-import {CHANNELS_TRANSFORMERS, CHANNELS_SHORTCUT_TRANSFORMERS} from './config/markdown_transformers';
+import {CHANNELS_MARKDOWN_IMPORT_WITHOUT_TABLE, CHANNELS_TRANSFORMERS, CHANNELS_SHORTCUT_TRANSFORMERS} from './config/markdown_transformers';
 import {MentionNode} from './nodes/mention_node';
 import {ChannelMentionNode} from './nodes/channel_mention_node';
 import {EmojiNode} from './nodes/emoji_node';
@@ -31,6 +31,9 @@ import ChannelMentionPlugin from './plugins/channel_mention_plugin';
 import EmojiPlugin from './plugins/emoji_plugin';
 import SlashCommandPlugin from './plugins/slash_command_plugin';
 import ListShortcutPlugin from './plugins/list_shortcut_plugin';
+import MarkdownPastePlugin from './plugins/markdown_paste_plugin';
+import {getPlainTextOffsetsFromContentEditable} from './utils/plain_text_selection_offsets';
+import {readChannelsMarkdownForSubmit} from './utils/read_channels_markdown_for_submit';
 
 import './lexical_text_editor.scss';
 
@@ -60,6 +63,9 @@ export type LexicalTextEditorHandle = {
     focus: () => void;
     blur: () => void;
     getInputBox: () => HTMLElement | null;
+    getPlainTextSelectionOffsets: () => {start: number; end: number} | null;
+    /** Enter 전송 직전 draft 와 동기화용 (OnChange 가 아직 반영되지 않은 경우 대비) */
+    readMarkdownForSubmit: () => string | null;
 };
 
 // 에디터 값 동기화 플러그인 (초기값 설정 + 외부에서 빈 값으로 리셋 시 클리어)
@@ -73,7 +79,7 @@ function ValueSyncPlugin({value}: {value: string}) {
             isInitialized.current = true;
             if (value) {
                 editor.update(() => {
-                    $convertFromMarkdownString(value, CHANNELS_TRANSFORMERS);
+                    $convertFromMarkdownString(value, CHANNELS_MARKDOWN_IMPORT_WITHOUT_TABLE);
                 });
             }
             return;
@@ -187,6 +193,16 @@ const LexicalTextEditor = forwardRef<LexicalTextEditorHandle, LexicalTextEditorP
         getInputBox: () => {
             return editorRef.current?.getRootElement() ?? null;
         },
+        getPlainTextSelectionOffsets: () => {
+            return getPlainTextOffsetsFromContentEditable(editorRef.current?.getRootElement() ?? null);
+        },
+        readMarkdownForSubmit: () => {
+            const ed = editorRef.current;
+            if (!ed) {
+                return null;
+            }
+            return readChannelsMarkdownForSubmit(ed);
+        },
     }), []);
 
     const initialConfig = useMemo(() => ({
@@ -233,6 +249,7 @@ const LexicalTextEditor = forwardRef<LexicalTextEditorHandle, LexicalTextEditorP
                     />
                 </div>
                 <MarkdownShortcutPlugin transformers={CHANNELS_SHORTCUT_TRANSFORMERS} />
+                <MarkdownPastePlugin />
                 <ListShortcutPlugin />
                 <HistoryPlugin />
                 <ListPlugin />

--- a/webapp/channels/src/components/lexical_editor/plugins/markdown_paste_plugin.tsx
+++ b/webapp/channels/src/components/lexical_editor/plugins/markdown_paste_plugin.tsx
@@ -1,0 +1,186 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {CodeHighlightNode, CodeNode} from '@lexical/code';
+import {createHeadlessEditor} from '@lexical/headless';
+import {LinkNode} from '@lexical/link';
+import {ListItemNode, ListNode} from '@lexical/list';
+import {$convertFromMarkdownString} from '@lexical/markdown';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {HeadingNode, QuoteNode} from '@lexical/rich-text';
+import {TableCellNode, TableNode, TableRowNode} from '@lexical/table';
+import {
+    $createParagraphNode,
+    $createTextNode,
+    $getRoot,
+    $getSelection,
+    $isElementNode,
+    $isRangeSelection,
+    $parseSerializedNode,
+    COMMAND_PRIORITY_HIGH,
+    PASTE_COMMAND,
+    PASTE_TAG,
+} from 'lexical';
+import type {LexicalEditor, LexicalNode, SerializedLexicalNode} from 'lexical';
+import {useEffect, useRef, type MutableRefObject} from 'react';
+
+import {CHANNELS_MARKDOWN_IMPORT_WITHOUT_TABLE} from '../config/markdown_transformers';
+import {ChannelMentionNode} from '../nodes/channel_mention_node';
+import {EmojiNode} from '../nodes/emoji_node';
+import {MentionNode} from '../nodes/mention_node';
+import {plainTextLooksLikeMarkdown} from '../utils/markdown_paste_heuristics';
+
+function sanitizePlainForMarkdown(text: string): string {
+    return text.
+        replace(/^\uFEFF/, '').
+        replace(/\u200B/g, '').
+        replace(/\r\n/g, '\n').
+        replace(/\r/g, '\n');
+}
+
+/**
+ * `exportJSON()`만 쓰면 Element의 `children`이 빠져 $parseSerializedNode 이후
+ * 제목 본문·테이블·리스트 내용이 비어 복원된다(EditorState.toJSON()은 재귀 export 사용).
+ */
+function deepSerializeLexicalNode(node: LexicalNode): SerializedLexicalNode {
+    const serialized = node.exportJSON();
+    if ($isElementNode(node)) {
+        return {
+            ...serialized,
+            children: node.getChildren().map(deepSerializeLexicalNode),
+        };
+    }
+    return serialized;
+}
+
+const STAGING_NODES = [
+    HeadingNode,
+    QuoteNode,
+    ListNode,
+    ListItemNode,
+    CodeNode,
+    CodeHighlightNode,
+    LinkNode,
+    TableNode,
+    TableCellNode,
+    TableRowNode,
+    MentionNode,
+    ChannelMentionNode,
+    EmojiNode,
+];
+
+function getHeadlessStagingEditor(ref: MutableRefObject<LexicalEditor | null>): LexicalEditor {
+    if (!ref.current) {
+        ref.current = createHeadlessEditor({
+            namespace: 'channels-markdown-paste-staging',
+            nodes: STAGING_NODES,
+            onError: () => {},
+        });
+    }
+    return ref.current;
+}
+
+export default function MarkdownPastePlugin(): null {
+    const [editor] = useLexicalComposerContext();
+    const stagingRef = useRef<LexicalEditor | null>(null);
+
+    useEffect(() => {
+        return () => {
+            stagingRef.current = null;
+        };
+    }, []);
+
+    useEffect(() => {
+        return editor.registerCommand(
+            PASTE_COMMAND,
+            (event) => {
+                if (!(event instanceof ClipboardEvent)) {
+                    return false;
+                }
+                const data = event.clipboardData;
+                if (!data) {
+                    return false;
+                }
+
+                if (data.files.length > 0) {
+                    return false;
+                }
+
+                const plainRaw = data.getData('text/plain');
+                const plain = sanitizePlainForMarkdown(plainRaw);
+                if (!plain || !plainTextLooksLikeMarkdown(plain)) {
+                    return false;
+                }
+
+                event.preventDefault();
+
+                const staging = getHeadlessStagingEditor(stagingRef);
+
+                // update 직후 바깥에서 getEditorState().read() 하면 이전 트랜잭션이 보일 수 있어
+                // (재사용 headless에서 두 번째 붙여넣기 시 빈/이전 결과) — 같은 update 안에서 직렬화한다.
+                let serializedChildren: SerializedLexicalNode[] = [];
+                staging.update(() => {
+                    $convertFromMarkdownString(plain, CHANNELS_MARKDOWN_IMPORT_WITHOUT_TABLE, undefined, true);
+                    serializedChildren = $getRoot().getChildren().map(deepSerializeLexicalNode);
+                });
+
+                editor.update(
+                    () => {
+                        const root = $getRoot();
+                        if (root.getChildrenSize() === 0) {
+                            root.append($createParagraphNode());
+                        }
+
+                        let selectionNode = $getSelection();
+                        if (selectionNode === null || !$isRangeSelection(selectionNode)) {
+                            root.selectEnd();
+                            selectionNode = $getSelection();
+                        }
+
+                        const insertAtRootEnd = () => {
+                            try {
+                                if (serializedChildren.length === 0) {
+                                    const p = $createParagraphNode();
+                                    p.append($createTextNode(plain));
+                                    root.append(p);
+                                    return;
+                                }
+                                const nodes = serializedChildren.map((json) => $parseSerializedNode(json));
+                                for (const node of nodes) {
+                                    root.append(node);
+                                }
+                            } catch {
+                                const p = $createParagraphNode();
+                                p.append($createTextNode(plainRaw));
+                                root.append(p);
+                            }
+                            root.selectEnd();
+                        };
+
+                        if (!$isRangeSelection(selectionNode)) {
+                            insertAtRootEnd();
+                            return;
+                        }
+
+                        try {
+                            if (serializedChildren.length === 0) {
+                                selectionNode.insertText(plain);
+                                return;
+                            }
+                            const nodes = serializedChildren.map((json) => $parseSerializedNode(json));
+                            selectionNode.insertNodes(nodes);
+                        } catch {
+                            selectionNode.insertText(plainRaw);
+                        }
+                    },
+                    {tag: PASTE_TAG},
+                );
+
+                return true;
+            },
+            COMMAND_PRIORITY_HIGH,
+        );
+    }, [editor]);
+
+    return null;
+}

--- a/webapp/channels/src/components/lexical_editor/plugins/on_change_plugin.tsx
+++ b/webapp/channels/src/components/lexical_editor/plugins/on_change_plugin.tsx
@@ -1,32 +1,45 @@
-import { useEffect } from "react";
-import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { $convertToMarkdownString } from "@lexical/markdown";
-import { CHANNELS_TRANSFORMERS } from "../config/markdown_transformers";
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {$convertToMarkdownString} from '@lexical/markdown';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {$getRoot} from 'lexical';
+import {useEffect} from 'react';
+
+import {CHANNELS_TRANSFORMERS} from '../config/markdown_transformers';
+import {unescapeUnderscoresInMarkdownUrls} from 'utils/markdown_normalize';
 
 type Props = {
     onChange: (markdown: string) => void;
 };
 
-export default function OnChangeMarkdownPlugin({ onChange }: Props): null {
+export default function OnChangeMarkdownPlugin({onChange}: Props): null {
     const [editor] = useLexicalComposerContext();
 
     useEffect(() => {
         return editor.registerUpdateListener(
-            ({ editorState, dirtyElements, dirtyLeaves, tags }) => {
-                // Skip selection-only changes and programmatic history merges
+            ({editorState, dirtyElements, dirtyLeaves, tags}) => {
                 if (
-                    tags.has("history-merge") ||
+                    tags.has('history-merge') ||
                     (dirtyElements.size === 0 && dirtyLeaves.size === 0)
                 ) {
                     return;
                 }
                 editorState.read(() => {
                     const markdown = $convertToMarkdownString(
-                        CHANNELS_TRANSFORMERS
+                        CHANNELS_TRANSFORMERS,
                     );
-                    onChange(markdown);
+                    const visibleText = $getRoot().getTextContent();
+
+                    // 마크다운 export 버그·일부 노드 미지원 시 빈 문자열만 나오면 draft가 ''가 되고
+                    // ValueSyncPlugin이 에디터를 비워 버림 → 평문으로라도 draft를 유지
+                    if (markdown.trim() === '' && visibleText.trim() !== '') {
+                        onChange(visibleText);
+                        return;
+                    }
+                    onChange(unescapeUnderscoresInMarkdownUrls(markdown));
                 });
-            }
+            },
         );
     }, [editor, onChange]);
 

--- a/webapp/channels/src/components/lexical_editor/utils/markdown_paste_heuristics.test.ts
+++ b/webapp/channels/src/components/lexical_editor/utils/markdown_paste_heuristics.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {clipboardHtmlLooksFormatted, plainTextLooksLikeMarkdown} from './markdown_paste_heuristics';
+
+describe('markdown_paste_heuristics', () => {
+    describe('clipboardHtmlLooksFormatted', () => {
+        it('returns false for empty html', () => {
+            expect(clipboardHtmlLooksFormatted('')).toBe(false);
+        });
+
+        it('detects anchor tags', () => {
+            expect(clipboardHtmlLooksFormatted('<a href="https://x.com">x</a>')).toBe(true);
+        });
+
+        it('detects bold tags', () => {
+            expect(clipboardHtmlLooksFormatted('<p><b>hi</b></p>')).toBe(true);
+        });
+
+        it('returns false for plain fragment wrapper only', () => {
+            expect(clipboardHtmlLooksFormatted('<div>just text</div>')).toBe(false);
+        });
+    });
+
+    describe('plainTextLooksLikeMarkdown', () => {
+        it('returns false for plain sentences', () => {
+            expect(plainTextLooksLikeMarkdown('hello world')).toBe(false);
+        });
+
+        it('detects headings', () => {
+            expect(plainTextLooksLikeMarkdown('## Title\n')).toBe(true);
+        });
+
+        it('detects hash-only heading lines (no space after #)', () => {
+            expect(plainTextLooksLikeMarkdown('###\n##\n#')).toBe(true);
+        });
+
+        it('detects bold markers', () => {
+            expect(plainTextLooksLikeMarkdown('**bold**')).toBe(true);
+        });
+
+        it('detects fenced code', () => {
+            expect(plainTextLooksLikeMarkdown('```\ncode\n```')).toBe(true);
+        });
+    });
+});

--- a/webapp/channels/src/components/lexical_editor/utils/markdown_paste_heuristics.ts
+++ b/webapp/channels/src/components/lexical_editor/utils/markdown_paste_heuristics.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/**
+ * 붙여넣기 클립보드 HTML이 의미 있는 리치 포맷인지 판별한다.
+ * 이 경우 Lexical 기본 HTML 붙여넣기에 맡긴다.
+ */
+export function clipboardHtmlLooksFormatted(html: string): boolean {
+    const h = html.trim();
+    if (!h) {
+        return false;
+    }
+    const lower = h.toLowerCase();
+    if ((/<a\s[^>]*href/i).test(lower)) {
+        return true;
+    }
+    if ((/<table[\s>]/i).test(lower)) {
+        return true;
+    }
+    if ((/<img[\s>]/i).test(lower)) {
+        return true;
+    }
+    if ((/<(?:strong|b|em|i|u|del|s|code|h[1-6]|blockquote|pre|ul|ol|li)[\s>]/i).test(lower)) {
+        return true;
+    }
+    if ((/<span[^>]*style\s*=/i).test(lower)) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * text/plain만 있는 붙여넣기에서 마크다운으로 파싱해 처리해도 될 만한지 휴리스틱으로 판별한다.
+ */
+export function plainTextLooksLikeMarkdown(text: string): boolean {
+    const t = text.trim();
+    if (t.length < 2) {
+        return false;
+    }
+
+    // `#`만 있는 줄(예: Dooray 등에서 복사) 또는 `### 제목` 형태
+    if ((/^#{1,6}(?:\s|$|\n)/m).test(t)) {
+        return true;
+    }
+    if ((/^[-*+]\s/m).test(t)) {
+        return true;
+    }
+    if ((/^\d+\.\s/m).test(t)) {
+        return true;
+    }
+    if ((/^>\s/m).test(t)) {
+        return true;
+    }
+    if ((/```/).test(t)) {
+        return true;
+    }
+    if ((/\*\*[^*\n]+?\*\*/).test(t)) {
+        return true;
+    }
+    if ((/__(?!_)[^_\n]+__(?!_)/).test(t)) {
+        return true;
+    }
+    if ((/(?<![*])\*(?![*\s])[^*\n]+\*(?!\*)/).test(t)) {
+        return true;
+    }
+    if ((/\[[^\]]+\]\([^)]+\)/).test(t)) {
+        return true;
+    }
+    if ((/^\|.+\|\s*$/m).test(t)) {
+        return true;
+    }
+    if ((/^(?:---+|\*\*\*+)\s*$/m).test(t)) {
+        return true;
+    }
+
+    return false;
+}

--- a/webapp/channels/src/components/lexical_editor/utils/plain_text_selection_offsets.ts
+++ b/webapp/channels/src/components/lexical_editor/utils/plain_text_selection_offsets.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/**
+ * Lexical contenteditable 루트 기준, 브라우저 Selection API로 평문 오프셋을 구한다.
+ * draft.message(마크다운) 문자열 인덱스와는 다를 수 있다. 포맷 바는 Lexical 명령에
+ * 에디터 내부 선택을 쓰므로, 버튼 클릭 시 포커스 유지(onMouseDown preventDefault)와 함께
+ * 오프셋은 UI/호환용으로만 쓰인다.
+ */
+export function getPlainTextOffsetsFromContentEditable(rootElement: HTMLElement | null): {start: number; end: number} | null {
+    if (!rootElement) {
+        return null;
+    }
+
+    const domSelection = document.getSelection();
+    if (!domSelection || domSelection.rangeCount === 0) {
+        return null;
+    }
+
+    const range = domSelection.getRangeAt(0);
+    if (!rootElement.contains(range.commonAncestorContainer)) {
+        return null;
+    }
+
+    try {
+        const preCaretRange = document.createRange();
+        preCaretRange.selectNodeContents(rootElement);
+        preCaretRange.setEnd(range.startContainer, range.startOffset);
+        const start = preCaretRange.toString().length;
+        const end = start + range.toString().length;
+        return {start, end};
+    } catch {
+        return null;
+    }
+}

--- a/webapp/channels/src/components/lexical_editor/utils/read_channels_markdown_for_submit.ts
+++ b/webapp/channels/src/components/lexical_editor/utils/read_channels_markdown_for_submit.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {$convertToMarkdownString} from '@lexical/markdown';
+import type {LexicalEditor} from 'lexical';
+import {$getRoot} from 'lexical';
+
+import {CHANNELS_TRANSFORMERS} from '../config/markdown_transformers';
+import {unescapeUnderscoresInMarkdownUrls} from 'utils/markdown_normalize';
+
+/**
+ * 전송 직전 등 OnChange 반영 전에 호출해 에디터 상태와 draft.message 를 맞춘다.
+ */
+export function readChannelsMarkdownForSubmit(editor: LexicalEditor): string {
+    let result = '';
+    editor.getEditorState().read(() => {
+        const markdown = $convertToMarkdownString(CHANNELS_TRANSFORMERS);
+        const visibleText = $getRoot().getTextContent();
+        if (markdown.trim() === '' && visibleText.trim() !== '') {
+            result = visibleText;
+        } else {
+            result = unescapeUnderscoresInMarkdownUrls(markdown);
+        }
+    });
+    return result;
+}

--- a/webapp/channels/src/components/post_view/post_list_virtualized/post_list_virtualized.tsx
+++ b/webapp/channels/src/components/post_view/post_list_virtualized/post_list_virtualized.tsx
@@ -357,7 +357,7 @@ export default class PostList extends React.PureComponent<Props, State> {
             try {
                 const url = new URL(href);
                 pathname = url.pathname;
-            } catch (e) {
+            } catch {
                 pathname = href;
             }
         }

--- a/webapp/channels/src/utils/markdown_normalize.test.ts
+++ b/webapp/channels/src/utils/markdown_normalize.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {normalizeGfmTablesInMarkdown, unescapeUnderscoresInMarkdownUrls} from './markdown_normalize';
+
+describe('normalizeGfmTablesInMarkdown', () => {
+    it('removes blank lines between GFM table rows', () => {
+        const input = '| a | b |\n\n| --- | --- |\n\n| x | y |';
+        expect(normalizeGfmTablesInMarkdown(input)).toBe('| a | b |\n| --- | --- |\n| x | y |');
+    });
+
+    it('keeps blank line between non-table blocks', () => {
+        const input = 'hello\n\nworld';
+        expect(normalizeGfmTablesInMarkdown(input)).toBe('hello\n\nworld');
+    });
+});
+
+describe('unescapeUnderscoresInMarkdownUrls', () => {
+    it('plain http(s) URL', () => {
+        expect(unescapeUnderscoresInMarkdownUrls('https://aaa\\_bbb')).
+            toBe('https://aaa_bbb');
+        expect(unescapeUnderscoresInMarkdownUrls('http://x\\_y\\_z')).
+            toBe('http://x_y_z');
+    });
+
+    it('does not change non-URLs', () => {
+        expect(unescapeUnderscoresInMarkdownUrls('aaa\\_bbb')).toBe('aaa\\_bbb');
+    });
+
+    it('parenthesized plain URL', () => {
+        expect(unescapeUnderscoresInMarkdownUrls('(https://aaa\\_bbb)')).
+            toBe('(https://aaa_bbb)');
+    });
+
+    it('markdown link target URL', () => {
+        expect(unescapeUnderscoresInMarkdownUrls('[t](https://aaa\\_bbb)')).toBe('[t](https://aaa_bbb)');
+    });
+
+    it('angle-bracket URL', () => {
+        expect(unescapeUnderscoresInMarkdownUrls('<https://aaa\\_bbb>')).
+            toBe('<https://aaa_bbb>');
+    });
+});

--- a/webapp/channels/src/utils/markdown_normalize.ts
+++ b/webapp/channels/src/utils/markdown_normalize.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/**
+ * Lexical이 문단마다 마크다운을 내보낼 때 표 행 사이에 빈 줄이 끼면 GFM 표가 깨진다.
+ * 연속된 `|...|` 형태 줄 사이의 공백 전용 줄을 제거한다.
+ */
+function lineLooksLikeGfmTableRow(line: string): boolean {
+    const t = line.replace(/\r$/, '').trimEnd();
+    if (t === '') {
+        return false;
+    }
+    return t.startsWith('|') && t.endsWith('|');
+}
+
+export function normalizeGfmTablesInMarkdown(markdown: string): string {
+    const lines = markdown.split('\n');
+    const out: string[] = [];
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (line.trim() === '' && out.length > 0 && i + 1 < lines.length) {
+            const prev = out[out.length - 1];
+            const next = lines[i + 1];
+            if (lineLooksLikeGfmTableRow(prev) && lineLooksLikeGfmTableRow(next)) {
+                continue;
+            }
+        }
+        out.push(line);
+    }
+    return out.join('\n');
+}
+
+/**
+ * Lexical $convertToMarkdownString 은 텍스트의 _ 를 마크다운 이스케이프(\_)로 내보냄.
+ * http(s) 본문·마크다운 링크 URL·각괄호 URL 안의 \_ 는 실제 주소로 쓰여야 하므로 _ 로 복원한다.
+ */
+export function unescapeUnderscoresInMarkdownUrls(markdown: string): string {
+    if (!markdown.includes('\\_')) {
+        return markdown;
+    }
+    let out = markdown;
+
+    out = out.replace(/\]\((https?:\/\/[^)\s]+)\)/gi, (full, url: string) => {
+        if (!url.includes('\\_')) {
+            return full;
+        }
+        return `](${url.replace(/\\_/g, '_')})`;
+    });
+
+    out = out.replace(/<(https?:\/\/[^>\s]+)>/gi, (full, url: string) => {
+        if (!url.includes('\\_')) {
+            return full;
+        }
+        return `<${url.replace(/\\_/g, '_')}>`;
+    });
+
+    out = out.replace(/\bhttps?:\/\/\S+/gi, (raw) => {
+        if (!raw.includes('\\_')) {
+            return raw;
+        }
+        let body = raw;
+        let suffix = '';
+        if (body.endsWith(')') && !body.includes('(')) {
+            body = body.slice(0, -1);
+            suffix = ')';
+        }
+        body = body.replace(/\\_/g, '_');
+        return body + suffix;
+    });
+
+    return out;
+}


### PR DESCRIPTION
* feat: 선택 처리와 마크다운 지원을 개선한 고급 텍스트 에디터
- 선택이 없을 때 getCurrentSelection이 start·end를 null로 반환하도록 변경함
- formatting bar가 nullable 선택 값을 다루도록 수정함
- 선택 관리를 위해 LexicalTextEditor에 getPlainTextSelectionOffsets 메서드 추가
- 마크다운 처리를 위해 MarkdownPastePlugin 연동
- 마크다운 내보내기 결과가 빈 문자열일 때 초안 내용이 유지되도록 OnChangeMarkdownPlugin 개선
- 표 처리를 위해 마크다운 트랜스포머에 GFM 테이블 지원 추가

* feat: 마크다운 테이블 처리 개선 및 관련 기능 추가

- GFM 테이블을 정규화하는 normalizeGfmTablesInMarkdown 함수 추가
- useSubmit 훅에서 제출 시 초안 메시지에 GFM 테이블 정규화 적용
- 마크다운 변환기에서 GFM 테이블을 Lexical TableNode로 변환하는 기능 추가
- MarkdownPastePlugin에서 GFM 테이블 없이 마크다운을 가져오는 설정 적용

* feat: 개선된 고급 텍스트 에디터 스타일 및 클래스 관리

- AdvancedTextEditor에서 editor actions가 겹치지 않도록 padding 조정
- isDisabled 상태에 따라 클래스 이름 동적으로 변경하여 에디터 동작 관리
- lexical_text_editor.scss에 overflow-wrap 속성 추가로 텍스트 처리 개선

* 기능: 고급 텍스트 에디터의 마크다운 처리 개선

- 전송 전에 최신 마크다운을 기존 초안과 합치도록 handleSubmitWithErrorHandling을 수정함.
- Lexical 텍스트 에디터에 마크다운 내보내기를 위한 readMarkdownForSubmit 메서드를 추가함.
- 제출 시 URL이 올바른 형식이 되도록 마크다운에서 URL을 정규화하는 unescapeUnderscoresInMarkdownUrls 함수를 도입함.
- 마크다운 변경 시 URL 정규화가 적용되도록 OnChangeMarkdownPlugin을 보강함.
- 기대 동작을 보장하기 위해 unescapeUnderscoresInMarkdownUrls에 대한 테스트를 추가함.

<!-- Pull Request를 기여해 주셔서 감사합니다! 다음은 도움이 될 만한 몇 가지 팁입니다:

1. 첫 기여인 경우, 기여 체크리스트를 읽어주세요 https://developers.okrbest.com/contribute/getting-started/contribution-checklist/
2. "훌륭한 PR 제출하기"에 대한 블로그 포스트를 읽어보세요 https://developers.okrbest.com/blog/2019-01-24-submitting-great-prs
3. 저장소별 문서는 여기서 확인하세요 https://developers.okrbest.com/contribute
-->

#### 요약

<!--
이 Pull Request가 수행하는 작업에 대한 설명과 QA 테스트 단계를 작성해주세요 (해당되는 경우이며 Jira 티켓에 아직 추가되지 않은 경우).
-->

#### 티켓 링크

<!--
해당되는 경우 다음 링크 중 하나 또는 둘 다 포함해주세요:

수정: https://github.com/okrbest/okrbest/issues/XXX

-->

#### 스크린샷

<!--
PR에 UI 변경사항이 포함된 경우 스크린샷/GIF를 포함해주세요.

UI 변경사항을 쉽게 비교하기 위해 아래 템플릿과 같은 표를 사용할 수 있습니다.

|  이전  |  이후  |
|----|----|
| <이전 스크린샷 삽입> | <이후 스크린샷 삽입> |

-->

#### 릴리스 노트

<!--
다음 각 항목에 대한 릴리스 노트를 추가해주세요:

* 설정 변경사항 (추가, 삭제, 업데이트)
* API 추가 - 새로운 엔드포인트, 새로운 응답 필드 또는 새롭게 허용된 요청 파라미터
* 데이터베이스 변경사항 (모든 변경)
* 스키마 마이그레이션 변경사항. [스키마 마이그레이션 템플릿](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing)을 시작점으로 사용하여 이러한 세부사항을 릴리스 노트로 작성하세요.
* 웹소켓 추가 또는 변경사항
* OKR.BEST 인스턴스 관리자에게 주목할 만한 모든 사항 (과다 소통이 나을 수 있음)
* UI 변경, CLI 변경 등을 포함한 새로운 기능과 개선사항
* 버그 수정 및 이전 알려진 문제 수정
* 사용 중단 경고, 주요 변경사항 또는 호환성 관련 참고사항

릴리스 노트가 필요하지 않은 경우 NONE을 작성하세요. 과거 시제를 사용하세요. 줄바꿈은 제거됩니다.

예시:
