### PR TITLE
upstream sync 2026-07-27 (picked 1)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,15 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-07-27 14:37
+- 갱신일: 2026-07-27 15:18
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1175개
+- 남은 커밋: 1174개
 
-**마지막 반영 커밋:** `08087a14` | [Update golang.org/x/crypto (#34838)](https://github.com/mattermost/mattermost/commit/08087a1420b0297bdfe6a5c43fc16605725bf773) | 2026-01-05
+**마지막 반영 커밋:** `d8445304` | [Fix copyright date and address for email footers (#34813)](https://github.com/mattermost/mattermost/commit/d84453049611abb69839462120fe3145f744bebf) | 2026-01-05
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| d8445304 | [Fix copyright date and address for email footers (#34813)](https://github.com/mattermost/mattermost/commit/d84453049611abb69839462120fe3145f744bebf) | 2026-01-05 |
 | 413cf4d6 | [\[MM-66918\] Return descriptive errors from IsValidWebAuthRedirectURL (#34712)](https://github.com/mattermost/mattermost/commit/413cf4d67cf2958bd1642666828a786e3bbeee9c) | 2026-01-06 |
 | 84e267e9 | [\[MM-66789\] Restrict ImportSettings.Directory changes via API and add validation (#34653)](https://github.com/mattermost/mattermost/commit/84e267e9e89a4d6c4087772362ffe8b89d678f3d) | 2026-01-06 |
 | 98124364 | [MM-66800 Migrate Add Channels menu to new menu component (#34757)](https://github.com/mattermost/mattermost/commit/98124364ea3078537027e36956cf2dce40fea250) | 2026-01-06 |

--- a/e2e-tests/cypress/tests/utils/email.js
+++ b/e2e-tests/cypress/tests/utils/email.js
@@ -37,7 +37,7 @@ export function getJoinEmailTemplate(sender, userEmail, team, isGuest = false) {
         'Mattermost is a flexible, open source messaging platform that enables secure team collaboration.',
         'Learn more ( mattermost.com )',
         '',
-        '© 2022 Mattermost, Inc. 530 Lytton Avenue, Second floor, Palo Alto, CA, 94301',
+        `© 2015 - ${new Date().getFullYear()} Mattermost, Inc. 2100 Geng Road, Suite 210, Palo Alto, CA, 94303`,
     ];
 }
 
@@ -59,7 +59,7 @@ export function getMentionEmailTemplate(sender, message, postId, siteName, teamN
         'Want to change your notifications settings?',
         `Login to ${siteName} ( ${baseUrl} ) and go to Settings > Notifications`,
         '',
-        '© 2022 Mattermost, Inc. 530 Lytton Avenue, Second floor, Palo Alto, CA, 94301',
+        `© 2015 - ${new Date().getFullYear()} Mattermost, Inc. 2100 Geng Road, Suite 210, Palo Alto, CA, 94303`,
     ];
 }
 
@@ -74,7 +74,7 @@ export function getPasswordResetEmailTemplate() {
         '',
         'The password reset link expires in 24 hours.',
         '',
-        '© 2022 Mattermost, Inc. 530 Lytton Avenue, Second floor, Palo Alto, CA, 94301',
+        `© 2015 - ${new Date().getFullYear()} Mattermost, Inc. 2100 Geng Road, Suite 210, Palo Alto, CA, 94303`,
     ];
 }
 
@@ -91,7 +91,7 @@ export function getEmailVerifyEmailTemplate(userEmail) {
         'This email address was used to create an account with Mattermost.',
         'If it was not you, you can safely ignore this email.',
         '',
-        '© 2022 Mattermost, Inc. 530 Lytton Avenue, Second floor, Palo Alto, CA, 94301',
+        `© 2015 - ${new Date().getFullYear()} Mattermost, Inc. 2100 Geng Road, Suite 210, Palo Alto, CA, 94303`,
     ];
 }
 
@@ -113,7 +113,7 @@ export function getWelcomeEmailTemplate(userEmail, siteName, teamName) {
         '',
         'Download ( https://mattermost.com/pl/download-apps )',
         '',
-        '© 2022 Mattermost, Inc. 530 Lytton Avenue, Second floor, Palo Alto, CA, 94301',
+        `© 2015 - ${new Date().getFullYear()} Mattermost, Inc. 2100 Geng Road, Suite 210, Palo Alto, CA, 94303`,
     ];
 }
 

--- a/server/channels/app/email/email.go
+++ b/server/channels/app/email/email.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -78,7 +79,7 @@ func (es *Service) SendEmailChangeVerifyEmail(newUserEmail, locale, siteURL, tok
 	data.Props["QuestionTitle"] = T("api.templates.questions_footer.title")
 	data.Props["EmailInfo1"] = T("api.templates.email_us_anytime_at")
 	data.Props["SupportEmail"] = "feedback@mattermost.com"
-	data.Props["FooterV2"] = T("api.templates.email_footer_v2")
+	data.Props["FooterV2"] = T("api.templates.email_footer_v2", map[string]any{"CurrentYear": time.Now().Year()})
 
 	body, err := es.templatesContainer.RenderToString("email_change_verify_body", data)
 	if err != nil {
@@ -859,7 +860,7 @@ func (es *Service) NewEmailTemplateData(locale string) templates.Data {
 				map[string]any{"SiteName": es.config().TeamSettings.SiteName}),
 			"SupportEmail": *es.config().SupportSettings.SupportEmail,
 			"Footer":       localT("api.templates.email_footer"),
-			"FooterV2":     localT("api.templates.email_footer_v2"),
+			"FooterV2":     localT("api.templates.email_footer_v2", map[string]any{"CurrentYear": time.Now().Year()}),
 			"Organization": organization,
 		},
 		HTML: map[string]template.HTML{},

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -3712,7 +3712,7 @@
   },
   {
     "id": "api.templates.email_footer_v2",
-    "translation": "© 2022 Mattermost, Inc. 530 Lytton Avenue, Second floor, Palo Alto, CA, 94301"
+    "translation": "© 2015 - {{ .CurrentYear }} Mattermost, Inc. 2100 Geng Road, Suite 210, Palo Alto, CA, 94303"
   },
   {
     "id": "api.templates.email_info1",


### PR DESCRIPTION
## Summary
- cherry-pick: Fix copyright date and address for email footers (#34813) — upstream 원문 그대로 반영 (Mattermost, Inc. 정보; OKR.BEST 리브랜딩은 별도 Phase 2 작업으로 보류) (Upstream: https://github.com/mattermost/mattermost/commit/d84453049611abb69839462120fe3145f744bebf)

## Commits
$(git log master..HEAD --reverse --pretty='- %s')

## Test plan
- [x] server: go build ./channels/app/email/... passed