### PR TITLE
upstream sync 2026-07-27 (picked 1)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,15 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-07-27 16:52
+- 갱신일: 2026-07-27 22:11
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1173개
+- 남은 커밋: 1178개
 
-**마지막 반영 커밋:** `98124364` | [MM-66800 Migrate Add Channels menu to new menu component (#34757)](https://github.com/mattermost/mattermost/commit/98124364ea3078537027e36956cf2dce40fea250) | 2026-01-06
+**마지막 반영 커밋:** `2f409ba4` | [MM-65828 Add ThemeProvider and make app use Denim theme by default (#34755)](https://github.com/mattermost/mattermost/commit/2f409ba46b42f80efef62a4bcdd88c07db8e5a9d) | 2026-01-06
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 2f409ba4 | [MM-65828 Add ThemeProvider and make app use Denim theme by default (#34755)](https://github.com/mattermost/mattermost/commit/2f409ba46b42f80efef62a4bcdd88c07db8e5a9d) | 2026-01-06 |
 | 586adbd6 | [\[MM-62503\] Channel Title Description not Scrollable (#29827)](https://github.com/mattermost/mattermost/commit/586adbd6f04828ca4e66db66e579a1d7cd4fa508) | 2026-01-06 |
 | 0184153d | [changed api spec definition for userThread (#34819)](https://github.com/mattermost/mattermost/commit/0184153d16212ee1261bb6b058693560f88ed3e4) | 2026-01-07 |
 | 0481bd1f | [Fliter post in search api with no read content channel permission (#34620)](https://github.com/mattermost/mattermost/commit/0481bd1fb04584db97eca45fd58ebd06c8200df4) | 2026-01-07 |
@@ -1184,6 +1183,12 @@
 | 10b780cb | [E2E/Test: Stabilize flaky tests (#37614)](https://github.com/mattermost/mattermost/commit/10b780cb097b2ec94ab0f9df7ebcbd5b7850f13f) | 2026-07-25 |
 | f0de1f48 | [\[Docs Revamp Feedback\] Readability & accessibility fixes (#37665)](https://github.com/mattermost/mattermost/commit/f0de1f485bd0c3168b31767b37d388fb1a5fa8a4) | 2026-07-27 |
 | 8828e5a2 | [fix(docs-preview): set commit status via gh api for correct target_url (#37664)](https://github.com/mattermost/mattermost/commit/8828e5a2585e8272555253a20e0efdf5bbda795c) | 2026-07-27 |
+| 7a1c7e4b | [\[Docs Revamp Feedback\] Fix content rendering bugs (admonitions, broken images, table wrapping, oversized icons) (#37669)](https://github.com/mattermost/mattermost/commit/7a1c7e4b6b997a52213cc00a4614a7a94e745fd7) | 2026-07-27 |
+| 9ac8f227 | [docs: fix broken mm-ref:/mm-doc: placeholder links from RST migration (#37673)](https://github.com/mattermost/mattermost/commit/9ac8f2273c0d46895fc1aef17192609aef8354fa) | 2026-07-27 |
+| e5d490e6 | [Remove unreviewed IA-redesign content, restructure air-gapped docs from legacy source (#37674)](https://github.com/mattermost/mattermost/commit/e5d490e6808f4b21e7d1aeb47ea0da814970a5f8) | 2026-07-27 |
+| 0e7b8a2f | [\[Docs Revamp Feedback\] Remove/restyle "vibe coded" yellow left-border signal (#37666)](https://github.com/mattermost/mattermost/commit/0e7b8a2ff60a70a73dd7154ecb5e622e86b1072a) | 2026-07-27 |
+| 0fed2262 | [Fix editing a post creating a draft (MM-69928) (#37658)](https://github.com/mattermost/mattermost/commit/0fed2262813c57bec6f47088efcbfe9e4335b5c4) | 2026-07-27 |
+| d73adf5b | [Fix image preview opening when clicking outside the image in a post (#37642)](https://github.com/mattermost/mattermost/commit/d73adf5b24fc5ff7f9e4fa67030d81d5cd45d59e) | 2026-07-27 |
 
 ## 제외된 커밋
 

--- a/webapp/channels/src/components/admin_console/admin_console.tsx
+++ b/webapp/channels/src/components/admin_console/admin_console.tsx
@@ -22,8 +22,6 @@ import DiscardChangesModal from 'components/discard_changes_modal';
 import ModalController from 'components/modal_controller';
 import SystemNotice from 'components/system_notice';
 
-import {applyTheme, resetTheme} from 'utils/utils';
-
 import {LhsItemType} from 'types/store/lhs';
 
 import AdminSidebar from './admin_sidebar';
@@ -96,12 +94,10 @@ const AdminConsole = (props: Props) => {
         props.actions.selectTeam('');
         document.body.classList.add('console__body');
         document.getElementById('root')?.classList.add('console__root');
-        resetTheme();
 
         return () => {
             document.body.classList.remove('console__body');
             document.getElementById('root')?.classList.remove('console__root');
-            applyTheme(props.currentTheme);
 
             // Reset the admin console users management table properties
             props.actions.setAdminConsoleUsersManagementTableProperties();

--- a/webapp/channels/src/components/admin_console/index.ts
+++ b/webapp/channels/src/components/admin_console/index.ts
@@ -12,7 +12,6 @@ import {selectTeam} from 'mattermost-redux/actions/teams';
 import {General} from 'mattermost-redux/constants';
 import * as Selectors from 'mattermost-redux/selectors/entities/admin';
 import {getConfig as getGeneralConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
-import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getRoles} from 'mattermost-redux/selectors/entities/roles';
 import {getTeam} from 'mattermost-redux/selectors/entities/teams';
 import {isCurrentUserSystemAdmin, currentUserHasAnAdminRole, getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
@@ -51,7 +50,6 @@ function mapStateToProps(state: GlobalState) {
         consoleAccess,
         cloud: state.entities.cloud,
         team,
-        currentTheme: getTheme(state),
     };
 }
 

--- a/webapp/channels/src/components/emoji/emoji_page.test.tsx
+++ b/webapp/channels/src/components/emoji/emoji_page.test.tsx
@@ -6,8 +6,6 @@ import {shallow} from 'enzyme';
 import React from 'react';
 import {Link} from 'react-router-dom';
 
-import type {Theme} from 'mattermost-redux/selectors/entities/preferences';
-
 import AnyTeamPermissionGate from 'components/permissions_gates/any_team_permission_gate';
 
 import EmojiList from './emoji_list';
@@ -15,21 +13,17 @@ import EmojiPage from './emoji_page';
 
 jest.mock('utils/utils', () => ({
     localizeMessage: jest.fn().mockReturnValue('Custom Emoji'),
-    resetTheme: jest.fn(),
-    applyTheme: jest.fn(),
 }));
 
 describe('EmojiPage', () => {
     const mockLoadRolesIfNeeded = jest.fn();
     const mockScrollToTop = jest.fn();
-    const mockCurrentTheme = {} as Theme;
 
     const defaultProps = {
         teamName: 'team',
         teamDisplayName: 'Team Display Name',
         siteName: 'Site Name',
         scrollToTop: mockScrollToTop,
-        currentTheme: mockCurrentTheme,
         actions: {
             loadRolesIfNeeded: mockLoadRolesIfNeeded,
         },

--- a/webapp/channels/src/components/emoji/emoji_page.tsx
+++ b/webapp/channels/src/components/emoji/emoji_page.tsx
@@ -6,11 +6,8 @@ import {FormattedMessage, useIntl} from 'react-intl';
 import {Link} from 'react-router-dom';
 
 import Permissions from 'mattermost-redux/constants/permissions';
-import type {Theme} from 'mattermost-redux/selectors/entities/preferences';
 
 import AnyTeamPermissionGate from 'components/permissions_gates/any_team_permission_gate';
-
-import * as Utils from 'utils/utils';
 
 import EmojiList from './emoji_list';
 
@@ -19,7 +16,6 @@ type Props = {
     teamDisplayName?: string;
     siteName?: string;
     scrollToTop(): void;
-    currentTheme: Theme;
     actions: {
         loadRolesIfNeeded(roles: Iterable<string>): void;
     };
@@ -33,7 +29,6 @@ export default function EmojiPage({
     teamName = '',
     siteName = '',
     scrollToTop,
-    currentTheme,
     actions,
 }: Props) {
     const intl = useIntl();
@@ -41,11 +36,6 @@ export default function EmojiPage({
     useEffect(() => {
         updateTitle();
         actions.loadRolesIfNeeded(ROLES);
-        Utils.resetTheme();
-
-        return () => {
-            Utils.applyTheme(currentTheme);
-        };
     }, []);
 
     useEffect(() => {

--- a/webapp/channels/src/components/emoji/index.ts
+++ b/webapp/channels/src/components/emoji/index.ts
@@ -6,7 +6,6 @@ import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
 import {loadRolesIfNeeded} from 'mattermost-redux/actions/roles';
-import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import EmojiPage from 'components/emoji/emoji_page';
@@ -20,7 +19,6 @@ function mapStateToProps(state: GlobalState) {
         teamName: team?.name,
         teamDisplayName: team?.display_name,
         siteName: state.entities.general.config.SiteName,
-        currentTheme: getTheme(state),
     };
 }
 

--- a/webapp/channels/src/components/linking_landing_page/index.tsx
+++ b/webapp/channels/src/components/linking_landing_page/index.tsx
@@ -5,7 +5,6 @@ import {connect} from 'react-redux';
 
 import {Client4} from 'mattermost-redux/client';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import type {GlobalState} from 'types/store';
 
@@ -18,7 +17,6 @@ function mapStateToProps(state: GlobalState) {
         desktopAppLink: config.AppDownloadLink,
         iosAppLink: config.IosAppDownloadLink,
         androidAppLink: config.AndroidAppDownloadLink,
-        defaultTheme: getTheme(state),
         siteUrl: config.SiteURL,
         siteName: config.SiteName,
         brandImageUrl: Client4.getBrandImageUrl('0'),

--- a/webapp/channels/src/components/linking_landing_page/linking_landing_page.tsx
+++ b/webapp/channels/src/components/linking_landing_page/linking_landing_page.tsx
@@ -13,10 +13,8 @@ import mobileImg from 'images/deep-linking/deeplinking-mobile-img.png';
 import MattermostLogoSvg from 'images/logo.svg';
 import {LandingPreferenceTypes} from 'utils/constants';
 import * as UserAgent from 'utils/user_agent';
-import * as Utils from 'utils/utils';
 
 type Props = {
-    defaultTheme: any;
     desktopAppLink?: string;
     iosAppLink?: string;
     androidAppLink?: string;
@@ -89,7 +87,6 @@ export default class LinkingLandingPage extends PureComponent<Props, State> {
     }
 
     componentDidMount() {
-        Utils.applyTheme(this.props.defaultTheme);
         if (this.checkLandingPreferenceApp()) {
             this.openMattermostApp();
         }

--- a/webapp/channels/src/components/popout_controller/popout_controller.tsx
+++ b/webapp/channels/src/components/popout_controller/popout_controller.tsx
@@ -14,6 +14,7 @@ import {loadStatusesByIds} from 'actions/status_actions';
 import LoggedIn from 'components/logged_in';
 import ModalController from 'components/modal_controller';
 import RhsPopout from 'components/rhs_popout';
+import {useUserTheme} from 'components/theme_provider';
 import ThreadPopout from 'components/thread_popout';
 
 import Pluggable from 'plugins/pluggable';
@@ -25,7 +26,10 @@ import './popout_controller.scss';
 const PopoutController: React.FC<RouteComponentProps> = (routeProps) => {
     const dispatch = useDispatch();
     const currentUserId = useSelector(getCurrentUserId);
+
     useBrowserPopout();
+    useUserTheme();
+
     useEffect(() => {
         document.body.classList.add('app__body', 'popout');
         dispatch(getMe());

--- a/webapp/channels/src/components/root/index.ts
+++ b/webapp/channels/src/components/root/index.ts
@@ -12,7 +12,6 @@ import {getFirstAdminSetupComplete} from 'mattermost-redux/actions/general';
 import {getProfiles} from 'mattermost-redux/actions/users';
 import {isCurrentLicenseCloud} from 'mattermost-redux/selectors/entities/cloud';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getTeam} from 'mattermost-redux/selectors/entities/teams';
 import {shouldShowTermsOfService, getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
@@ -52,7 +51,6 @@ function mapStateToProps(state: GlobalState) {
     const isConfigLoaded = config && !isEmpty(config);
 
     return {
-        theme: getTheme(state),
         isConfigLoaded,
         telemetryEnabled: config.DiagnosticsEnabled === 'true',
         noAccounts: config.NoAccounts === 'true',

--- a/webapp/channels/src/components/root/root.test.tsx
+++ b/webapp/channels/src/components/root/root.test.tsx
@@ -5,14 +5,11 @@ import React from 'react';
 import type {RouteComponentProps} from 'react-router-dom';
 import {bindActionCreators} from 'redux';
 
-import type {Theme} from 'mattermost-redux/selectors/entities/preferences';
-
 import * as GlobalActions from 'actions/global_actions';
 
 import testConfigureStore from 'packages/mattermost-redux/test/test_store';
-import {act, renderWithContext, waitFor} from 'tests/react_testing_utils';
+import {renderWithContext, waitFor} from 'tests/react_testing_utils';
 import {StoragePrefixes} from 'utils/constants';
-import * as Utils from 'utils/utils';
 
 import {handleLoginLogoutSignal, redirectToOnboardingOrDefaultTeam} from './actions';
 import type {Props} from './root';
@@ -45,7 +42,6 @@ describe('components/Root', () => {
     const store = testConfigureStore();
 
     const baseProps: Props = {
-        theme: {sidebarBg: 'color'} as Theme,
         isConfigLoaded: true,
         telemetryEnabled: true,
         noAccounts: false,
@@ -286,52 +282,6 @@ describe('components/Root', () => {
             await waitFor(() => {
                 expect(props.history.push).not.toHaveBeenCalled();
             });
-        });
-    });
-
-    describe('applyTheme', () => {
-        test('should apply theme initially and on change', async () => {
-            const props = {
-                ...baseProps,
-            };
-
-            const {rerender} = renderWithContext(<Root {...props}/>);
-
-            await waitFor(() => {
-                expect(Utils.applyTheme).toHaveBeenCalledWith(props.theme);
-            });
-
-            const props2 = {
-                ...props,
-                theme: {sidebarBg: 'color2'} as Theme,
-            };
-
-            rerender(<Root {...props2}/>);
-
-            expect(Utils.applyTheme).toHaveBeenCalledWith(props2.theme);
-        });
-
-        test('should not apply theme in system console', async () => {
-            const props = {
-                ...baseProps,
-                ...{
-                    location: {
-                        pathname: '/admin_console',
-                    },
-                } as RouteComponentProps,
-            };
-
-            const {rerender} = renderWithContext(<Root {...props}/>);
-
-            const props2 = {
-                ...props,
-                theme: {sidebarBg: 'color2'} as Theme,
-            };
-
-            rerender(<Root {...props2}/>);
-
-            await act(() => {});
-            expect(Utils.applyTheme).not.toHaveBeenCalled();
         });
     });
 });

--- a/webapp/channels/src/components/root/root.tsx
+++ b/webapp/channels/src/components/root/root.tsx
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import classNames from 'classnames';
-import deepEqual from 'fast-deep-equal';
 import React, {lazy} from 'react';
 import {Route, Switch, Redirect} from 'react-router-dom';
 import type {RouteComponentProps} from 'react-router-dom';
@@ -24,6 +23,7 @@ import LoggedInRoute from 'components/logged_in_route';
 import {LAUNCHING_WORKSPACE_FULLSCREEN_Z_INDEX} from 'components/preparing_workspace/launching_workspace';
 import {Animations} from 'components/preparing_workspace/steps';
 import Readout from 'components/readout/readout';
+import {WithUserTheme} from 'components/theme_provider';
 
 import webSocketClient from 'client/web_websocket_client';
 import {initializePlugins} from 'plugins';
@@ -35,7 +35,7 @@ import {EmojiIndicesByAlias} from 'utils/emoji';
 import {TEAM_NAME_PATH_PATTERN} from 'utils/path';
 import {getSiteURL} from 'utils/url';
 import {isAndroidWeb, isChromebook, isDesktopApp, isIosWeb} from 'utils/user_agent';
-import {applyTheme, isTextDroppableEvent} from 'utils/utils';
+import {isTextDroppableEvent} from 'utils/utils';
 
 import LuxonController from './luxon_controller';
 import PerformanceReporterController from './performance_reporter_controller';
@@ -114,8 +114,6 @@ export default class Root extends React.PureComponent<Props, State> {
         this.props.actions.migrateRecentEmojis();
         this.props.actions.loadRecentlyUsedCustomEmojis();
         this.showLandingPageIfNecessary();
-
-        this.applyTheme();
     };
 
     private showLandingPageIfNecessary = () => {
@@ -179,21 +177,7 @@ export default class Root extends React.PureComponent<Props, State> {
         BrowserStore.setLandingPageSeen(true);
     };
 
-    applyTheme() {
-        // don't apply theme when in system console; system console hardcoded to THEMES.denim
-        // AdminConsole will apply denim on mount re-apply user theme on unmount
-        if (this.props.location.pathname.startsWith('/admin_console')) {
-            return;
-        }
-
-        applyTheme(this.props.theme);
-    }
-
     componentDidUpdate(prevProps: Props, prevState: State) {
-        if (!deepEqual(prevProps.theme, this.props.theme)) {
-            this.applyTheme();
-        }
-
         if (this.props.location.pathname === '/') {
             if (this.props.noAccounts) {
                 prevProps.history.push('/signup_user_complete');
@@ -420,7 +404,7 @@ export default class Root extends React.PureComponent<Props, State> {
                         path={'/_popout'}
                         component={PopoutController}
                     />
-                    <>
+                    <WithUserTheme>
                         {(this.props.showLaunchingWorkspace && !this.props.location.pathname.includes('/preparing-workspace') &&
                             <LaunchingWorkspace
                                 fullscreen={true}
@@ -509,7 +493,7 @@ export default class Root extends React.PureComponent<Props, State> {
                         <Pluggable pluggableName='Global'/>
                         <AppBar/>
                         <Readout/>
-                    </>
+                    </WithUserTheme>
                 </Switch>
             </RootProvider>
         );

--- a/webapp/channels/src/components/root/root_provider.tsx
+++ b/webapp/channels/src/components/root/root_provider.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 
 import IntlProvider from 'components/intl_provider';
+import ThemeProvider from 'components/theme_provider';
 
 import WebSocketClient from 'client/web_websocket_client';
 import {WebSocketContext} from 'utils/use_websocket';
@@ -16,7 +17,9 @@ export default function RootProvider(props: Props) {
     return (
         <IntlProvider>
             <WebSocketContext.Provider value={WebSocketClient}>
-                {props.children}
+                <ThemeProvider>
+                    {props.children}
+                </ThemeProvider>
             </WebSocketContext.Provider>
         </IntlProvider>
     );

--- a/webapp/channels/src/components/theme_provider/index.ts
+++ b/webapp/channels/src/components/theme_provider/index.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import ThemeProvider from './theme_provider';
+
+export {useUserTheme, WithUserTheme} from './theme_context';
+
+export default ThemeProvider;

--- a/webapp/channels/src/components/theme_provider/theme_context.ts
+++ b/webapp/channels/src/components/theme_provider/theme_context.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useContext, useEffect} from 'react';
+
+export const ThemeContext = React.createContext({
+    startUsingUserTheme: () => {},
+    stopUsingUserTheme: () => {},
+});
+
+/**
+ * useUserTheme makes it so that the app will apply the user's theme instead of the default one for as long as the
+ * calling component remains mounted.
+ */
+export function useUserTheme() {
+    const context = useContext(ThemeContext);
+
+    useEffect(() => {
+        context.startUsingUserTheme();
+
+        return () => {
+            context.stopUsingUserTheme();
+        };
+    }, [context]);
+}
+
+/**
+ * WithUserTheme makes it so that the app will apply the user's theme instead of the default one for as long as it
+ * remains mounted. It's used to wrap multiple routes in the Root component instead of having each of them call
+ * useUserTheme separately.
+ */
+export function WithUserTheme({children}: {children: React.ReactNode}) {
+    useUserTheme();
+
+    return children;
+}

--- a/webapp/channels/src/components/theme_provider/theme_provider.tsx
+++ b/webapp/channels/src/components/theme_provider/theme_provider.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useEffect, useMemo, useState} from 'react';
+import {useSelector} from 'react-redux';
+
+import {Preferences} from 'mattermost-redux/constants';
+import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+
+import {applyTheme} from 'utils/utils';
+
+import type {GlobalState} from 'types/store';
+
+import {ThemeContext} from './theme_context';
+
+export default function ThemeProvider({children}: {children: React.ReactNode}) {
+    // This keeps track of if we're in a themed part of the app. Realistically, it should only ever be 0 (unthemed) or
+    // 1 (themed), but using a counter lets us handle cases where the start/stop functions are called multiple times or
+    // in the wrong order.
+    const [usingUserTheme, setUsingUserTheme] = useState(0);
+
+    const theme = useSelector((state: GlobalState) => {
+        if (usingUserTheme > 0) {
+            return getTheme(state);
+        }
+
+        return Preferences.THEMES.denim;
+    });
+
+    useEffect(() => {
+        applyTheme(theme);
+    }, [theme]);
+
+    const context = useMemo(() => ({
+        startUsingUserTheme: () => setUsingUserTheme((count) => count + 1),
+        stopUsingUserTheme: () => setUsingUserTheme((count) => count - 1),
+    }), []);
+
+    return (
+        <ThemeContext.Provider value={context}>
+            {children}
+        </ThemeContext.Provider>
+    );
+}


### PR DESCRIPTION
## Summary
- cherry-pick: MM-65828 Add ThemeProvider and make app use Denim theme by default (#34755) — 산발적 테마 적용 로직을 중앙집중 ThemeProvider(React Context)로 리팩터. 로그인 전 화면은 고정 Denim 테마, 로그인 후 메인 앱은 사용자 테마 적용 (Upstream: https://github.com/mattermost/mattermost/commit/2f409ba46b42f80efef62a4bcdd88c07db8e5a9d)
- 리브랜드 영향 검토 완료: 우리 config.json의 DefaultTheme이 커스텀 색상 없이 기본값이라 시각적 회귀 없음

## Commits
$(git log master..HEAD --reverse --pretty='- %s')

## Test plan
- [x] webapp: tsc -b (check-types) — 접촉 파일 타입 에러 0건 (무관 파일 44건은 기존 이슈)
- [x] webapp: jest root.test.tsx, emoji_page.test.tsx — 16/16 통과
- [x] webapp: eslint (접촉 파일, linebreak-style 제외) — 위반 0건