### PR TITLE
docs: constitution v1.1.0 — upstream 선별 반영 예외 조항 + speckit-sync 검증 강화

### DIFF
--- a/.claude/skills/speckit-sync/SKILL.md
+++ b/.claude/skills/speckit-sync/SKILL.md
@@ -57,7 +57,8 @@ okrbest는 mattermost/mattermost의 heavily-diverged 포크다. upstream 커밋�
 1. **upstream 커밋의 의도** 파악: 무엇을 왜 바꾸는가 (버그픽스/기능/리팩터/문서/번역).
 2. **우리 포크의 자체 변경과 대조**: signals의 FORK HISTORY에 나온 커밋들을 `git show`로 확인하고, 필요시 `git log -p master -- <경로>`와 `spec-docs/`(특히 `rebrand.md`, `feat-plan/`)를 조사한다. 질문: *우리가 이 영역을 의도적으로 바꿨거나 제거했는가?*
 3. **의미 충돌 검토**: merge-tree가 CLEAN이어도 리브랜드 문자열(Mattermost→OKR.BEST), 우리가 제거한 기능 참조, 플러그인/버전 의존을 확인한다. 텍스트가 안 겹쳐도 의미가 깨질 수 있다.
-4. 근거와 함께 **권고 결정**: cherry-pick / adapt / exclude / spec.
+4. **미반영 의존 검토**: 이 커밋이 exclude·건너뜀·아직 미반영인 upstream 커밋(선행 리팩터, feature flag, config 기본값, DB 스키마)에 의존하는지 확인한다. ledger 부록과 `git log upstream-master`로 선행 커밋 문맥을 조사한다.
+5. 근거와 함께 **권고 결정**: cherry-pick / adapt / exclude / spec.
 
 #### 2-3. 대화형 승인 (커밋마다 필수)
 
@@ -102,6 +103,13 @@ okrbest는 mattermost/mattermost의 heavily-diverged 포크다. upstream 커밋�
 - **spec**: `$SYNC to-spec <hash> "<가칭 또는 specs/NNN-이름>"` 기록. 그 후 사용자에게 `/speckit-specify` 착수 여부를 **명시적으로 질문**한다 (CLAUDE.md 핸드오프 규칙 — 자동 진입 금지). spec 구현 완료 커밋 본문에 `Upstream: <링크>`를 넣어야 목록에서 자동 차감됨을 안내.
 - **건너뜀**: 아무것도 하지 않음 (목록 유지).
 
+**커밋 직후 검증 (cherry-pick·adapt 공통, 코드 커밋만)**: 접촉 패키지 한정 테스트를 즉시 실행해 회귀를 커밋 단위로 귀속시킨다 (constitution 원칙 III 예외 조건).
+
+- server 접촉 시: `cd server && go test ./<접촉 패키지>...`
+- webapp 접촉 시: `cd webapp && npm run test -- <관련 경로>`
+- docs·i18n·주석만 건드린 커밋은 생략 가능.
+- 실패 시 즉시 해결(systematic-debugging) 또는 해당 커밋 revert 후 사용자 보고 — 실패를 안고 다음 커밋으로 넘어가지 않는다.
+
 #### 2-5. 목록 갱신
 
 `$SYNC update` 재실행 → 남은 개수·마지막 반영 커밋 갱신 확인.
@@ -145,4 +153,5 @@ okrbest는 mattermost/mattermost의 heavily-diverged 포크다. upstream 커밋�
 - 오래된 순서를 건너뛰어 최신 커밋을 먼저 반영하지 않는다 (의존성 붕괴). "건너뜀"은 예외적·일시적이어야 한다.
 - 대량 자동 처리 금지 — 커밋마다 분석·승인. 시간이 걸려도 정밀 분석이 우선.
 - Translations update(Weblate) 커밋은 우리 i18n 변경(ko.json)과 상시 충돌 — adapt 시 우리 ko.json 문자열을 보존한다 (constitution 원칙 V).
+- upstream 커밋이 `en.json`에 문자열을 추가·변경하면 같은 세션에서 `ko.json` 번역을 동반한다 (constitution 원칙 V — cherry-pick이면 직후 adapt 커밋으로 보충 가능).
 - 라이선스·리브랜드 충실성 (constitution 원칙 IV): copyright 헤더·NOTICE.txt 관련 upstream 변경은 그대로 반영, 우리 리브랜드 문자열은 보존.

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,9 +1,12 @@
 <!--
 Sync Impact Report
