### PR TITLE
upstream sync 2026-07-27 (picked 1)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,15 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-07-27 15:18
+- 갱신일: 2026-07-27 15:34
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1174개
+- 남은 커밋: 1173개
 
-**마지막 반영 커밋:** `d8445304` | [Fix copyright date and address for email footers (#34813)](https://github.com/mattermost/mattermost/commit/d84453049611abb69839462120fe3145f744bebf) | 2026-01-05
+**마지막 반영 커밋:** `413cf4d6` | [\[MM-66918\] Return descriptive errors from IsValidWebAuthRedirectURL (#34712)](https://github.com/mattermost/mattermost/commit/413cf4d67cf2958bd1642666828a786e3bbeee9c) | 2026-01-06
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 413cf4d6 | [\[MM-66918\] Return descriptive errors from IsValidWebAuthRedirectURL (#34712)](https://github.com/mattermost/mattermost/commit/413cf4d67cf2958bd1642666828a786e3bbeee9c) | 2026-01-06 |
 | 84e267e9 | [\[MM-66789\] Restrict ImportSettings.Directory changes via API and add validation (#34653)](https://github.com/mattermost/mattermost/commit/84e267e9e89a4d6c4087772362ffe8b89d678f3d) | 2026-01-06 |
 | 98124364 | [MM-66800 Migrate Add Channels menu to new menu component (#34757)](https://github.com/mattermost/mattermost/commit/98124364ea3078537027e36956cf2dce40fea250) | 2026-01-06 |
 | 2f409ba4 | [MM-65828 Add ThemeProvider and make app use Denim theme by default (#34755)](https://github.com/mattermost/mattermost/commit/2f409ba46b42f80efef62a4bcdd88c07db8e5a9d) | 2026-01-06 |

--- a/server/channels/utils/utils.go
+++ b/server/channels/utils/utils.go
@@ -188,20 +188,28 @@ func AppendQueryParamsToURL(baseURL string, params map[string]string) string {
 	return u.String()
 }
 
-// Validates RedirectURL passed during OAuth or SAML
-func IsValidWebAuthRedirectURL(config *model.Config, redirectURL string) bool {
+// ValidateWebAuthRedirectUrl validates a RedirectURL passed during OAuth or SAML.
+func ValidateWebAuthRedirectUrl(config *model.Config, redirectURL string) error {
 	u, err := url.Parse(redirectURL)
-	if err != nil || config.ServiceSettings.SiteURL == nil {
-		return false
+	if err != nil {
+		return errors.Wrap(err, "failed to parse redirect URL")
+	}
+
+	if config.ServiceSettings.SiteURL == nil {
+		return errors.New("SiteURL is not configured")
 	}
 	siteURL, err := url.Parse(*config.ServiceSettings.SiteURL)
 	if err != nil {
-		return false
+		return errors.Wrap(err, "failed to parse SiteURL from config")
 	}
-	if u.Scheme == siteURL.Scheme && u.Host == siteURL.Host {
-		return true
+
+	if u.Scheme != siteURL.Scheme {
+		return errors.Errorf("redirect URL scheme %q does not match site URL scheme %q", u.Scheme, siteURL.Scheme)
 	}
-	return false
+	if u.Host != siteURL.Host {
+		return errors.Errorf("redirect URL host %q does not match site URL host %q", u.Host, siteURL.Host)
+	}
+	return nil
 }
 
 // Validates Mobile Custom URL Scheme passed during OAuth or SAML

--- a/server/channels/utils/utils_test.go
+++ b/server/channels/utils/utils_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost/server/public/model"
 )
@@ -444,8 +445,8 @@ func TestIsValidWebAuthRedirectURL(t *testing.T) {
 		}
 		redirectURL := "https://example.com/oauth/callback"
 
-		result := IsValidWebAuthRedirectURL(config, redirectURL)
-		assert.True(t, result)
+		err := ValidateWebAuthRedirectUrl(config, redirectURL)
+		require.NoError(t, err)
 	})
 
 	t.Run("Valid redirect URL with matching scheme and host with port", func(t *testing.T) {
@@ -456,8 +457,8 @@ func TestIsValidWebAuthRedirectURL(t *testing.T) {
 		}
 		redirectURL := "https://example.com:8080/oauth/callback"
 
-		result := IsValidWebAuthRedirectURL(config, redirectURL)
-		assert.True(t, result)
+		err := ValidateWebAuthRedirectUrl(config, redirectURL)
+		require.NoError(t, err)
 	})
 
 	t.Run("Invalid redirect URL with different scheme", func(t *testing.T) {
@@ -468,8 +469,9 @@ func TestIsValidWebAuthRedirectURL(t *testing.T) {
 		}
 		redirectURL := "http://example.com/oauth/callback"
 
-		result := IsValidWebAuthRedirectURL(config, redirectURL)
-		assert.False(t, result)
+		err := ValidateWebAuthRedirectUrl(config, redirectURL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "scheme")
 	})
 
 	t.Run("Invalid redirect URL with different host", func(t *testing.T) {
@@ -480,8 +482,9 @@ func TestIsValidWebAuthRedirectURL(t *testing.T) {
 		}
 		redirectURL := "https://malicious.com/oauth/callback"
 
-		result := IsValidWebAuthRedirectURL(config, redirectURL)
-		assert.False(t, result)
+		err := ValidateWebAuthRedirectUrl(config, redirectURL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "host")
 	})
 
 	t.Run("Invalid redirect URL with different port", func(t *testing.T) {
@@ -492,8 +495,9 @@ func TestIsValidWebAuthRedirectURL(t *testing.T) {
 		}
 		redirectURL := "https://example.com:9090/oauth/callback"
 
-		result := IsValidWebAuthRedirectURL(config, redirectURL)
-		assert.False(t, result)
+		err := ValidateWebAuthRedirectUrl(config, redirectURL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "host")
 	})
 
 	t.Run("Invalid redirect URL - malformed URL", func(t *testing.T) {
@@ -502,10 +506,11 @@ func TestIsValidWebAuthRedirectURL(t *testing.T) {
 				SiteURL: model.NewPointer("https://example.com"),
 			},
 		}
-		redirectURL := "not-a-valid-url"
+		redirectURL := "://not-a-valid-url"
 
-		result := IsValidWebAuthRedirectURL(config, redirectURL)
-		assert.False(t, result)
+		err := ValidateWebAuthRedirectUrl(config, redirectURL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse redirect URL")
 	})
 
 	t.Run("Invalid config - nil SiteURL", func(t *testing.T) {
@@ -516,20 +521,22 @@ func TestIsValidWebAuthRedirectURL(t *testing.T) {
 		}
 		redirectURL := "https://example.com/oauth/callback"
 
-		result := IsValidWebAuthRedirectURL(config, redirectURL)
-		assert.False(t, result)
+		err := ValidateWebAuthRedirectUrl(config, redirectURL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "SiteURL is not configured")
 	})
 
 	t.Run("Invalid config - malformed SiteURL", func(t *testing.T) {
 		config := &model.Config{
 			ServiceSettings: model.ServiceSettings{
-				SiteURL: model.NewPointer("not-a-valid-url"),
+				SiteURL: model.NewPointer("://not-a-valid-url"),
 			},
 		}
 		redirectURL := "https://example.com/oauth/callback"
 
-		result := IsValidWebAuthRedirectURL(config, redirectURL)
-		assert.False(t, result)
+		err := ValidateWebAuthRedirectUrl(config, redirectURL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse SiteURL")
 	})
 
 	t.Run("Valid redirect URL with subdomain", func(t *testing.T) {
@@ -540,8 +547,8 @@ func TestIsValidWebAuthRedirectURL(t *testing.T) {
 		}
 		redirectURL := "https://app.example.com/oauth/callback"
 
-		result := IsValidWebAuthRedirectURL(config, redirectURL)
-		assert.True(t, result)
+		err := ValidateWebAuthRedirectUrl(config, redirectURL)
+		require.NoError(t, err)
 	})
 
 	t.Run("Invalid redirect URL with different subdomain", func(t *testing.T) {
@@ -552,8 +559,9 @@ func TestIsValidWebAuthRedirectURL(t *testing.T) {
 		}
 		redirectURL := "https://api.example.com/oauth/callback"
 
-		result := IsValidWebAuthRedirectURL(config, redirectURL)
-		assert.False(t, result)
+		err := ValidateWebAuthRedirectUrl(config, redirectURL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "host")
 	})
 
 	t.Run("Valid redirect URL with path", func(t *testing.T) {
@@ -564,8 +572,8 @@ func TestIsValidWebAuthRedirectURL(t *testing.T) {
 		}
 		redirectURL := "https://example.com/mattermost/oauth/callback"
 
-		result := IsValidWebAuthRedirectURL(config, redirectURL)
-		assert.True(t, result)
+		err := ValidateWebAuthRedirectUrl(config, redirectURL)
+		require.NoError(t, err)
 	})
 
 	t.Run("Valid redirect URL with query parameters", func(t *testing.T) {
@@ -576,8 +584,8 @@ func TestIsValidWebAuthRedirectURL(t *testing.T) {
 		}
 		redirectURL := "https://example.com/oauth/callback?state=abc123&code=def456"
 
-		result := IsValidWebAuthRedirectURL(config, redirectURL)
-		assert.True(t, result)
+		err := ValidateWebAuthRedirectUrl(config, redirectURL)
+		require.NoError(t, err)
 	})
 
 	t.Run("Valid redirect URL with fragment", func(t *testing.T) {
@@ -588,8 +596,8 @@ func TestIsValidWebAuthRedirectURL(t *testing.T) {
 		}
 		redirectURL := "https://example.com/oauth/callback#token=abc123"
 
-		result := IsValidWebAuthRedirectURL(config, redirectURL)
-		assert.True(t, result)
+		err := ValidateWebAuthRedirectUrl(config, redirectURL)
+		require.NoError(t, err)
 	})
 
 	t.Run("Invalid redirect URL with @ symbol in host", func(t *testing.T) {
@@ -600,7 +608,8 @@ func TestIsValidWebAuthRedirectURL(t *testing.T) {
 		}
 		redirectURL := "https://qa-release.test.mattermost.cloud@example.com/oauth/callback"
 
-		result := IsValidWebAuthRedirectURL(config, redirectURL)
-		assert.False(t, result)
+		err := ValidateWebAuthRedirectUrl(config, redirectURL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "host")
 	})
 }

--- a/server/channels/web/oauth.go
+++ b/server/channels/web/oauth.go
@@ -464,9 +464,11 @@ func loginWithOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	redirectURL := r.URL.Query().Get("redirect_to")
 	desktopToken := r.URL.Query().Get("desktop_token")
 
-	if redirectURL != "" && !utils.IsValidWebAuthRedirectURL(c.App.Config(), redirectURL) {
-		c.Err = model.NewAppError("loginWithOAuth", "api.invalid_redirect_url", nil, "", http.StatusBadRequest)
-		return
+	if redirectURL != "" {
+		if err := utils.ValidateWebAuthRedirectUrl(c.App.Config(), redirectURL); err != nil {
+			c.Err = model.NewAppError("loginWithOAuth", "api.invalid_redirect_url", nil, err.Error(), http.StatusBadRequest)
+			return
+		}
 	}
 
 	auditRec := c.MakeAuditRecord(model.AuditEventLoginWithOAuth, model.AuditStatusFail)


### PR DESCRIPTION
## Summary
- cherry-pick: [MM-66918] Return descriptive errors from IsValidWebAuthRedirectURL (#34712) — OAuth/SAML 리다이렉트 URL 검증 함수를 bool 반환에서 구체적 에러 메시지 반환으로 리팩터 (Upstream: https://github.com/mattermost/mattermost/commit/413cf4d67cf2958bd1642666828a786e3bbeee9c)

## Commits
$(git log master..HEAD --reverse --pretty='- %s')

## Test plan
- [x] server: go build ./channels/utils/... ./channels/web/... passed
- [x] server: go test ./channels/utils/... -run TestIsValidWebAuthRedirectURL passed (14/14)
- [x] server: go vet ./channels/utils/... ./channels/web/... passed
- [x] server: golangci-lint run ./channels/utils/... ./channels/web/... passed