### PR TITLE
upstream sync 2026-01-09 (adapted 1)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,15 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-07-29 09:42
+- 갱신일: 2026-07-29 11:31
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1185개
+- 남은 커밋: 1184개
 
-**마지막 반영 커밋:** `81dc5f88` | [bumps go version to 1.24.11 (#34876)](https://github.com/mattermost/mattermost/commit/81dc5f880186029884d47349f83d8dca7c5d14c2) | 2026-01-09
+**마지막 반영 커밋:** `07ba32e8` | [MM-62151 avoid select * for post store (#34709)](https://github.com/mattermost/mattermost/commit/07ba32e849e11238392934888640787f853b3fda) | 2026-01-09
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 07ba32e8 | [MM-62151 avoid select * for post store (#34709)](https://github.com/mattermost/mattermost/commit/07ba32e849e11238392934888640787f853b3fda) | 2026-01-09 |
 | 43bab4d7 | [\[MM-67025\] Add new E2E for testing keyboard shortcut Shift+Up (#34793)](https://github.com/mattermost/mattermost/commit/43bab4d7c76c2bcb3ced334e9546106c970a34e2) | 2026-01-12 |
 | d9123c33 | [MM-67037 Skipping flaky test TestAddChannelMemberNoUserRequestor (#34805)](https://github.com/mattermost/mattermost/commit/d9123c33f16c64a73d53becfcc9669f78f61e78b) | 2026-01-12 |
 | ec3ba68e | [Translations update from Mattermost Weblate (#34906)](https://github.com/mattermost/mattermost/commit/ec3ba68e328e91815e55a9ba166b2051d734a1d2) | 2026-01-12 |

--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -42,9 +42,6 @@ linters:
           - misspell
         path: platform/shared/markdown/html_entities.go
       - linters:
-          - unqueryvet
-        path: channels/store/sqlstore/post_store.go
-      - linters:
           - staticcheck
         text: SA1019
       - linters:

--- a/server/Makefile
+++ b/server/Makefile
@@ -789,7 +789,18 @@ endif
 
 vet: ## Run mattermost go vet specific checks
 	$(GO) install github.com/mattermost/mattermost-govet/v2@7d8db289e508999dfcac47b97c9490a0fec12d66
-	$(GO) vet -vettool=$(GOBIN)/mattermost-govet -structuredLogging -inconsistentReceiverName -emptyStrCmp -tFatal -configtelemetry -errorAssertions -requestCtxNaming -license -inconsistentReceiverName.ignore=session_serial_gen.go,team_member_serial_gen.go,user_serial_gen.go,utils_serial_gen.go ./...
+	$(GO) vet -vettool=$(GOBIN)/mattermost-govet \
+		-structuredLogging \
+		-inconsistentReceiverName \
+		-emptyStrCmp \
+		-tFatal \
+		-configtelemetry \
+		-errorAssertions \
+		-requestCtxNaming \
+		-license \
+		-inconsistentReceiverName.ignore=session_serial_gen.go,team_member_serial_gen.go,user_serial_gen.go,utils_serial_gen.go \
+		-noSelectStar \
+		./...
 ifeq ($(BUILD_ENTERPRISE_READY),true)
   ifneq ($(MM_NO_ENTERPRISE_LINT),true)
 	$(GO) vet -vettool=$(GOBIN)/mattermost-govet -structuredLogging -inconsistentReceiverName -emptyStrCmp -tFatal -configtelemetry -errorAssertions -requestCtxNaming -enterpriseLicense $(BUILD_ENTERPRISE_DIR)/...

--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -24,15 +24,14 @@ import (
 	"github.com/mattermost/mattermost/server/v8/einterfaces"
 )
 
-// Regex to get quoted strings
-var quotedStringsRegex = regexp.MustCompile(`("[^"]*")`)
-var wildCardRegex = regexp.MustCompile(`\*($| )`)
-
 type SqlPostStore struct {
 	*SqlStore
 	metrics           einterfaces.MetricsInterface
 	maxPostSizeOnce   sync.Once
 	maxPostSizeCached int
+
+	// postsQuery is a starting point for queries that return one or more Posts.
+	postsQuery sq.SelectBuilder
 }
 
 type postWithExtra struct {
@@ -138,11 +137,17 @@ func postSliceCoalesceQuery() string {
 }
 
 func newSqlPostStore(sqlStore *SqlStore, metrics einterfaces.MetricsInterface) store.PostStore {
-	return &SqlPostStore{
+	s := &SqlPostStore{
 		SqlStore:          sqlStore,
 		metrics:           metrics,
 		maxPostSizeCached: model.PostMessageMaxRunesV1,
 	}
+
+	s.postsQuery = s.getQueryBuilder().
+		Select(postSliceColumnsWithName("Posts")...).
+		From("Posts")
+
+	return s
 }
 
 func (s *SqlPostStore) SaveMultiple(rctx request.CTX, posts []*model.Post) ([]*model.Post, int, error) {
@@ -238,10 +243,6 @@ func (s *SqlPostStore) SaveMultiple(rctx request.CTX, posts []*model.Post) ([]*m
 	for _, post := range posts {
 		builder = builder.Values(postToSlice(post)...)
 	}
-	query, args, err := builder.ToSql()
-	if err != nil {
-		return nil, -1, errors.Wrap(err, "post_tosql")
-	}
 
 	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
@@ -249,7 +250,7 @@ func (s *SqlPostStore) SaveMultiple(rctx request.CTX, posts []*model.Post) ([]*m
 	}
 	defer finalizeTransactionX(transaction, &err)
 
-	if _, err = transaction.Exec(query, args...); err != nil {
+	if _, err = transaction.ExecBuilder(builder); err != nil {
 		return nil, -1, errors.Wrap(err, "failed to save Post")
 	}
 
@@ -353,12 +354,7 @@ func (s *SqlPostStore) populateReplyCount(posts []*model.Post) error {
 		Where(sq.Eq{"Posts.DeleteAt": 0}).
 		GroupBy("RootId")
 
-	queryString, args, err := query.ToSql()
-	if err != nil {
-		return errors.Wrap(err, "post_tosql")
-	}
-	err = s.GetMaster().Select(&countList, queryString, args...)
-	if err != nil {
+	if err := s.GetMaster().SelectBuilder(&countList, query); err != nil {
 		return errors.Wrap(err, "failed to count Posts")
 	}
 
@@ -435,12 +431,7 @@ func (s *SqlPostStore) Update(rctx request.CTX, newPost *model.Post, oldPost *mo
 		Insert("Posts").
 		Columns(postSliceColumns()...).
 		Values(postToSlice(oldPost)...)
-	query, args, err := builder.ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "post_tosql")
-	}
-	_, err = s.GetMaster().Exec(query, args...)
-	if err != nil {
+	if _, err := s.GetMaster().ExecBuilder(builder); err != nil {
 		return nil, errors.Wrap(err, "failed to insert the old post")
 	}
 
@@ -528,13 +519,16 @@ func (s *SqlPostStore) GetFlaggedPostsForChannel(userId, channelId string, offse
 func (s *SqlPostStore) getFlaggedPosts(userId, channelId, teamId string, offset int, limit int) (*model.PostList, error) {
 	pl := model.NewPostList()
 
+	postColumnsA := strings.Join(postSliceColumnsWithName("A"), ", ")
+	postColumnsPosts := strings.Join(postSliceColumnsWithName("Posts"), ", ")
+
 	posts := []*model.Post{}
 	query := `
             SELECT
-                A.*, (SELECT count(*) FROM Posts WHERE Posts.RootId = (CASE WHEN A.RootId = '' THEN A.Id ELSE A.RootId END) AND Posts.DeleteAt = 0) as ReplyCount
+                ` + postColumnsA + `, (SELECT count(*) FROM Posts WHERE Posts.RootId = (CASE WHEN A.RootId = '' THEN A.Id ELSE A.RootId END) AND Posts.DeleteAt = 0) as ReplyCount
             FROM
                 (SELECT
-                    *
+                    ` + postColumnsPosts + `
                 FROM
                     Posts
                 WHERE
@@ -624,34 +618,26 @@ func (s *SqlPostStore) getPostWithCollapsedThreads(rctx request.CTX, id, userID 
 	)
 	var post postWithExtra
 
-	postFetchQuery, args, err := s.getQueryBuilder().
+	query := s.getQueryBuilder().
 		Select(columns...).
 		From("Posts").
 		LeftJoin("Threads ON Threads.PostId = Id").
 		LeftJoin("ThreadMemberships ON ThreadMemberships.PostId = Id AND ThreadMemberships.UserId = ?", userID).
 		Where(sq.Eq{"Posts.DeleteAt": 0}).
-		Where(sq.Eq{"Posts.Id": id}).ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "getPostWithCollapsedThreads_ToSql2")
-	}
+		Where(sq.Eq{"Posts.Id": id})
 
-	err = s.GetReplica().Get(&post, postFetchQuery, args...)
-	if err != nil {
+	if err := s.GetReplica().GetBuilder(&post, query); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Post", id)
 		}
-
 		return nil, errors.Wrapf(err, "failed to get Post with id=%s", id)
 	}
 
 	posts := []*model.Post{}
-	query := s.getQueryBuilder().
-		Select("*").
-		From("Posts").
-		Where(sq.Eq{
-			"Posts.RootId":   id,
-			"Posts.DeleteAt": 0,
-		})
+	query = s.postsQuery.Where(sq.Eq{
+		"Posts.RootId":   id,
+		"Posts.DeleteAt": 0,
+	})
 
 	var sort string
 	if opts.Direction != "" {
@@ -713,12 +699,7 @@ func (s *SqlPostStore) getPostWithCollapsedThreads(rctx request.CTX, id, userID 
 		query = query.Limit(uint64(opts.PerPage + 1))
 	}
 
-	sql, args, err := query.ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "getPostWithCollapsedThreads_Tosql2")
-	}
-	err = s.GetReplica().Select(&posts, sql, args...)
-	if err != nil {
+	if err := s.GetReplica().SelectBuilder(&posts, query); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Posts for thread %s", id)
 	}
 
@@ -756,7 +737,8 @@ func (s *SqlPostStore) Get(rctx request.CTX, id string, opts model.GetPostsOptio
 		return nil, store.NewErrInvalidInput("Post", "id", id)
 	}
 	var post model.Post
-	postFetchQuery := "SELECT p.*, (SELECT count(*) FROM Posts WHERE Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END) AND Posts.DeleteAt = 0) as ReplyCount FROM Posts p WHERE p.Id = ? AND p.DeleteAt = 0"
+	postColumns := strings.Join(postSliceColumnsWithName("p"), ", ")
+	postFetchQuery := "SELECT " + postColumns + ", (SELECT count(*) FROM Posts WHERE Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END) AND Posts.DeleteAt = 0) as ReplyCount FROM Posts p WHERE p.Id = ? AND p.DeleteAt = 0"
 	err := s.DBXFromContext(rctx.Context()).Get(&post, postFetchQuery, id)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -780,7 +762,8 @@ func (s *SqlPostStore) Get(rctx request.CTX, id string, opts model.GetPostsOptio
 
 		var query sq.SelectBuilder
 		query = s.getQueryBuilder().
-			Select("p.*, replycount.num as ReplyCount").
+			Select(postSliceColumnsWithName("p")...).
+			Column("replycount.num as ReplyCount").
 			PrefixExpr(s.getQueryBuilder().
 				Select().
 				Prefix("WITH replycount as (").
@@ -880,14 +863,8 @@ func (s *SqlPostStore) Get(rctx request.CTX, id string, opts model.GetPostsOptio
 			query = query.Limit(uint64(opts.PerPage + 1))
 		}
 
-		sql, args, err := query.ToSql()
-		if err != nil {
-			return nil, errors.Wrap(err, "Get_Tosql")
-		}
-
 		posts := []*model.Post{}
-		err = s.GetReplica().Select(&posts, sql, args...)
-		if err != nil {
+		if err := s.GetReplica().SelectBuilder(&posts, query); err != nil {
 			return nil, errors.Wrap(err, "failed to find Posts")
 		}
 
@@ -923,33 +900,23 @@ func (s *SqlPostStore) Get(rctx request.CTX, id string, opts model.GetPostsOptio
 }
 
 func (s *SqlPostStore) GetSingle(rctx request.CTX, id string, inclDeleted bool) (*model.Post, error) {
-	query := s.getQueryBuilder().
-		Select("p.*").
-		From("Posts p").
-		Where(sq.Eq{"p.Id": id})
+	query := s.postsQuery.Where(sq.Eq{"Posts.Id": id})
 
 	replyCountSubQuery := s.getQueryBuilder().
 		Select("COUNT(*)").
-		From("Posts").
-		Where(sq.Expr("Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END) AND Posts.DeleteAt = 0"))
+		From("Posts p").
+		Where(sq.Expr("p.RootId = (CASE WHEN Posts.RootId = '' THEN Posts.Id ELSE Posts.RootId END) AND p.DeleteAt = 0"))
 
 	if !inclDeleted {
-		query = query.Where(sq.Eq{"p.DeleteAt": 0})
+		query = query.Where(sq.Eq{"Posts.DeleteAt": 0})
 	}
 	query = query.Column(sq.Alias(replyCountSubQuery, "ReplyCount"))
 
-	queryString, args, err := query.ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "getsingleincldeleted_tosql")
-	}
-
 	var post model.Post
-	err = s.DBXFromContext(rctx.Context()).Get(&post, queryString, args...)
-	if err != nil {
+	if err := s.DBXFromContext(rctx.Context()).GetBuilder(&post, query); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Post", id)
 		}
-
 		return nil, errors.Wrapf(err, "failed to get Post with id=%s", id)
 	}
 	return &post, nil
@@ -1009,7 +976,6 @@ func (s *SqlPostStore) Delete(rctx request.CTX, postID string, time int64, delet
 				UpdateAt = $1,
 				Props = jsonb_set(Props, $2, $3)
 			WHERE Id = $4 OR RootId = $4`, time, jsonKeyPath(model.PostPropsDeleteBy), jsonStringVal(deleteByID), postID)
-
 	if err != nil {
 		return errors.Wrap(err, "failed to update Posts")
 	}
@@ -1321,19 +1287,18 @@ func (s *SqlPostStore) getPostsCollapsedThreads(rctx request.CTX, options model.
 		Where(sq.Eq{"Posts.DeleteAt": 0}).
 		Where(sq.Eq{"Posts.ChannelId": options.ChannelId}).
 		Where(sq.Eq{"Posts.RootId": ""})
-	
+
 	if len(options.FilterUserIds) > 0 {
 		builder = builder.Where(sq.Eq{"Posts.UserId": options.FilterUserIds}).
 			Where(sq.NotLike{"Posts.Type": model.PostSystemMessagePrefix + "%"})
 	}
-	
-	postFetchQuery, args, _ := builder.
+
+	query := builder.
 		Limit(uint64(options.PerPage)).
 		Offset(uint64(offset)).
-		OrderBy("Posts.CreateAt DESC").ToSql()
+		OrderBy("Posts.CreateAt DESC")
 
-	err := s.GetReplica().Select(&posts, postFetchQuery, args...)
-	if err != nil {
+	if err := s.GetReplica().SelectBuilder(&posts, query); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Posts with channelId=%s", options.ChannelId)
 	}
 
@@ -1412,23 +1377,17 @@ func (s *SqlPostStore) getPostsSinceCollapsedThreads(rctx request.CTX, options m
 		Where(sq.Eq{"Posts.ChannelId": options.ChannelId}).
 		Where(sq.Gt{"Posts.UpdateAt": options.Time}).
 		Where(sq.Eq{"Posts.RootId": ""})
-	
+
 	if len(options.FilterUserIds) > 0 {
 		builder = builder.Where(sq.Eq{"Posts.UserId": options.FilterUserIds}).
 			Where(sq.NotLike{"Posts.Type": model.PostSystemMessagePrefix + "%"})
 	}
-	
-	postFetchQuery, args, err := builder.
+
+	query := builder.
 		OrderBy("Posts.CreateAt DESC").
-		Limit(1000).
-		ToSql()
+		Limit(1000)
 
-	if err != nil {
-		return nil, errors.Wrapf(err, "getPostsSinceCollapsedThreads_ToSql")
-	}
-
-	err = s.GetReplica().Select(&posts, postFetchQuery, args...)
-	if err != nil {
+	if err := s.GetReplica().SelectBuilder(&posts, query); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Posts with channelId=%s", options.ChannelId)
 	}
 	return s.prepareThreadedResponse(rctx, posts, options.CollapsedThreadsExtended, false, sanitizeOptions)
@@ -1468,16 +1427,20 @@ func (s *SqlPostStore) GetPostsSince(rctx request.CTX, options model.GetPostsSin
 		userIdFilter = " AND UserId IN (" + strings.Join(placeholders, ",") + ") AND Type NOT LIKE 'system_%'"
 	}
 
+	postColumnsPosts := strings.Join(postSliceColumnsWithName("Posts"), ", ")
+	postColumnsCte := strings.Join(postSliceColumnsWithName("cte"), ", ")
+	postColumnsP1 := strings.Join(postSliceColumnsWithName("p1"), ", ")
+
 	query = `WITH cte AS (SELECT
-	       *
+	       ` + postColumnsPosts + `
 	FROM
 	       Posts
 	WHERE
 	       UpdateAt > ? AND ChannelId = ?` + userIdFilter + `
 	       LIMIT 1000)
-	(SELECT *` + replyCountQuery2 + ` FROM cte)
+	(SELECT ` + postColumnsCte + replyCountQuery2 + ` FROM cte)
 	UNION
-	(SELECT *` + replyCountQuery1 + ` FROM Posts p1 WHERE id in (SELECT rootid FROM cte))
+	(SELECT ` + postColumnsP1 + replyCountQuery1 + ` FROM Posts p1 WHERE id in (SELECT rootid FROM cte))
 	ORDER BY CreateAt ` + order
 	err := s.GetReplica().Select(&posts, query, params...)
 	if err != nil {
@@ -1522,9 +1485,7 @@ func (s *SqlPostStore) HasAutoResponsePostByUserSince(options model.GetPostsSinc
 }
 
 func (s *SqlPostStore) GetPostsSinceForSync(options model.GetPostsSinceForSyncOptions, cursor model.GetPostsSinceForSyncCursor, limit int) ([]*model.Post, model.GetPostsSinceForSyncCursor, error) {
-	query := s.getQueryBuilder().
-		Select("*").
-		From("Posts").
+	query := s.postsQuery.
 		OrderBy("Posts.UpdateAt", "Id").
 		Limit(uint64(limit))
 
@@ -1537,8 +1498,10 @@ func (s *SqlPostStore) GetPostsSinceForSync(options model.GetPostsSinceForSyncOp
 			},
 		})
 	} else {
-		query = query.Where(sq.Or{sq.Gt{"Posts.UpdateAt": cursor.LastPostUpdateAt},
-			sq.And{sq.Eq{"Posts.UpdateAt": cursor.LastPostUpdateAt}, sq.Gt{"Posts.Id": cursor.LastPostUpdateID}}})
+		query = query.Where(sq.Or{
+			sq.Gt{"Posts.UpdateAt": cursor.LastPostUpdateAt},
+			sq.And{sq.Eq{"Posts.UpdateAt": cursor.LastPostUpdateAt}, sq.Gt{"Posts.Id": cursor.LastPostUpdateID}},
+		})
 	}
 
 	if options.ChannelId != "" {
@@ -1561,14 +1524,8 @@ func (s *SqlPostStore) GetPostsSinceForSync(options model.GetPostsSinceForSyncOp
 		}})
 	}
 
-	queryString, args, err := query.ToSql()
-	if err != nil {
-		return nil, cursor, errors.Wrap(err, "getpostssinceforsync_tosql")
-	}
-
 	posts := []*model.Post{}
-	err = s.GetReplica().Select(&posts, queryString, args...)
-	if err != nil {
+	if err := s.GetReplica().SelectBuilder(&posts, query); err != nil {
 		return nil, cursor, errors.Wrapf(err, "error getting Posts with channelId=%s", options.ChannelId)
 	}
 
@@ -1610,9 +1567,7 @@ func (s *SqlPostStore) GetPostsForReporting(rctx request.CTX, queryParams model.
 	}
 
 	// Build base query - request one extra to determine if there are more pages
-	query := s.getQueryBuilder().
-		Select(postSliceColumns()...).
-		From("Posts").
+	query := s.postsQuery.
 		Where(sq.Eq{"ChannelId": queryParams.ChannelId}).
 		OrderBy(fmt.Sprintf("%s %s", timeField, sortDirection), fmt.Sprintf("Id %s", sortDirection)).
 		Limit(uint64(queryParams.PerPage + 1))
@@ -1695,9 +1650,7 @@ func (s *SqlPostStore) GetPostsForReporting(rctx request.CTX, queryParams model.
 }
 
 func (s *SqlPostStore) GetPostsByThread(threadId string, since int64) ([]*model.Post, error) {
-	query := s.getQueryBuilder().
-		Select("*").
-		From("Posts").
+	query := s.postsQuery.
 		Where(sq.Eq{"RootId": threadId}).
 		Where(sq.Eq{"DeleteAt": 0}).
 		Where(sq.GtOrEq{"CreateAt": since})
@@ -1733,7 +1686,7 @@ func (s *SqlPostStore) getPostsAround(rctx request.CTX, before bool, options mod
 		direction = ">"
 		sort = "ASC"
 	}
-	columns := []string{"p.*"}
+	columns := postSliceColumnsWithName("p")
 	if options.CollapsedThreads {
 		columns = append(columns,
 			"COALESCE(Threads.ReplyCount, 0) as ThreadReplyCount",
@@ -1775,12 +1728,7 @@ func (s *SqlPostStore) getPostsAround(rctx request.CTX, before bool, options mod
 		Limit(uint64(options.PerPage)).
 		Offset(uint64(offset))
 
-	queryString, args, err := query.ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "post_tosql")
-	}
-	err = s.GetReplica().Select(&posts, queryString, args...)
-	if err != nil {
+	if err := s.GetReplica().SelectBuilder(&posts, query); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Posts with channelId=%s", options.ChannelId)
 	}
 
@@ -1792,7 +1740,7 @@ func (s *SqlPostStore) getPostsAround(rctx request.CTX, before bool, options mod
 				rootIds = append(rootIds, post.RootId)
 			}
 		}
-		rootQuery := s.getQueryBuilder().Select("p.*")
+		rootQuery := s.getQueryBuilder().Select(postSliceColumnsWithName("p")...)
 		idQuery := sq.Or{
 			sq.Eq{"Id": rootIds},
 		}
@@ -1812,14 +1760,8 @@ func (s *SqlPostStore) getPostsAround(rctx request.CTX, before bool, options mod
 			rootQuery = rootQuery.Where(sq.Eq{"p.DeleteAt": 0})
 		}
 
-		rootQueryString, rootArgs, nErr := rootQuery.ToSql()
-
-		if nErr != nil {
-			return nil, errors.Wrap(nErr, "post_tosql")
-		}
-		nErr = s.GetReplica().Select(&parents, rootQueryString, rootArgs...)
-		if nErr != nil {
-			return nil, errors.Wrapf(nErr, "failed to find Posts with channelId=%s", options.ChannelId)
+		if err := s.GetReplica().SelectBuilder(&parents, rootQuery); err != nil {
+			return nil, errors.Wrapf(err, "failed to find Posts with channelId=%s", options.ChannelId)
 		}
 	}
 
@@ -1872,13 +1814,8 @@ func (s *SqlPostStore) getPostIdAroundTime(channelId string, time int64, before 
 		OrderBy("Posts.ChannelId", "Posts.DeleteAt", "Posts.CreateAt "+sort).
 		Limit(1)
 
-	queryString, args, err := query.ToSql()
-	if err != nil {
-		return "", errors.Wrap(err, "post_tosql")
-	}
-
 	var postId string
-	if err := s.GetMaster().Get(&postId, queryString, args...); err != nil {
+	if err := s.GetMaster().GetBuilder(&postId, query); err != nil {
 		if err != sql.ErrNoRows {
 			return "", errors.Wrapf(err, "failed to get Post id with channelId=%s", channelId)
 		}
@@ -1896,9 +1833,7 @@ func (s *SqlPostStore) GetPostAfterTime(channelId string, time int64, collapsedT
 	if collapsedThreads {
 		conditions = sq.And{conditions, sq.Eq{"RootId": ""}}
 	}
-	query := s.getQueryBuilder().
-		Select("*").
-		From("Posts").
+	query := s.postsQuery.
 		Where(conditions).
 		// Adding ChannelId and DeleteAt order columns
 		// to let mysql choose the "idx_posts_channel_id_delete_at_create_at" index always.
@@ -1906,13 +1841,8 @@ func (s *SqlPostStore) GetPostAfterTime(channelId string, time int64, collapsedT
 		OrderBy("Posts.ChannelId", "Posts.DeleteAt", "Posts.CreateAt ASC").
 		Limit(1)
 
-	queryString, args, err := query.ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "post_tosql")
-	}
-
 	var post model.Post
-	if err := s.GetMaster().Get(&post, queryString, args...); err != nil {
+	if err := s.GetMaster().GetBuilder(&post, query); err != nil {
 		if err != sql.ErrNoRows {
 			return nil, errors.Wrapf(err, "failed to get Post with channelId=%s", channelId)
 		}
@@ -1926,7 +1856,7 @@ func (s *SqlPostStore) getRootPosts(channelId string, offset int, limit int, ski
 	var fetchQuery string
 	userIdCondition := ""
 	params := []any{channelId}
-	
+
 	if len(filterUserIds) > 0 {
 		placeholders := make([]string, len(filterUserIds))
 		for i := range filterUserIds {
@@ -1935,19 +1865,22 @@ func (s *SqlPostStore) getRootPosts(channelId string, offset int, limit int, ski
 		}
 		userIdCondition = " AND p.UserId IN (" + strings.Join(placeholders, ",") + ") AND p.Type NOT LIKE 'system_%'"
 	}
-	
+
+	postColumnsP := strings.Join(postSliceColumnsWithName("p"), ", ")
+	postColumnsPosts := strings.Join(postSliceColumnsWithName("Posts"), ", ")
+
 	if skipFetchThreads {
-		fetchQuery = "SELECT p.*, (SELECT COUNT(*) FROM Posts WHERE Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END)) as ReplyCount FROM Posts p WHERE p.ChannelId = ?" + userIdCondition + " ORDER BY p.CreateAt DESC LIMIT ? OFFSET ?"
+		fetchQuery = "SELECT " + postColumnsP + ", (SELECT COUNT(*) FROM Posts WHERE Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END)) as ReplyCount FROM Posts p WHERE p.ChannelId = ?" + userIdCondition + " ORDER BY p.CreateAt DESC LIMIT ? OFFSET ?"
 		if !includeDeleted {
-			fetchQuery = "SELECT p.*, (SELECT COUNT(*) FROM Posts WHERE Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END) AND Posts.DeleteAt = 0) as ReplyCount FROM Posts p WHERE p.ChannelId = ? AND p.DeleteAt = 0" + userIdCondition + " ORDER BY p.CreateAt DESC LIMIT ? OFFSET ?"
+			fetchQuery = "SELECT " + postColumnsP + ", (SELECT COUNT(*) FROM Posts WHERE Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END) AND Posts.DeleteAt = 0) as ReplyCount FROM Posts p WHERE p.ChannelId = ? AND p.DeleteAt = 0" + userIdCondition + " ORDER BY p.CreateAt DESC LIMIT ? OFFSET ?"
 		}
 	} else {
-		fetchQuery = "SELECT * FROM Posts WHERE Posts.ChannelId = ?" + userIdCondition + " ORDER BY Posts.CreateAt DESC LIMIT ? OFFSET ?"
+		fetchQuery = "SELECT " + postColumnsPosts + " FROM Posts WHERE Posts.ChannelId = ?" + userIdCondition + " ORDER BY Posts.CreateAt DESC LIMIT ? OFFSET ?"
 		if !includeDeleted {
-			fetchQuery = "SELECT * FROM Posts WHERE Posts.ChannelId = ? AND Posts.DeleteAt = 0" + userIdCondition + " ORDER BY Posts.CreateAt DESC LIMIT ? OFFSET ?"
+			fetchQuery = "SELECT " + postColumnsPosts + " FROM Posts WHERE Posts.ChannelId = ? AND Posts.DeleteAt = 0" + userIdCondition + " ORDER BY Posts.CreateAt DESC LIMIT ? OFFSET ?"
 		}
 	}
-	
+
 	params = append(params, limit, offset)
 	err := s.GetReplica().Select(&posts, fetchQuery, params...)
 	if err != nil {
@@ -2002,7 +1935,7 @@ func (s *SqlPostStore) getParentsPosts(channelId string, offset int, limit int, 
 		return nil, nil
 	}
 
-	cols := []string{"p.*"}
+	cols := postSliceColumnsWithName("p")
 	var where sq.Sqlizer
 	where = sq.Eq{"p.Id": roots}
 	if skipFetchThreads {
@@ -2037,14 +1970,8 @@ func (s *SqlPostStore) getParentsPosts(channelId string, offset int, limit int, 
 		query = query.Where(sq.Eq{"p.DeleteAt": 0})
 	}
 
-	sql, args, err := query.ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "ParentPosts_Tosql")
-	}
-
 	posts := []*model.Post{}
-	err = s.GetReplica().Select(&posts, sql, args...)
-	if err != nil {
+	if err := s.GetReplica().SelectBuilder(&posts, query); err != nil {
 		return nil, errors.Wrap(err, "failed to find Posts")
 	}
 	return posts, nil
@@ -2091,8 +2018,10 @@ func (s *SqlPostStore) getParentsPostsPostgreSQL(channelId string, offset int, l
 	
 	params = append(params, limit, offset, channelId)
 
+	postColumnsQ2 := strings.Join(postSliceColumnsWithName("q2"), ", ")
+
 	err := s.GetReplica().Select(&posts,
-		`SELECT q2.*`+replyCountQuery+`
+		`SELECT `+postColumnsQ2+replyCountQuery+`
         FROM
             Posts q2
                 INNER JOIN
@@ -2124,7 +2053,7 @@ func (s *SqlPostStore) GetNthRecentPostTime(n int64) (int64, error) {
 		return 0, errors.New("n can't be less than 1")
 	}
 
-	builder := s.getQueryBuilder().
+	query := s.getQueryBuilder().
 		Select("CreateAt").
 		From("Posts p").
 		// Consider users posts only for cloud limit
@@ -2136,17 +2065,11 @@ func (s *SqlPostStore) GetNthRecentPostTime(n int64) (int64, error) {
 		Limit(1).
 		Offset(uint64(n - 1))
 
-	query, queryArgs, err := builder.ToSql()
-	if err != nil {
-		return 0, errors.Wrap(err, "GetNthRecentPostTime_tosql")
-	}
-
 	var createAt int64
-	if err := s.GetMaster().Get(&createAt, query, queryArgs...); err != nil {
+	if err := s.GetMaster().GetBuilder(&createAt, query); err != nil {
 		if err == sql.ErrNoRows {
 			return 0, store.NewErrNotFound("Post", "none")
 		}
-
 		return 0, errors.Wrapf(err, "failed to get the Nth Post=%d", n)
 	}
 
@@ -2285,7 +2208,8 @@ func (s *SqlPostStore) search(teamId string, userId string, params *model.Search
 	}
 
 	baseQuery := s.getQueryBuilder().Select(
-		"*",
+		postSliceColumnsWithName("q2")...,
+	).Column(
 		"(SELECT COUNT(*) FROM Posts WHERE Posts.RootId = (CASE WHEN q2.RootId = '' THEN q2.Id ELSE q2.RootId END) AND Posts.DeleteAt = 0) as ReplyCount",
 	).From("Posts q2").
 		Where("q2.DeleteAt = 0").
@@ -2385,14 +2309,9 @@ func (s *SqlPostStore) search(teamId string, userId string, params *model.Search
 
 	baseQuery = baseQuery.Where(fmt.Sprintf("ChannelId IN (%s)", inQueryClause), inQueryClauseArgs...)
 
-	searchQuery, searchQueryArgs, err := baseQuery.ToSql()
-	if err != nil {
-		return nil, err
-	}
-
 	var posts []*model.Post
 
-	if err := s.GetSearchReplicaX().Select(&posts, searchQuery, searchQueryArgs...); err != nil {
+	if err := s.GetSearchReplicaX().SelectBuilder(&posts, baseQuery); err != nil {
 		mlog.Warn("Query error searching posts.", mlog.String("error", trimInput(err.Error())))
 		// Don't return the error to the caller as it is of no use to the user. Instead return an empty set of search results.
 	} else {
@@ -2424,8 +2343,7 @@ func (s *SqlPostStore) search(teamId string, userId string, params *model.Search
 // TODO: convert to squirrel HW
 func (s *SqlPostStore) AnalyticsUserCountsWithPostsByDay(teamId string) (model.AnalyticsRows, error) {
 	var args []any
-	query :=
-		`SELECT DISTINCT
+	query := `SELECT DISTINCT
 		        DATE(FROM_UNIXTIME(Posts.CreateAt / 1000)) AS Name,
 		        COUNT(DISTINCT Posts.UserId) AS Value
 		FROM Posts`
@@ -2443,8 +2361,7 @@ func (s *SqlPostStore) AnalyticsUserCountsWithPostsByDay(teamId string) (model.A
 		LIMIT 30`
 
 	if s.DriverName() == model.DatabaseDriverPostgres {
-		query =
-			`SELECT
+		query = `SELECT
 				TO_CHAR(DATE(TO_TIMESTAMP(Posts.CreateAt / 1000)), 'YYYY-MM-DD') AS Name, COUNT(DISTINCT Posts.UserId) AS Value
 			FROM Posts`
 
@@ -2550,8 +2467,7 @@ func (s *SqlPostStore) AnalyticsPostCountsByDay(options *model.AnalyticsPostCoun
 	}
 
 	var args []any
-	query :=
-		`SELECT
+	query := `SELECT
 		        DATE(FROM_UNIXTIME(Posts.CreateAt / 1000)) AS Name,
 		        COUNT(Posts.Id) AS Value
 		    FROM Posts`
@@ -2665,14 +2581,15 @@ func (s *SqlPostStore) AnalyticsPostCount(options *model.PostCountOptions) (int6
 	var v int64
 	err := s.GetReplica().GetBuilder(&v, query)
 	if err != nil {
-		return 0, fmt.Errorf("post_tosql failed or failed to count Posts: %w", err)
+		return 0, fmt.Errorf("failed to count Posts: %w", err)
 	}
 
 	return v, nil
 }
 
 func (s *SqlPostStore) GetPostsCreatedAt(channelId string, time int64) ([]*model.Post, error) {
-	query := `SELECT * FROM Posts WHERE CreateAt = ? AND ChannelId = ?`
+	postColumns := strings.Join(postSliceColumns(), ", ")
+	query := "SELECT " + postColumns + " FROM Posts WHERE CreateAt = ? AND ChannelId = ?"
 
 	posts := []*model.Post{}
 	err := s.GetReplica().Select(&posts, query, time, channelId)
@@ -2683,19 +2600,15 @@ func (s *SqlPostStore) GetPostsCreatedAt(channelId string, time int64) ([]*model
 }
 
 func (s *SqlPostStore) GetPostsByIds(postIds []string) ([]*model.Post, error) {
-	baseQuery := s.getQueryBuilder().Select("p.*, (SELECT count(*) FROM Posts WHERE Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END) AND Posts.DeleteAt = 0) as ReplyCount").
+	query := s.getQueryBuilder().
+		Select(postSliceColumnsWithName("p")...).
+		Column("(SELECT count(*) FROM Posts WHERE Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END) AND Posts.DeleteAt = 0) as ReplyCount").
 		From("Posts p").
 		Where(sq.Eq{"p.Id": postIds}).
 		OrderBy("CreateAt DESC")
 
-	query, args, err := baseQuery.ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "getPostsByIds_tosql")
-	}
 	posts := []*model.Post{}
-
-	err = s.GetReplica().Select(&posts, query, args...)
-	if err != nil {
+	if err := s.GetReplica().SelectBuilder(&posts, query); err != nil {
 		return nil, errors.Wrap(err, "failed to find Posts")
 	}
 	if len(posts) == 0 {
@@ -2705,23 +2618,12 @@ func (s *SqlPostStore) GetPostsByIds(postIds []string) ([]*model.Post, error) {
 }
 
 func (s *SqlPostStore) GetEditHistoryForPost(postId string) ([]*model.Post, error) {
-	builder := s.getQueryBuilder().
-		Select("*").
-		From("Posts").
+	query := s.postsQuery.
 		Where(sq.Eq{"Posts.OriginalId": postId}).
 		OrderBy("Posts.EditAt DESC")
 
-	queryString, args, err := builder.ToSql()
-	if err != nil {
-		if err == sql.ErrNoRows {
-			return nil, store.NewErrNotFound("Post", postId)
-		}
-		return nil, errors.Wrap(err, "failed to find post history")
-	}
-
 	posts := []*model.Post{}
-	err = s.GetReplica().Select(&posts, queryString, args...)
-	if err != nil {
+	if err := s.GetReplica().SelectBuilder(&posts, query); err != nil {
 		return nil, errors.Wrapf(err, "error getting posts edit history with postId=%s", postId)
 	}
 
@@ -2743,8 +2645,9 @@ func (s *SqlPostStore) GetPostsBatchForIndexing(startTime int64, startPostID str
 	// More information in: https://github.com/mattermost/mattermost/pull/26517
 	// and https://community.mattermost.com/core/pl/ui5dz96shinetb8nq83myggbma
 
+	postColumnsPosts := strings.Join(postSliceColumnsWithName("Posts"), ", ")
 	query := `SELECT
-				Posts.*, Channels.TeamId
+				` + postColumnsPosts + `, Channels.TeamId
 			FROM Posts
 			LEFT JOIN
 				Channels
@@ -2816,7 +2719,9 @@ func (s *SqlPostStore) PermanentDeleteBatch(endTime int64, limit int64) (int64, 
 
 func (s *SqlPostStore) GetOldest() (*model.Post, error) {
 	var post model.Post
-	err := s.GetReplica().Get(&post, "SELECT * FROM Posts ORDER BY CreateAt LIMIT 1")
+	postColumns := strings.Join(postSliceColumns(), ", ")
+	query := "SELECT " + postColumns + " FROM Posts ORDER BY CreateAt LIMIT 1"
+	err := s.GetReplica().Get(&post, query)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Post", "none")
@@ -2900,9 +2805,9 @@ func (s *SqlPostStore) GetParentsForExportAfter(limit int, afterId string, inclu
 		aggFn := "COALESCE(json_agg(u1.username) FILTER (WHERE u1.username IS NOT NULL), '[]')"
 		result := []*model.PostForExport{}
 
-		builder := s.getQueryBuilder().
+		query := s.getQueryBuilder().
 			Select(fmt.Sprintf("%s, Users.Username as Username, Teams.Name as TeamName, Channels.Name as ChannelName, %s as FlaggedBy", strings.Join(postSliceColumnsWithName("p1"), ", "), aggFn)).
-			FromSelect(sq.Select("*").From("Posts").Where(sq.Eq{"Posts.Id": rootIds}), "p1").
+			FromSelect(sq.Select(postSliceColumnsWithName("Posts")...).From("Posts").Where(sq.Eq{"Posts.Id": rootIds}), "p1").
 			LeftJoin("Preferences ON p1.Id = Preferences.Name").
 			LeftJoin("Users u1 ON Preferences.UserId = u1.Id").
 			InnerJoin("Channels ON p1.ChannelId = Channels.Id").
@@ -2912,13 +2817,7 @@ func (s *SqlPostStore) GetParentsForExportAfter(limit int, afterId string, inclu
 			GroupBy(fmt.Sprintf("%s, Users.Username, Teams.Name, Channels.Name", strings.Join(postSliceColumnsWithName("p1"), ", "))).
 			OrderBy("p1.Id")
 
-		query, args, err := builder.ToSql()
-		if err != nil {
-			return nil, errors.Wrap(err, "postsForExport_toSql")
-		}
-
-		err = s.GetSearchReplicaX().Select(&result, query, args...)
-		if err != nil {
+		if err := s.GetSearchReplicaX().SelectBuilder(&result, query); err != nil {
 			return nil, errors.Wrap(err, "failed to find Posts")
 		}
 
@@ -2937,8 +2836,9 @@ func (s *SqlPostStore) GetRepliesForExport(rootId string) ([]*model.ReplyForExpo
 	aggFn := "COALESCE(json_agg(u1.username) FILTER (WHERE u1.username IS NOT NULL), '[]')"
 	result := []*model.ReplyForExport{}
 
-	qb := s.getQueryBuilder().Select(fmt.Sprintf("Posts.*, u2.Username as Username, %s as FlaggedBy", aggFn)).
-		From("Posts").
+	query := s.postsQuery.
+		Column("u2.Username as Username").
+		Column(fmt.Sprintf("%s as FlaggedBy", aggFn)).
 		LeftJoin("Preferences ON Posts.Id = Preferences.Name").
 		LeftJoin("Users u1 ON Preferences.UserId = u1.Id").
 		InnerJoin("Users u2 ON Posts.UserId = u2.Id").
@@ -2946,13 +2846,7 @@ func (s *SqlPostStore) GetRepliesForExport(rootId string) ([]*model.ReplyForExpo
 		GroupBy("Posts.Id, u2.Username").
 		OrderBy("Posts.Id")
 
-	query, args, err := qb.ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "postsForExport_toSql")
-	}
-
-	err = s.GetSearchReplicaX().Select(&result, query, args...)
-	if err != nil {
+	if err := s.GetSearchReplicaX().SelectBuilder(&result, query); err != nil {
 		return nil, errors.Wrap(err, "failed to find Posts")
 	}
 
@@ -2964,7 +2858,9 @@ func (s *SqlPostStore) GetDirectPostParentsForExportAfter(limit int, afterId str
 	result := []*model.DirectPostForExport{}
 
 	query := s.getQueryBuilder().
-		Select(fmt.Sprintf("p.*, u2.Username as User, %s as FlaggedBy", aggFn)).
+		Select(postSliceColumnsWithName("p")...).
+		Column("u2.Username as User").
+		Column(fmt.Sprintf("%s as FlaggedBy", aggFn)).
 		From("Posts p").
 		LeftJoin("Preferences ON p.Id = Preferences.Name").
 		LeftJoin("Users u1 ON Preferences.UserId = u1.Id").
@@ -2986,13 +2882,8 @@ func (s *SqlPostStore) GetDirectPostParentsForExportAfter(limit int, afterId str
 		)
 	}
 
-	queryString, args, err := query.ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "post_tosql")
-	}
-
-	if err2 := s.GetReplica().Select(&result, queryString, args...); err2 != nil {
-		return nil, errors.Wrap(err2, "failed to find Posts")
+	if err := s.GetReplica().SelectBuilder(&result, query); err != nil {
+		return nil, errors.Wrap(err, "failed to find Posts")
 	}
 	var channelIds []string
 	for _, p := range result {
@@ -3006,13 +2897,8 @@ func (s *SqlPostStore) GetDirectPostParentsForExportAfter(limit int, afterId str
 			"cm.ChannelId": channelIds,
 		})
 
-	queryString, args, err = query.ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "post_tosql")
-	}
-
 	channelMembers := []*model.ChannelMemberForExport{}
-	if err = s.GetReplica().Select(&channelMembers, queryString, args...); err != nil {
+	if err := s.GetReplica().SelectBuilder(&channelMembers, query); err != nil {
 		return nil, errors.Wrap(err, "failed to find ChannelMembers")
 	}
 
@@ -3093,7 +2979,8 @@ func (s *SqlPostStore) SearchRecentMentions(rctx request.CTX, userID string, men
 	offset := page * perPage
 
 	baseQuery := s.getQueryBuilder().Select(
-		"p.*",
+		postSliceColumnsWithName("p")...,
+	).Column(
 		"(SELECT COUNT(*) FROM Posts WHERE Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END) AND Posts.DeleteAt = 0) as ReplyCount",
 	).From("Posts p").
 		Join("ChannelMembers cm ON cm.ChannelId = p.ChannelId AND cm.UserId = ?", userID).
@@ -3143,14 +3030,9 @@ func (s *SqlPostStore) GetOldestEntityCreationTime() (int64, error) {
 					UNION
 					(SELECT MIN(createat) min_createat FROM Channels)
 				) entities`)
-	queryString, args, err := query.ToSql()
-	if err != nil {
-		return -1, errors.Wrap(err, "post_tosql")
-	}
 
 	var oldest int64
-	err = s.GetReplica().Get(&oldest, queryString, args...)
-	if err != nil {
+	if err := s.GetReplica().GetBuilder(&oldest, query); err != nil {
 		return -1, errors.Wrap(err, "unable to scan oldest entity creation time")
 	}
 	return oldest, nil
@@ -3217,17 +3099,12 @@ func (s *SqlPostStore) permanentDeleteTemporaryPosts(transaction *sqlxTxWrapper,
 
 // deleteThread marks a thread as deleted at the given time.
 func (s *SqlPostStore) deleteThread(transaction *sqlxTxWrapper, postId string, deleteAtTime int64) error {
-	queryString, args, err := s.getQueryBuilder().
+	query := s.getQueryBuilder().
 		Update("Threads").
 		Set("ThreadDeleteAt", deleteAtTime).
-		Where(sq.Eq{"PostId": postId}).
-		ToSql()
-	if err != nil {
-		return errors.Wrapf(err, "failed to create SQL query to mark thread for root post %s as deleted", postId)
-	}
+		Where(sq.Eq{"PostId": postId})
 
-	_, err = transaction.Exec(queryString, args...)
-	if err != nil {
+	if _, err := transaction.ExecBuilder(query); err != nil {
 		return errors.Wrapf(err, "failed to mark thread for root post %s as deleted", postId)
 	}
 
@@ -3262,24 +3139,17 @@ func (s *SqlPostStore) deleteThreadFiles(transaction *sqlxTxWrapper, postID stri
 // list as necessary.
 func (s *SqlPostStore) updateThreadAfterReplyDeletion(transaction *sqlxTxWrapper, rootId string, userId string) error {
 	if rootId != "" {
-		queryString, args, err := s.getQueryBuilder().
+		query := s.getQueryBuilder().
 			Select("COUNT(Posts.Id)").
 			From("Posts").
 			Where(sq.And{
 				sq.Eq{"Posts.RootId": rootId},
 				sq.Eq{"Posts.UserId": userId},
 				sq.Eq{"Posts.DeleteAt": 0},
-			}).
-			ToSql()
-
-		if err != nil {
-			return errors.Wrap(err, "failed to create SQL query to count user's posts")
-		}
+			})
 
 		var count int64
-		err = transaction.Get(&count, queryString, args...)
-
-		if err != nil {
+		if err := transaction.GetBuilder(&count, query); err != nil {
 			return errors.Wrap(err, "failed to count user's posts in thread")
 		}
 
@@ -3311,22 +3181,15 @@ func (s *SqlPostStore) updateThreadAfterReplyDeletion(transaction *sqlxTxWrapper
 				"DeleteAt": 0,
 			})
 
-		updateQueryString, updateArgs, err := updateQuery.
+		updateQuery = updateQuery.
 			Set("LastReplyAt", lastReplyAtSubquery).
 			Set("ReplyCount", lastReplyCountSubquery).
 			Where(sq.And{
 				sq.Eq{"PostId": rootId},
 				sq.Gt{"ReplyCount": 0},
-			}).
-			ToSql()
+			})
 
-		if err != nil {
-			return errors.Wrap(err, "failed to create SQL query to update thread")
-		}
-
-		_, err = transaction.Exec(updateQueryString, updateArgs...)
-
-		if err != nil {
+		if _, err := transaction.ExecBuilder(updateQuery); err != nil {
 			return errors.Wrap(err, "failed to update Threads")
 		}
 	}
@@ -3379,7 +3242,7 @@ func (s *SqlPostStore) updateThreadsFromPosts(transaction *sqlxTxWrapper, posts 
 	if len(rootIds) == 0 {
 		return nil
 	}
-	threadsByRootsSql, threadsByRootsArgs, err := s.getQueryBuilder().
+	query := s.getQueryBuilder().
 		Select(
 			"Threads.PostId",
 			"Threads.ChannelId",
@@ -3389,15 +3252,10 @@ func (s *SqlPostStore) updateThreadsFromPosts(transaction *sqlxTxWrapper, posts 
 			"COALESCE(Threads.ThreadDeleteAt, 0) AS DeleteAt",
 		).
 		From("Threads").
-		Where(sq.Eq{"Threads.PostId": rootIds}).
-		ToSql()
-	if err != nil {
-		return errors.Wrap(err, "updateThreadsFromPosts_ToSql")
-	}
+		Where(sq.Eq{"Threads.PostId": rootIds})
 
 	threadsByRoots := []*model.Thread{}
-	err = transaction.Select(&threadsByRoots, threadsByRootsSql, threadsByRootsArgs...)
-	if err != nil {
+	if err := transaction.SelectBuilder(&threadsByRoots, query); err != nil {
 		return err
 	}
 
@@ -3512,14 +3370,10 @@ func (s *SqlPostStore) SetPostReminder(reminder *model.PostReminder) error {
 		Values(reminder.PostId, reminder.UserId, reminder.TargetTime).
 		SuffixExpr(sq.Expr("ON CONFLICT (postid, userid) DO UPDATE SET TargetTime = ?", reminder.TargetTime))
 
-	sql, args, err := query.ToSql()
-	if err != nil {
-		return errors.Wrap(err, "setPostReminder_tosql")
+	if _, err := transaction.ExecBuilder(query); err != nil {
+		return errors.Wrap(err, "failed to insert post reminder")
 	}
-	if _, err2 := transaction.Exec(sql, args...); err2 != nil {
-		return errors.Wrap(err2, "failed to insert post reminder")
-	}
-	if err = transaction.Commit(); err != nil {
+	if err := transaction.Commit(); err != nil {
 		return errors.Wrap(err, "commit_transaction")
 	}
 	return nil

--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -49,45 +49,58 @@ func (us *SqlUserStore) ClearCaches() {}
 
 func (us SqlUserStore) InvalidateProfileCacheForUser(userId string) {}
 
-// getUsersColumns exposes the set of columns that can be queried from the
-// Users table (and not the Bots table).
+// getUsersColumnsWithName returns the user columns prefixed with the given name,
+// with any extra columns appended.
 //
+// Note that the order of these columns must match the order in
+// [SqlUserStore.Get] and [SqlUserStore.GetAllProfilesInChannel].
+func getUsersColumnsWithName(name string, extraColumns ...string) []string {
+	columns := []string{
+		"Id",
+		"CreateAt",
+		"UpdateAt",
+		"DeleteAt",
+		"Username",
+		"Password",
+		"AuthData",
+		"AuthService",
+		"Email",
+		"EmailVerified",
+		"Nickname",
+		"FirstName",
+		"LastName",
+		"Position",
+		"Roles",
+		"AllowMarketing",
+		"Props",
+		"NotifyProps",
+		"LastPasswordUpdate",
+		"LastPictureUpdate",
+		"FailedAttempts",
+		"Locale",
+		"Timezone",
+		"MfaActive",
+		"MfaSecret",
+		"MfaUsedTimestamps",
+		"RemoteId",
+		"LastLogin",
+	}
+	columns = append(columns, extraColumns...)
+	result := make([]string, len(columns))
+	for i, col := range columns {
+		result[i] = name + "." + col
+	}
+	return result
+}
+
+// getUsersColumns returns the user columns for the Users table.
 // This is primarily useful for other stores who choose to directly query
 // and return [model.User] data.
 //
 // Note that the order of these columns must match the order in
 // [SqlUserStore.Get] and [SqlUserStore.GetAllProfilesInChannel].
 func getUsersColumns() []string {
-	return []string{
-		"Users.Id",
-		"Users.CreateAt",
-		"Users.UpdateAt",
-		"Users.DeleteAt",
-		"Users.Username",
-		"Users.Password",
-		"Users.AuthData",
-		"Users.AuthService",
-		"Users.Email",
-		"Users.EmailVerified",
-		"Users.Nickname",
-		"Users.FirstName",
-		"Users.LastName",
-		"Users.Position",
-		"Users.Roles",
-		"Users.AllowMarketing",
-		"Users.Props",
-		"Users.NotifyProps",
-		"Users.LastPasswordUpdate",
-		"Users.LastPictureUpdate",
-		"Users.FailedAttempts",
-		"Users.Locale",
-		"Users.Timezone",
-		"Users.MfaActive",
-		"Users.MfaSecret",
-		"Users.MfaUsedTimestamps",
-		"Users.RemoteId",
-		"Users.LastLogin",
-	}
+	return getUsersColumnsWithName("Users")
 }
 
 func getBotInfoColumns() []string {
@@ -2545,7 +2558,7 @@ func (us SqlUserStore) GetUserReport(filter *model.UserReportOptions) ([]*model.
 		}
 
 		parentQuery = us.getQueryBuilder().
-			Select("data.*").
+			Select(getUsersColumnsWithName("data", "LastStatusAt", "LastPostDate", "DaysActive", "TotalPosts")...).
 			FromSelect(query, "data").
 			OrderBy(filter.SortColumn+" "+reverseSortDirection, "Id")
 	}


### PR DESCRIPTION
## 처리 내역

- adapt: MM-62151 avoid select * for post store (#34709) — 우리 커스텀 SQL 로직(FilterUserIds 필터링, 시스템 메시지 제외, SearchRecentMentions #203, 한글 LIKE 검색 6eecf5ee32)과 겹쳐 발생한 병합 충돌 3곳을 함수 단위로 대조·해결. 새로 활성화된 noSelectStar 린터가 잡아낸 SearchRecentMentions의 잔여 SELECT * 1건도 함께 수정하고, 사용되지 않던 정규식 죽은 코드 제거.

이로써 2026-01-09일자 upstream 커밋 4건이 모두 처리 완료 (cherry-pick 3건은 PR #237에서 이미 병합됨, 이번 PR은 남은 adapt 1건).

## 검증

- server: go build ./... 통과, golangci-lint 스코프 검사(channels/store/sqlstore)에서 신규 이슈 없음(unused 죽은 코드 제거로 오히려 개선)
- TestPostStore 전체 서브테스트 통과 (getPostsCollapsedThreads/getPostsSinceCollapsedThreads/getRootPosts/GetPostsSince 등 충돌 해결 함수 포함)
- TestSearchPostStore: 사전 존재하는 검색 실패 25건 확인 — cherry-pick 전후 정확히 동일한 테스트 목록임을 diff로 검증(한글 LIKE 검색 설계로 인한 기존 실패, 이번 변경과 무관)
- 전체 sqlstore 패키지 실행 시 TestChannelStore*/TestSqlxSelect 등 무관한 사전 존재 실패 있음(환경 특성, post_store.go/user_store.go 비접촉 영역)

🤖 Generated with [Claude Code](https://claude.com/claude-code)