### PR TITLE
feat: 해시태그 링크 복사-붙여넣기 시 플레인 텍스트로 변환

### DIFF
--- a/webapp/channels/src/components/lexical_editor/plugins/markdown_paste_plugin.tsx
+++ b/webapp/channels/src/components/lexical_editor/plugins/markdown_paste_plugin.tsx
@@ -24,6 +24,9 @@ import {
 import type {LexicalEditor, LexicalNode, SerializedLexicalNode} from 'lexical';
 import {useEffect, useRef, type MutableRefObject} from 'react';
 
+import {stripHashtagLinks} from 'utils/paste';
+import turndownService from 'utils/turndown';
+
 import {CHANNELS_MARKDOWN_IMPORT_WITHOUT_TABLE} from '../config/markdown_transformers';
 import {ChannelMentionNode} from '../nodes/channel_mention_node';
 import {EmojiNode} from '../nodes/emoji_node';
@@ -106,10 +109,37 @@ export default function MarkdownPastePlugin(): null {
                     return false;
                 }
 
+                const html = data.getData('text/html');
+                const strippedHtml = html ? stripHashtagLinks(html) : html;
+                const hasHashtagLink = html && strippedHtml !== html;
+
                 const plainRaw = data.getData('text/plain');
                 const plain = sanitizePlainForMarkdown(plainRaw);
-                if (!plain || !plainTextLooksLikeMarkdown(plain)) {
+                if (!hasHashtagLink && (!plain || !plainTextLooksLikeMarkdown(plain))) {
                     return false;
+                }
+
+                if (hasHashtagLink) {
+                    const hashtagText = turndownService.turndown(strippedHtml).trim();
+                    if (!hashtagText) {
+                        return false;
+                    }
+                    event.preventDefault();
+                    editor.update(
+                        () => {
+                            const selection = $getSelection();
+                            if ($isRangeSelection(selection)) {
+                                selection.insertText(hashtagText);
+                            } else {
+                                const root = $getRoot();
+                                const p = $createParagraphNode();
+                                p.append($createTextNode(hashtagText));
+                                root.append(p);
+                            }
+                        },
+                        {tag: PASTE_TAG},
+                    );
+                    return true;
                 }
 
                 event.preventDefault();

--- a/webapp/channels/src/utils/paste.test.tsx
+++ b/webapp/channels/src/utils/paste.test.tsx
@@ -12,7 +12,9 @@ import {
     isTextUrl,
     hasPlainText,
     createFileFromClipboardDataItem,
-    pasteHandler, isKnownTargetForPaste,
+    pasteHandler,
+    isKnownTargetForPaste,
+    stripHashtagLinks,
 } from './paste';
 
 const validClipboardData: any = {
@@ -47,6 +49,33 @@ describe('getHtmlTable', () => {
 
     test('returns table from valid clipboard data', () => {
         expect(getHtmlTable(validClipboardData)).toEqual(validTable);
+    });
+});
+
+describe('stripHashtagLinks', () => {
+    test('should strip hashtag link with data-hashtag attribute', () => {
+        const html = '<a class="mention-link" href="#" data-hashtag="#홈피방문분석">#홈피방문분석</a>';
+        expect(stripHashtagLinks(html)).toBe('#홈피방문분석');
+    });
+
+    test('should strip hashtag link when browser resolves href to absolute URL', () => {
+        const html = '<a class="mention-link" href="http://localhost:8065/aaa/channels/off-topic#" data-hashtag="#홈피방문분석" style="box-sizing: border-box;">#홈피방문분석</a>';
+        expect(stripHashtagLinks(html)).toBe('#홈피방문분석');
+    });
+
+    test('should not strip regular links without data-hashtag', () => {
+        const html = '<a href="https://example.com">link text</a>';
+        expect(stripHashtagLinks(html)).toBe(html);
+    });
+
+    test('should strip multiple hashtag links in mixed content', () => {
+        const html = '텍스트 <a data-hashtag="#프로젝트" href="#">#프로젝트</a> 중간 <a data-hashtag="#진행중" href="#">#진행중</a> 끝';
+        expect(stripHashtagLinks(html)).toBe('텍스트 #프로젝트 중간 #진행중 끝');
+    });
+
+    test('should strip hashtag link when href appears before class', () => {
+        const html = '<a href="http://localhost:8065/channels/town-square#" class="mention-link">#프로젝트</a>';
+        expect(stripHashtagLinks(html)).toBe('#프로젝트');
     });
 });
 
@@ -98,6 +127,42 @@ describe('formatMarkdownMessage', () => {
         const markdownLink = '[link text](https://test.domain)';
 
         expect(formatMarkdownMessage(linkClipboardData).formattedMessage).toBe(markdownLink);
+    });
+
+    test('returns plain hashtag text when hashtag link is pasted', () => {
+        const hashtagClipboardData: any = {
+            items: [1],
+            types: ['text/html'],
+            getData: () => {
+                return '<a class="mention-link" href="#" data-hashtag="#홈피방문분석">#홈피방문분석</a>';
+            },
+        };
+
+        expect(formatMarkdownMessage(hashtagClipboardData).formattedMessage).toBe('#홈피방문분석');
+    });
+
+    test('returns plain hashtag text when browser resolves href to absolute URL', () => {
+        const hashtagClipboardData: any = {
+            items: [1],
+            types: ['text/html'],
+            getData: () => {
+                return '<a class="mention-link" href="http://localhost:8065/aaa/channels/off-topic#">#홈피방문분석</a>';
+            },
+        };
+
+        expect(formatMarkdownMessage(hashtagClipboardData).formattedMessage).toBe('#홈피방문분석');
+    });
+
+    test('returns plain hashtag with surrounding text when hashtag link is within content', () => {
+        const mixedClipboardData: any = {
+            items: [1],
+            types: ['text/html'],
+            getData: () => {
+                return '텍스트 <a class="mention-link" href="#" data-hashtag="#프로젝트">#프로젝트</a> 내용';
+            },
+        };
+
+        expect(formatMarkdownMessage(mixedClipboardData).formattedMessage).toBe('텍스트 #프로젝트 내용');
     });
 });
 
@@ -272,6 +337,28 @@ describe('pasteHandler', () => {
                 },
             },
             expectedMarkdown: '[link text](https://test.domain)',
+        },
+        {
+            testName: 'should paste hashtag as plain text instead of markdown link (with data-hashtag)',
+            clipboardData: {
+                items: [1],
+                types: ['text/html'],
+                getData: () => {
+                    return '<a class="mention-link" href="#" data-hashtag="#홈피방문분석">#홈피방문분석</a>';
+                },
+            },
+            expectedMarkdown: '#홈피방문분석',
+        },
+        {
+            testName: 'should paste hashtag as plain text when browser resolves href to absolute URL',
+            clipboardData: {
+                items: [1],
+                types: ['text/html'],
+                getData: () => {
+                    return '<a class="mention-link" href="http://localhost:8065/aaa/channels/off-topic#">#홈피방문분석</a>';
+                },
+            },
+            expectedMarkdown: '#홈피방문분석',
         },
         {
             testName: 'should be able to format a github codeblock (pasted as a table)',

--- a/webapp/channels/src/utils/paste.tsx
+++ b/webapp/channels/src/utils/paste.tsx
@@ -71,8 +71,14 @@ function isTableWithoutHeaderRow(table: HTMLTableElement): boolean {
  * @property {string} formattedMessage - The formatted message, including the formatted Markdown.
  * @property {string} formattedMarkdown - The resulting Markdown from the HTML clipboard data.
  */
+export function stripHashtagLinks(html: string): string {
+    return html.
+        replace(/<a\s[^>]*data-hashtag="([^"]*)"[^>]*>[^<]*<\/a>/gi, '$1').
+        replace(/<a\s(?=[^>]*class="[^"]*mention-link[^"]*")(?=[^>]*href="[^"]*#")[^>]*>(#[^<]*)<\/a>/gi, '$1');
+}
+
 export function formatMarkdownMessage(clipboardData: DataTransfer, message?: string, caretPosition?: number): {formattedMessage: string; formattedMarkdown: string} {
-    const html = clipboardData.getData('text/html');
+    const html = stripHashtagLinks(clipboardData.getData('text/html'));
 
     let formattedMarkdown = turndownService.turndown(html).trim();
 


### PR DESCRIPTION
- 포스트에서 해시태그를 복사-붙여넣기할 때 마크다운 링크([#태그](URL))가 아닌 플레인 텍스트(#태그)로 삽입되도록 수정
- Lexical 에디터의 MarkdownPastePlugin에서 해시태그 HTML 감지 시 text/plain을 직접 사용하도록 처리
- 해시태그 링크 제거 함수(stripHashtagLinks) 및 관련 테스트 추가

<!-- Pull Request를 기여해 주셔서 감사합니다! 다음은 도움이 될 만한 몇 가지 팁입니다:

1. 첫 기여인 경우, 기여 체크리스트를 읽어주세요 https://developers.okrbest.com/contribute/getting-started/contribution-checklist/
2. "훌륭한 PR 제출하기"에 대한 블로그 포스트를 읽어보세요 https://developers.okrbest.com/blog/2019-01-24-submitting-great-prs
3. 저장소별 문서는 여기서 확인하세요 https://developers.okrbest.com/contribute
-->

#### 요약

<!--
이 Pull Request가 수행하는 작업에 대한 설명과 QA 테스트 단계를 작성해주세요 (해당되는 경우이며 Jira 티켓에 아직 추가되지 않은 경우).
-->

#### 티켓 링크

<!--
해당되는 경우 다음 링크 중 하나 또는 둘 다 포함해주세요:

수정: https://github.com/okrbest/okrbest/issues/XXX

-->

#### 스크린샷

<!--
PR에 UI 변경사항이 포함된 경우 스크린샷/GIF를 포함해주세요.

UI 변경사항을 쉽게 비교하기 위해 아래 템플릿과 같은 표를 사용할 수 있습니다.

|  이전  |  이후  |
|----|----|
| <이전 스크린샷 삽입> | <이후 스크린샷 삽입> |

-->

#### 릴리스 노트

<!--
다음 각 항목에 대한 릴리스 노트를 추가해주세요:

* 설정 변경사항 (추가, 삭제, 업데이트)
* API 추가 - 새로운 엔드포인트, 새로운 응답 필드 또는 새롭게 허용된 요청 파라미터
* 데이터베이스 변경사항 (모든 변경)
* 스키마 마이그레이션 변경사항. [스키마 마이그레이션 템플릿](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing)을 시작점으로 사용하여 이러한 세부사항을 릴리스 노트로 작성하세요.
* 웹소켓 추가 또는 변경사항
* OKR.BEST 인스턴스 관리자에게 주목할 만한 모든 사항 (과다 소통이 나을 수 있음)
* UI 변경, CLI 변경 등을 포함한 새로운 기능과 개선사항
* 버그 수정 및 이전 알려진 문제 수정
* 사용 중단 경고, 주요 변경사항 또는 호환성 관련 참고사항

릴리스 노트가 필요하지 않은 경우 NONE을 작성하세요. 과거 시제를 사용하세요. 줄바꿈은 제거됩니다.

예시:
