### PR TITLE
upstream sync 2026-07-27 (picked 1) - invite_id permission fix

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,15 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-07-27 14:10
+- 갱신일: 2026-07-27 14:19
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1177개
+- 남은 커밋: 1176개
 
-**마지막 반영 커밋:** `346bc3f5` | [Translations update from Mattermost Weblate (#34844)](https://github.com/mattermost/mattermost/commit/346bc3f561f80a6b02687c3bb5eb68040e423770) | 2026-01-05
+**마지막 반영 커밋:** `cc427af4` | [\[MM-66827\] Omit invite_id from team creation response based on permissions (#34693)](https://github.com/mattermost/mattermost/commit/cc427af41b2a8d3a552d8dc42978831dcfecc1d8) | 2026-01-05
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| cc427af4 | [\[MM-66827\] Omit invite_id from team creation response based on permissions (#34693)](https://github.com/mattermost/mattermost/commit/cc427af41b2a8d3a552d8dc42978831dcfecc1d8) | 2026-01-05 |
 | 08087a14 | [Update golang.org/x/crypto (#34838)](https://github.com/mattermost/mattermost/commit/08087a1420b0297bdfe6a5c43fc16605725bf773) | 2026-01-05 |
 | d8445304 | [Fix copyright date and address for email footers (#34813)](https://github.com/mattermost/mattermost/commit/d84453049611abb69839462120fe3145f744bebf) | 2026-01-05 |
 | 413cf4d6 | [\[MM-66918\] Return descriptive errors from IsValidWebAuthRedirectURL (#34712)](https://github.com/mattermost/mattermost/commit/413cf4d67cf2958bd1642666828a786e3bbeee9c) | 2026-01-06 |

--- a/server/channels/api4/team.go
+++ b/server/channels/api4/team.go
@@ -139,6 +139,12 @@ func createTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Don't sanitize the team here since the user will be a team admin and their session won't reflect that yet
+	// instead check the scheme roles for the team and if the user has the permission to invite users
+	_, schemeUserRole, schemeAdminRole, schemeErr := c.App.GetSchemeRolesForTeam(rteam.Id)
+	if schemeErr != nil || !c.App.RolesGrantPermission([]string{schemeUserRole, schemeAdminRole}, model.PermissionInviteUser.Id) {
+		// If we can't check permissions, fail secure by hiding the invite_id because the team is already created above
+		rteam.InviteId = ""
+	}
 
 	auditRec.Success()
 	auditRec.AddEventResultState(&team)

--- a/server/channels/api4/team_test.go
+++ b/server/channels/api4/team_test.go
@@ -233,6 +233,29 @@ func TestCreateTeamSanitization(t *testing.T) {
 	}, "system admin")
 }
 
+func TestCreateTeamInviteIdHiddenWithoutInvitePermission(t *testing.T) {
+	th := Setup(t)
+
+	defaultRolePermissions := th.SaveDefaultRolePermissions(t)
+	defer th.RestoreDefaultRolePermissions(t, defaultRolePermissions)
+
+	// Remove PermissionInviteUser from the default team user role
+	th.RemovePermissionFromRole(t, model.PermissionInviteUser.Id, model.TeamUserRoleId)
+
+	// Regular user creates a team - InviteId should be hidden
+	// since the team user role lacks invite permission
+	rteam, _, err := th.Client.CreateTeam(context.Background(), &model.Team{
+		DisplayName:    "Team Without Invite Permission",
+		Name:           GenerateTestTeamName(),
+		Email:          th.GenerateTestEmail(),
+		Type:           model.TeamOpen,
+		AllowedDomains: "simulator.amazonses.com,localhost",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, rteam.Email, "should not have sanitized email")
+	require.Empty(t, rteam.InviteId, "should have hidden invite_id when user lacks invite permission")
+}
+
 func TestGetTeam(t *testing.T) {
 	mainHelper.Parallel(t)
 

--- a/server/channels/app/team.go
+++ b/server/channels/app/team.go
@@ -375,6 +375,7 @@ func (a *App) sendTeamEvent(team *model.Team, event model.WebsocketEventType) *m
 	return nil
 }
 
+// GetSchemeRolesForTeam Gets the scheme roles for a team, they may be empty, default or custom permissions based on the scheme.
 func (a *App) GetSchemeRolesForTeam(teamID string) (string, string, string, *model.AppError) {
 	team, err := a.GetTeam(teamID)
 	if err != nil {


### PR DESCRIPTION
- [MM-66827] Omit invite_id from team creation response based on permissions (#34693) - docs: upstream sync 진행 (picked 1)