### PR TITLE
feat: 채널 북마크 메뉴 '채널 링크'로 변경 및 상시 노출

### DIFF
--- a/webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_direct_menu.tsx
+++ b/webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_direct_menu.tsx
@@ -60,7 +60,7 @@ const ChannelHeaderDirectMenu = ({channel, user, isMuted, isMobile, isFavorite, 
                 channel={channel}
             />
             <Menu.Separator/>
-            {!isGuest(user.roles) && isChannelBookmarksEnabled && (
+            {!isGuest(user.roles) && (
                 <MenuItemChannelBookmarks
                     channel={channel}
                 />

--- a/webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_group_menu.tsx
+++ b/webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_group_menu.tsx
@@ -102,7 +102,7 @@ const ChannelHeaderGroupMenu = ({channel, user, isMuted, isMobile, isFavorite, p
                     />
                 </Menu.SubMenu>
             )}
-            {!isArchived && !isGuest(user.roles) && isChannelBookmarksEnabled && (
+            {!isArchived && !isGuest(user.roles) && (
                 <MenuItemChannelBookmarks
                     channel={channel}
                 />

--- a/webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_public_private_menu.tsx
+++ b/webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_public_private_menu.tsx
@@ -74,11 +74,9 @@ const ChannelHeaderPublicMenu = ({channel, user, isMuted, isDefault, isMobile, i
                     <MenuItemChannelSettings
                         channel={channel}
                     />
-                    {isChannelBookmarksEnabled && (
-                        <MenuItemChannelBookmarks
-                            channel={channel}
-                        />
-                    )}
+                    <MenuItemChannelBookmarks
+                        channel={channel}
+                    />
                 </>
             )}
             <Menu.Separator/>

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -3773,7 +3773,7 @@
   "channel_members_rhs.policy_enforced_restrictions": "Channel access is restricted by user attributes",
   "channel_members_rhs.search_bar.aria.cancel_search_button": "cancel members search",
   "channel_members_rhs.search_bar.placeholder": "Search members",
-  "channel_menu.bookmarks": "Bookmarks Bar",
+  "channel_menu.bookmarks": "Channel Links",
   "channel_menu.bookmarks.addFile": "Attach a file",
   "channel_menu.bookmarks.addLink": "Add a link",
   "channel_modal.alreadyExist": "A channel with that URL already exists",

--- a/webapp/channels/src/i18n/ko.json
+++ b/webapp/channels/src/i18n/ko.json
@@ -3674,7 +3674,7 @@
   "channel_members_rhs.policy_enforced_restrictions": "채널 접근이 사용자 속성으로 제한됩니다",
   "channel_members_rhs.search_bar.aria.cancel_search_button": "멤버 검색 취소",
   "channel_members_rhs.search_bar.placeholder": "멤버 검색",
-  "channel_menu.bookmarks": "북마크 바",
+  "channel_menu.bookmarks": "채널 링크",
   "channel_menu.bookmarks.addFile": "파일 첨부하기",
   "channel_menu.bookmarks.addLink": "링크 추가하기",
   "channel_modal.alreadyExist": "해당 URL을 가진 채널이 이미 존재합니다",


### PR DESCRIPTION
## Summary
- `channel_menu.bookmarks` 다국어 텍스트 변경: `북마크 바` → `채널 링크` (ko), `Bookmarks Bar` → `Channel Links` (en)
- `isChannelBookmarksEnabled` feature flag / license 조건 제거로 채널 링크 메뉴 상시 노출 적용
  - `channel_header_public_private_menu.tsx`
  - `channel_header_group_menu.tsx`
  - `channel_header_direct_menu.tsx`

## Changed Files
- `webapp/channels/src/i18n/ko.json`
- `webapp/channels/src/i18n/en.json`
- `webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_public_private_menu.tsx`
- `webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_group_menu.tsx`
- `webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_direct_menu.tsx`

## Test plan
- [ ] 채널 헤더 메뉴에서 '채널 링크' 메뉴 항목이 항상 노출되는지 확인
- [ ] 북마크 데이터가 없는 채널에서도 메뉴가 표시되는지 확인
- [ ] 한국어/영어 로케일에서 텍스트가 올바르게 표시되는지 확인