### PR TITLE
upstream sync 2026-07-27 (picked 1)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,15 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-07-27 14:19
+- 갱신일: 2026-07-27 14:37
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1176개
+- 남은 커밋: 1175개
 
-**마지막 반영 커밋:** `cc427af4` | [\[MM-66827\] Omit invite_id from team creation response based on permissions (#34693)](https://github.com/mattermost/mattermost/commit/cc427af41b2a8d3a552d8dc42978831dcfecc1d8) | 2026-01-05
+**마지막 반영 커밋:** `08087a14` | [Update golang.org/x/crypto (#34838)](https://github.com/mattermost/mattermost/commit/08087a1420b0297bdfe6a5c43fc16605725bf773) | 2026-01-05
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 08087a14 | [Update golang.org/x/crypto (#34838)](https://github.com/mattermost/mattermost/commit/08087a1420b0297bdfe6a5c43fc16605725bf773) | 2026-01-05 |
 | d8445304 | [Fix copyright date and address for email footers (#34813)](https://github.com/mattermost/mattermost/commit/d84453049611abb69839462120fe3145f744bebf) | 2026-01-05 |
 | 413cf4d6 | [\[MM-66918\] Return descriptive errors from IsValidWebAuthRedirectURL (#34712)](https://github.com/mattermost/mattermost/commit/413cf4d67cf2958bd1642666828a786e3bbeee9c) | 2026-01-06 |
 | 84e267e9 | [\[MM-66789\] Restrict ImportSettings.Directory changes via API and add validation (#34653)](https://github.com/mattermost/mattermost/commit/84e267e9e89a4d6c4087772362ffe8b89d678f3d) | 2026-01-06 |

--- a/server/go.mod
+++ b/server/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/wiggin77/merror v1.0.5
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c
 	github.com/yuin/goldmark v1.7.13
-	golang.org/x/crypto v0.44.0
+	golang.org/x/crypto v0.45.0
 	golang.org/x/image v0.32.0
 	golang.org/x/net v0.47.0
 	golang.org/x/sync v0.18.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -723,8 +723,8 @@ golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
-golang.org/x/crypto v0.44.0 h1:A97SsFvM3AIwEEmTBiaxPPTYpDC47w720rdiiUvgoAU=
-golang.org/x/crypto v0.44.0/go.mod h1:013i+Nw79BMiQiMsOPcVCB5ZIJbYkerPrGnOa00tvmc=
+golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
+golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=


### PR DESCRIPTION
## Summary
- cherry-pick: golang.org/x/crypto v0.44.0 → v0.45.0 dependency bump (Upstream: https://github.com/mattermost/mattermost/commit/08087a1420b0297bdfe6a5c43fc16605725bf773)

## Commits
$(git log master..HEAD --reverse --pretty='- %s')

## Test plan
- [x] server: go build ./... passed