### PR TITLE
fix: upstream-sync signals의 merge-tree 상시 CONFLICT 오탐 수정

### DIFF
--- a/.specify/scripts/bash/upstream-sync.sh
+++ b/.specify/scripts/bash/upstream-sync.sh
@@ -168,6 +168,15 @@ cmd_signals() {
     echo "=== MERGE-TREE (cherry-pick 충돌 예측) ==="
     if git merge-tree --write-tree --merge-base="$hash^" "$BASE_BRANCH" "$hash" >/tmp/mt.$$ 2>&1; then
         echo "CLEAN"
+    elif grep -q '^usage: git merge-tree' /tmp/mt.$$; then
+        # git < 2.38: --write-tree 미지원 → 구식 merge-tree로 충돌 마커 검사
+        git merge-tree "$hash^" "$BASE_BRANCH" "$hash" >/tmp/mt.$$ 2>/dev/null || true
+        if grep -q '^+<<<<<<<' /tmp/mt.$$; then
+            echo "CONFLICT (legacy merge-tree)"
+            grep -B6 '^+<<<<<<<' /tmp/mt.$$ | awk '$1=="our"{print $NF}' | sort -u | awk "NR<=20"
+        else
+            echo "CLEAN (legacy merge-tree)"
+        fi
     else
         echo "CONFLICT"
         # --name-only 출력부에서 충돌 파일 추출


### PR DESCRIPTION
git < 2.38은 merge-tree --write-tree를 지원하지 않아 usage 에러의
비정상 종료가 항상 CONFLICT로 표시됐다. usage 에러 감지 시 구식
merge-tree(base ours theirs) 충돌 마커 검사로 폴백하고 충돌 파일을
출력한다. git 2.38+에서는 기존 경로 그대로 동작.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
