### PR TITLE
upstream sync 2026-01-08 (picked 2)

### DIFF
--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -33,8 +33,8 @@ jobs:
       - name: buildenv/docker-login
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
-          username: ${{ secrets.DOCKERHUB_DEV_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_DEV_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: buildenv/build
         uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
@@ -44,16 +44,16 @@ jobs:
           load: true
           push: false
           pull: false
-          tags: mattermostdevelopment/mattermost-build-server:test
+          tags: mattermost/mattermost-build-server:test
 
       - name: buildenv/test
         run: |
-          docker run --rm mattermostdevelopment/mattermost-build-server:test /bin/sh -c "go version && node --version"
+          docker run --rm mattermost/mattermost-build-server:test /bin/sh -c "go version && node --version"
 
       - name: buildenv/calculate-golang-version
         id: go
         run: |
-          GO_VERSION=$(docker run --rm mattermostdevelopment/mattermost-build-server:test go version | awk '{print $3}' | sed 's/go//')
+          GO_VERSION=$(docker run --rm mattermost/mattermost-build-server:test go version | awk '{print $3}' | sed 's/go//')
           echo "GO_VERSION=${GO_VERSION}" >> "${GITHUB_OUTPUT}"
 
       - name: buildenv/push
@@ -65,7 +65,7 @@ jobs:
           load: false
           push: true
           pull: true
-          tags: mattermostdevelopment/mattermost-build-server:${{ steps.go.outputs.GO_VERSION }}
+          tags: mattermost/mattermost-build-server:${{ steps.go.outputs.GO_VERSION }}
 
   build-image-fips:
     runs-on: ubuntu-22.04
@@ -79,8 +79,8 @@ jobs:
       - name: buildenv/docker-login
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
-          username: ${{ secrets.DOCKERHUB_DEV_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_DEV_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: buildenv/build
         uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
@@ -90,16 +90,16 @@ jobs:
           load: true
           push: false
           pull: false
-          tags: mattermostdevelopment/mattermost-build-server-fips:test
+          tags: mattermost/mattermost-build-server-fips:test
 
       - name: buildenv/test
         run: |
-          docker run --rm --entrypoint bash mattermostdevelopment/mattermost-build-server-fips:test -c "go version && node --version"
+          docker run --rm --entrypoint bash mattermost/mattermost-build-server-fips:test -c "go version && node --version"
 
       - name: buildenv/calculate-golang-version
         id: go
         run: |
-          GO_VERSION=$(docker run --rm --entrypoint bash mattermostdevelopment/mattermost-build-server-fips:test -c "go version" | awk '{print $3}' | sed 's/go//')
+          GO_VERSION=$(docker run --rm --entrypoint bash mattermost/mattermost-build-server-fips:test -c "go version" | awk '{print $3}' | sed 's/go//')
           echo "GO_VERSION=${GO_VERSION}" >> "${GITHUB_OUTPUT}"
 
       - name: buildenv/push
@@ -111,4 +111,4 @@ jobs:
           load: false
           push: true
           pull: true
-          tags: mattermostdevelopment/mattermost-build-server-fips:${{ steps.go.outputs.GO_VERSION }}
+          tags: mattermost/mattermost-build-server-fips:${{ steps.go.outputs.GO_VERSION }}

--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -46,7 +46,7 @@ jobs:
             echo "BUILD_IMAGE=mattermost/mattermost-build-server-fips:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}-fips" >> "${GITHUB_OUTPUT}"
           else
-            echo "BUILD_IMAGE=mattermostdevelopment/mattermost-build-server:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
+            echo "BUILD_IMAGE=mattermost/mattermost-build-server:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}" >> "${GITHUB_OUTPUT}"
           fi
 

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -40,7 +40,7 @@ jobs:
     name: Check mocks
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
@@ -57,7 +57,7 @@ jobs:
     name: Check go mod tidy
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
@@ -74,7 +74,7 @@ jobs:
     name: check-style
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
@@ -91,7 +91,7 @@ jobs:
     name: Check serialization methods for hot structs
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
@@ -108,7 +108,7 @@ jobs:
     name: Vet API
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
@@ -123,7 +123,7 @@ jobs:
     name: Check migration files
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
@@ -138,7 +138,7 @@ jobs:
     name: Generate email templates
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
@@ -155,7 +155,7 @@ jobs:
     name: Check store layers
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
@@ -172,7 +172,7 @@ jobs:
     name: Check mmctl docs
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
@@ -271,7 +271,7 @@ jobs:
     name: Build mattermost server app
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -59,7 +59,7 @@ jobs:
             echo "BUILD_IMAGE=mattermost/mattermost-build-server-fips:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}-fips" >> "${GITHUB_OUTPUT}"
           else
-            echo "BUILD_IMAGE=mattermostdevelopment/mattermost-build-server:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
+            echo "BUILD_IMAGE=mattermost/mattermost-build-server:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}" >> "${GITHUB_OUTPUT}"
           fi
 

--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,16 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-07-28 15:23
+- 갱신일: 2026-07-28 15:56
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1179개
+- 남은 커밋: 1177개
 
-**마지막 반영 커밋:** `9e305018` | [updates Dockerfile go version to 1.24.11 to generate new build containers (#34871)](https://github.com/mattermost/mattermost/commit/9e3050188584b602f5ac28f7151a2f0d56484163) | 2026-01-07
+**마지막 반영 커밋:** `0f432a1e` | [fixes registry used for mattermost-build-server image push and pull (#34882)](https://github.com/mattermost/mattermost/commit/0f432a1ee3f1082abdbdc069a79e45d4988df2bc) | 2026-01-08
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 4389116b | [Update latest minor version to 11.4.0 (#34874)](https://github.com/mattermost/mattermost/commit/4389116b19419d702a04b1576a74ccc3dcd5a63e) | 2026-01-08 |
-| 0f432a1e | [fixes registry used for mattermost-build-server image push and pull (#34882)](https://github.com/mattermost/mattermost/commit/0f432a1ee3f1082abdbdc069a79e45d4988df2bc) | 2026-01-08 |
 | 0b0658bd | [chore: upgrade playwright to 1.57 and its dependencies (#34769)](https://github.com/mattermost/mattermost/commit/0b0658bdd04ceaba9d76c76d488f39c992ad9ee8) | 2026-01-09 |
 | e45dd2cc | [Upgraded board version to v9.2.2 (#34884)](https://github.com/mattermost/mattermost/commit/e45dd2ccf322b11b42fef15623e936a29d180464) | 2026-01-09 |
 | 81dc5f88 | [bumps go version to 1.24.11 (#34876)](https://github.com/mattermost/mattermost/commit/81dc5f880186029884d47349f83d8dca7c5d14c2) | 2026-01-09 |

--- a/server/public/model/version.go
+++ b/server/public/model/version.go
@@ -13,6 +13,7 @@ import (
 // It should be maintained in chronological order with most current
 // release at the front of the list.
 var versions = []string{
+	"11.4.0",
 	"11.3.0",
 	"11.2.0",
 	"11.1.0",


### PR DESCRIPTION
- Update latest minor version to 11.4.0 (#34874)
- fixes registry used for mattermost-build-server image push and pull (#34882)

## 처리 내역

- cherry-pick: Update latest minor version to 11.4.0 (#34874)
- cherry-pick: fixes registry used for mattermost-build-server image push and pull (#34882)

## 검증

- server: go build / go vet 통과, golangci-lint 스코프 검사(public/model)에서 신규 이슈 없음
- .github/workflows 변경은 CI 설정 전용(CODEOWNERS 강제 리뷰 대상 아님), 기능 코드 무영향으로 테스트 생략

🤖 Generated with [Claude Code](https://claude.com/claude-code)