### PR TITLE
upstream sync 2026-07-27 (picked 1)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,15 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-07-27 15:34
+- 갱신일: 2026-07-27 15:51
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1173개
+- 남은 커밋: 1172개
 
-**마지막 반영 커밋:** `413cf4d6` | [\[MM-66918\] Return descriptive errors from IsValidWebAuthRedirectURL (#34712)](https://github.com/mattermost/mattermost/commit/413cf4d67cf2958bd1642666828a786e3bbeee9c) | 2026-01-06
+**마지막 반영 커밋:** `84e267e9` | [\[MM-66789\] Restrict ImportSettings.Directory changes via API and add validation (#34653)](https://github.com/mattermost/mattermost/commit/84e267e9e89a4d6c4087772362ffe8b89d678f3d) | 2026-01-06
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 84e267e9 | [\[MM-66789\] Restrict ImportSettings.Directory changes via API and add validation (#34653)](https://github.com/mattermost/mattermost/commit/84e267e9e89a4d6c4087772362ffe8b89d678f3d) | 2026-01-06 |
 | 98124364 | [MM-66800 Migrate Add Channels menu to new menu component (#34757)](https://github.com/mattermost/mattermost/commit/98124364ea3078537027e36956cf2dce40fea250) | 2026-01-06 |
 | 2f409ba4 | [MM-65828 Add ThemeProvider and make app use Denim theme by default (#34755)](https://github.com/mattermost/mattermost/commit/2f409ba46b42f80efef62a4bcdd88c07db8e5a9d) | 2026-01-06 |
 | 586adbd6 | [\[MM-62503\] Channel Title Description not Scrollable (#29827)](https://github.com/mattermost/mattermost/commit/586adbd6f04828ca4e66db66e579a1d7cd4fa508) | 2026-01-06 |

--- a/server/channels/api4/config.go
+++ b/server/channels/api4/config.go
@@ -159,6 +159,9 @@ func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	// modifications to the slice.
 	cfg.PluginSettings.SignaturePublicKeyFiles = appCfg.PluginSettings.SignaturePublicKeyFiles
 
+	// Do not allow import directory to be changed through the API
+	*cfg.ImportSettings.Directory = *appCfg.ImportSettings.Directory
+
 	// Do not allow marketplace URL to be toggled through the API if EnableUploads are disabled.
 	if cfg.PluginSettings.EnableUploads != nil && !*appCfg.PluginSettings.EnableUploads {
 		*cfg.PluginSettings.MarketplaceURL = *appCfg.PluginSettings.MarketplaceURL
@@ -302,6 +305,12 @@ func patchConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	// Do not allow plugin uploads to be toggled through the API
 	if cfg.PluginSettings.EnableUploads != nil && *cfg.PluginSettings.EnableUploads != *appCfg.PluginSettings.EnableUploads {
 		c.Err = model.NewAppError("patchConfig", "api.config.update_config.not_allowed_security.app_error", map[string]any{"Name": "PluginSettings.EnableUploads"}, "", http.StatusForbidden)
+		return
+	}
+
+	// Do not allow import directory to be changed through the API
+	if cfg.ImportSettings.Directory != nil && *cfg.ImportSettings.Directory != *appCfg.ImportSettings.Directory {
+		c.Err = model.NewAppError("patchConfig", "api.config.update_config.not_allowed_security.app_error", map[string]any{"Name": "ImportSettings.Directory"}, "", http.StatusForbidden)
 		return
 	}
 

--- a/server/channels/api4/config_test.go
+++ b/server/channels/api4/config_test.go
@@ -305,6 +305,43 @@ func TestUpdateConfig(t *testing.T) {
 		CheckForbiddenStatus(t, resp)
 	})
 
+	t.Run("Should not be able to modify ImportSettings.Directory", func(t *testing.T) {
+		t.Run("sysadmin", func(t *testing.T) {
+			oldDirectory := *th.App.Config().ImportSettings.Directory
+			cfg2 := th.App.Config().Clone()
+			*cfg2.ImportSettings.Directory = "./new-import-dir"
+
+			cfg2, _, err = th.SystemAdminClient.UpdateConfig(context.Background(), cfg2)
+			require.NoError(t, err)
+			assert.Equal(t, oldDirectory, *cfg2.ImportSettings.Directory)
+			assert.Equal(t, oldDirectory, *th.App.Config().ImportSettings.Directory)
+
+			cfg2.ImportSettings.Directory = nil
+			cfg2, _, err = th.SystemAdminClient.UpdateConfig(context.Background(), cfg2)
+			require.NoError(t, err)
+			assert.Equal(t, oldDirectory, *cfg2.ImportSettings.Directory)
+			assert.Equal(t, oldDirectory, *th.App.Config().ImportSettings.Directory)
+		})
+
+		t.Run("local mode", func(t *testing.T) {
+			oldDirectory := *th.App.Config().ImportSettings.Directory
+			cfg2 := th.App.Config().Clone()
+			newDirectory := "./new-import-dir"
+			*cfg2.ImportSettings.Directory = newDirectory
+
+			cfg2, _, err = th.LocalClient.UpdateConfig(context.Background(), cfg2)
+			require.NoError(t, err)
+			assert.Equal(t, newDirectory, *cfg2.ImportSettings.Directory)
+			assert.Equal(t, newDirectory, *th.App.Config().ImportSettings.Directory)
+
+			cfg2.ImportSettings.Directory = nil
+			cfg2, _, err = th.LocalClient.UpdateConfig(context.Background(), cfg2)
+			require.NoError(t, err)
+			assert.Equal(t, oldDirectory, *cfg2.ImportSettings.Directory)
+			assert.Equal(t, oldDirectory, *th.App.Config().ImportSettings.Directory)
+		})
+	})
+
 	t.Run("System Admin should not be able to clear Site URL", func(t *testing.T) {
 		siteURL := cfg.ServiceSettings.SiteURL
 		defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.SiteURL = siteURL })
@@ -817,6 +854,30 @@ func TestPatchConfig(t *testing.T) {
 			} else {
 				require.Error(t, err)
 				CheckForbiddenStatus(t, resp)
+			}
+		})
+
+		t.Run("not allowing to change import directory via api, unless local mode", func(t *testing.T) {
+			oldDirectory := *th.App.Config().ImportSettings.Directory
+			config := model.Config{ImportSettings: model.ImportSettings{
+				Directory: model.NewPointer("./new-import-dir"),
+			}}
+
+			updatedConfig, resp, err := client.PatchConfig(context.Background(), &config)
+			if client == th.LocalClient {
+				require.NoError(t, err)
+				CheckOKStatus(t, resp)
+				assert.Equal(t, "./new-import-dir", *updatedConfig.ImportSettings.Directory)
+			} else {
+				require.Error(t, err)
+				CheckForbiddenStatus(t, resp)
+			}
+
+			// Reset for local mode
+			if client == th.LocalClient {
+				th.App.UpdateConfig(func(cfg *model.Config) {
+					*cfg.ImportSettings.Directory = oldDirectory
+				})
 			}
 		})
 	})


### PR DESCRIPTION
## Summary
- cherry-pick: [MM-66789] Restrict ImportSettings.Directory changes via API and add validation (#34653) — ImportSettings.Directory를 공개 API로 변경 불가하게 차단, local mode에서만 허용 (Upstream: https://github.com/mattermost/mattermost/commit/84e267e9e89a4d6c4087772362ffe8b89d678f3d)

## Commits
$(git log master..HEAD --reverse --pretty='- %s')

## Test plan
- [x] server: go build ./channels/api4/... ./cmd/mmctl/... passed
- [x] server: go vet ./channels/api4/... ./cmd/mmctl/... passed
- [x] server: golangci-lint run ./channels/api4/... ./cmd/mmctl/... passed
- [ ] server: go test ./channels/api4/... — Windows 환경 symlink 권한 제약으로 TestMain 단계에서 실행 불가 (환경 제약, 코드 변경과 무관)