-- Version change: (template) → 1.0.0 (신규 제정)
-- Modified principles: 전체 신규 작성 (7개 원칙)
-- Added sections: Core Principles(I~VII), 기술·범위 제약, 개발 워크플로, Governance
-- Removed sections: 없음 (템플릿 슬롯 대체)
+- Version change: 1.0.0 → 1.1.0 (MINOR — upstream 선별 반영 예외 조항 추가)
+- Modified principles:
+  - III. 동작 변경 시 테스트 동반 — upstream 원본 cherry-pick 예외 + 접촉 패키지 검증 추가
+  - VI. 집중 브랜치 + Conventional Commits + PR — upstream 반영 커밋 제목·sync PR 묶음 예외 추가
+  - VII. Spec 주도 개발 워크플로 — upstream cherry-pick/adapt의 spec 파이프라인 예외 추가
+- Added sections: 없음
+- Removed sections: 없음
 - Templates requiring updates:
   - ✅ .specify/templates/plan-template.md (Constitution Check — 범용 게이트, 수정 불필요)
   - ✅ .specify/templates/spec-template.md (수정 불필요)
@@ -51,6 +54,11 @@ npm이 유일한 패키지 매니저다 (`webapp/package.json` workspaces: `chan
 버그 수정은 회귀 테스트를 포함한다. 통과를 위해 테스트를 약화·스킵·삭제하는 것을
 금지한다.
 
+예외: upstream 선별 반영(`/speckit-sync`)에서 원본 그대로 cherry-pick하는 커밋
+(`Upstream:` 참조 포함)은 테스트 동반 요건의 예외다. 대신 반영 직후 접촉 패키지
+테스트로 회귀를 검증해야 한다. adapt(프로젝트 맞춤 수정) 커밋은 예외가 아니며 본
+원칙을 그대로 따른다.
+
 ### IV. 라이선스·리브랜드 충실성 (NON-NEGOTIABLE)
 
 `spec-docs/rebrand.md`의 규칙을 따른다.
@@ -78,6 +86,11 @@ Conventional Commits 접두사(`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`)�
 리팩터·설정 변경을 섞지 않는다. DB 마이그레이션 디렉터리와 CI 설정은 CODEOWNERS
 보호 경로(`@okrbest/okrbest`)이므로 변경 시 신중히 검토한다.
 
+예외: upstream 선별 반영 커밋(`Upstream:` 참조 포함)은 추적성 보존을 위해 원본
+커밋 제목을 유지할 수 있으며(Conventional Commits 접두사 면제), sync PR은 여러
+upstream 커밋을 묶을 수 있다. 이때 병합은 커밋별 제목·본문이 보존되는 rebase
+merge로 한정한다(squash 금지 — `Upstream:` 참조 소실 방지).
+
 ### VII. Spec 주도 개발 워크플로
 
 기능 작업은 Spec Kit 파이프라인을 따른다:
@@ -88,6 +101,10 @@ superpowers 플러그인이 런타임에 집행한다: 실패 테스트 우선
 (test-driven-development), 증거 기반 완료 선언(verification-before-completion),
 근본 원인 우선 디버깅(systematic-debugging). superpowers는 원칙 I·III을
 운영화하고, spec-kit은 spec/plan 산출물을 소유한다.
+
+예외: upstream 선별 반영(`/speckit-sync`)의 cherry-pick/adapt 커밋은 커밋별
+의도 분석·대화형 승인을 거치므로 spec 파이프라인 요건의 예외다. 대규모·큰 영향
+upstream 커밋은 spec 분기로 본 파이프라인에 합류한다.
 
 ## 기술·범위 제약
 
@@ -114,4 +131,4 @@ PATCH: 문구 명확화). 모든 PR·리뷰는 원칙 준수를 확인해야 하
 필요한 경우 그 근거를 plan의 Complexity Tracking에 문서화한다.
 `/speckit-plan`·`/speckit-analyze`가 Constitution Check 게이트로 자동 참조한다.
 
-**Version**: 1.0.0 | **Ratified**: 2026-07-23 | **Last Amended**: 2026-07-23
+**Version**: 1.1.0 | **Ratified**: 2026-07-23 | **Last Amended**: 2026-07-27


### PR DESCRIPTION
- 원칙 III·VI·VII에 upstream 선별 반영(Upstream: 참조) 예외 명문화
- speckit-sync: 미반영 의존 검토, 커밋 직후 접촉 패키지 테스트, en.json→ko.json 동반 규칙 추가

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
