### PR TITLE
upstream sync 2026-01-15 (picked 2, adapted 1)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -9697,41 +9697,6 @@ SOFTWARE.
 
 ---
 
-## oov/psd
-
-This product contains 'psd' by oov.
-
-A PSD/PSB file reader for go
-
-* HOMEPAGE:
-  * https://github.com/oov/psd
-
-* LICENSE: MIT
-
-MIT License
-
-Copyright (c) 2016 oov
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
 ## opensearch-project/opensearch-go
 
 This product contains 'opensearch-project/opensearch-go' by OpenSearch Project.
@@ -13051,5 +13016,3 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-

--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,17 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-07-30 12:59
+- 갱신일: 2026-07-30 13:31
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1173개
+- 남은 커밋: 1170개
 
-**마지막 반영 커밋:** `0885f560` | [Add optional Claude.md orchestration for Webapp folder (#34668)](https://github.com/mattermost/mattermost/commit/0885f56010ac74f03c88cfee41c885a3e53249a8) | 2026-01-14
+**마지막 반영 커밋:** `38b413a2` | [MM-67077: Remove PSD file previews (#34898)](https://github.com/mattermost/mattermost/commit/38b413a27604e8721fbe008f8ec4b4e6c47ad4f0) | 2026-01-15
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 52411cf6 | [Migrate UserList to a function component (#34511)](https://github.com/mattermost/mattermost/commit/52411cf613381fff286365b12faf6bc48f13042a) | 2026-01-15 |
-| 688e0c6c | [Update en.json (#34935)](https://github.com/mattermost/mattermost/commit/688e0c6c4e64a159e111d24648357a69e33e7f9f) | 2026-01-15 |
-| 38b413a2 | [MM-67077: Remove PSD file previews (#34898)](https://github.com/mattermost/mattermost/commit/38b413a27604e8721fbe008f8ec4b4e6c47ad4f0) | 2026-01-15 |
 | 0a12ca2f | [E2E/Playwright: Reorganize user and team creation (#34912)](https://github.com/mattermost/mattermost/commit/0a12ca2f7d1ba87830d5b34942d3494893a29aa4) | 2026-01-16 |
 | 53975de0 | [MM-66671 Migrate tests to RTL, batches E1 and E2 (#34506)](https://github.com/mattermost/mattermost/commit/53975de036b331168497a65246982c399ad0b33b) | 2026-01-16 |
 | 9268d4b1 | [MM-66672 Migrate tests to RTL (#34508)](https://github.com/mattermost/mattermost/commit/9268d4b1d0065fa9b6d22231d1cf10f7c3fe4bf8) | 2026-01-16 |

--- a/e2e-tests/cypress/tests/integration/channels/files_and_attachments/file_preview_image_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/files_and_attachments/file_preview_image_spec.js
@@ -92,18 +92,6 @@ describe('Upload Files - Image', () => {
         testImage(properties);
     });
 
-    it('MM-T2264_6 - PSD', () => {
-        const properties = {
-            filePath: 'mm_file_testing/Images/PSD.psd',
-            fileName: 'PSD.psd',
-            originalWidth: 400,
-            originalHeight: 479,
-            mimeType: 'application/psd',
-        };
-
-        testImage(properties);
-    });
-
     it('MM-T2264_7 - WEBP', () => {
         const properties = {
             filePath: 'mm_file_testing/Images/WEBP.webp',

--- a/server/channels/app/imaging/decode.go
+++ b/server/channels/app/imaging/decode.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"sync"
 
-	_ "github.com/oov/psd"
 	_ "golang.org/x/image/bmp"
 	_ "golang.org/x/image/tiff"
 	_ "golang.org/x/image/webp"

--- a/server/channels/app/imaging/decode_test.go
+++ b/server/channels/app/imaging/decode_test.go
@@ -115,6 +115,20 @@ func TestDecoderDecode(t *testing.T) {
 	})
 }
 
+func TestPSDNotSupported(t *testing.T) {
+	// MM-67077: PSD preview support was removed due to memory vulnerability in oov/psd package
+	d, err := NewDecoder(DecoderOptions{})
+	require.NotNil(t, d)
+	require.NoError(t, err)
+
+	// PSD file header magic bytes: "8BPS" followed by version (0x0001 for PSD)
+	psdHeader := []byte("8BPS\x00\x01")
+	_, _, err = d.Decode(bytes.NewReader(psdHeader))
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown format")
+}
+
 func TestDecoderDecodeMemBounded(t *testing.T) {
 	t.Run("concurrency bounded", func(t *testing.T) {
 		d, err := NewDecoder(DecoderOptions{

--- a/server/go.mod
+++ b/server/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/mholt/archives v0.1.5
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/minio/minio-go/v7 v7.0.95
-	github.com/oov/psd v0.0.0-20220121172623-5db5eafcecbb
 	github.com/opensearch-project/opensearch-go/v4 v4.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
@@ -132,7 +131,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/jsonschema-go v0.2.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gopherjs/gopherjs v1.17.2 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -282,8 +282,6 @@ github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE0
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
-github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
 github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
 github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
@@ -473,8 +471,6 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
 github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
-github.com/oov/psd v0.0.0-20220121172623-5db5eafcecbb h1:JF9kOhBBk4WPF7luXFu5yR+WgaFm9L/KiHJHhU9vDwA=
-github.com/oov/psd v0.0.0-20220121172623-5db5eafcecbb/go.mod h1:GHI1bnmAcbp96z6LNfBJvtrjxhaXGkbsk967utPlvL8=
 github.com/opensearch-project/opensearch-go/v4 v4.5.0 h1:26XckmmF6MhlXt91Bu1yY6R51jy1Ns/C3XgIfvyeTRo=
 github.com/opensearch-project/opensearch-go/v4 v4.5.0/go.mod h1:VmFc7dqOEM3ZtLhrpleOzeq+cqUgNabqQG5gX0xId64=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -11686,11 +11686,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "Version 140+"
+    "translation": "Version 142+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "Version 140+"
+    "translation": "Version 142+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",

--- a/server/i18n/ko.json
+++ b/server/i18n/ko.json
@@ -10406,11 +10406,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "버전 132+"
+    "translation": "버전 142+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "버전 132+"
+    "translation": "버전 142+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",

--- a/webapp/channels/src/components/file_attachment/file_thumbnail/__snapshots__/file_thumbnail.test.tsx.snap
+++ b/webapp/channels/src/components/file_attachment/file_thumbnail/__snapshots__/file_thumbnail.test.tsx.snap
@@ -30,6 +30,12 @@ exports[`FileThumbnail should render an icon for a PDF 1`] = `
 />
 `;
 
+exports[`FileThumbnail should render an icon for a PSD (MM-67077) 1`] = `
+<div
+  className="file-icon generic"
+/>
+`;
+
 exports[`FileThumbnail should render an icon for an SVG when SVG previews are disabled 1`] = `
 <div
   className="file-icon generic"

--- a/webapp/channels/src/components/file_attachment/file_thumbnail/file_thumbnail.test.tsx
+++ b/webapp/channels/src/components/file_attachment/file_thumbnail/file_thumbnail.test.tsx
@@ -105,4 +105,21 @@ describe('FileThumbnail', () => {
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find('div.file-icon').exists()).toBe(true);
     });
+
+    test('should render an icon for a PSD (MM-67077)', () => {
+        const props = {
+            ...baseProps,
+            fileInfo: {
+                ...fileInfo,
+                extension: 'psd',
+            },
+        };
+
+        const wrapper = shallow(
+            <FileThumbnail {...props}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('div.file-icon').exists()).toBe(true);
+    });
 });

--- a/webapp/channels/src/components/search/search.tsx
+++ b/webapp/channels/src/components/search/search.tsx
@@ -394,7 +394,7 @@ const Search = ({
             filterFilesSearchByExt(['py', 'go', 'java', 'kt', 'c', 'cpp', 'h', 'html', 'js', 'ts', 'cs', 'vb', 'php', 'pl', 'r', 'rb', 'sql', 'swift', 'json']);
             break;
         case 'images':
-            filterFilesSearchByExt(['png', 'jpg', 'jpeg', 'bmp', 'tiff', 'svg', 'psd', 'xcf']);
+            filterFilesSearchByExt(['png', 'jpg', 'jpeg', 'bmp', 'tiff', 'svg', 'xcf']);
             break;
         case 'audio':
             filterFilesSearchByExt(['ogg', 'mp3', 'wav', 'flac']);

--- a/webapp/channels/src/components/user_list.tsx
+++ b/webapp/channels/src/components/user_list.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {memo, useRef} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import type {Channel, ChannelMembership} from '@mattermost/types/channels';
@@ -39,74 +39,63 @@ type Props = {
     };
 }
 
-export default class UserList extends React.PureComponent <Props> {
-    static defaultProps = {
-        users: [],
-        extraInfo: {},
-        actions: [],
-        actionProps: {},
-        rowComponentType: UserListRow,
-    };
-    containerRef: React.RefObject<any>;
+const UserList = ({
+    actionUserProps,
+    isDisabled,
+    actionProps,
+    users: usersFromProps = [],
+    extraInfo = {},
+    actions = [],
+    rowComponentType = UserListRow,
+}: Props) => {
+    const containerRef = useRef(null);
 
-    constructor(props: Props) {
-        super(props);
-        this.containerRef = React.createRef();
-    }
+    const users = usersFromProps;
+    const RowComponentType = rowComponentType;
 
-    scrollToTop = () => {
-        if (this.containerRef.current) {
-            this.containerRef.current.scrollTop = 0;
-        }
-    };
-
-    render() {
-        const users = this.props.users;
-        const RowComponentType = this.props.rowComponentType;
-
-        let content;
-        if (users == null) {
-            return <LoadingScreen/>;
-        } else if (users.length > 0 && RowComponentType && this.props.actionProps) {
-            content = users.map((user: UserProfile, index: number) => {
-                const {actionUserProps, extraInfo} = this.props;
-                const userId = user.id;
-                return (
-                    <RowComponentType
-                        key={user.id}
-                        user={user}
-                        extraInfo={extraInfo?.[userId]}
-                        actions={this.props.actions}
-                        actionProps={this.props.actionProps}
-                        actionUserProps={actionUserProps?.[userId]}
-                        index={index}
-                        totalUsers={users.length}
-                        userCount={index >= 0 ? index : -1}
-                        isDisabled={this.props.isDisabled}
-                    />
-                );
-            });
-        } else {
-            content = (
-                <div
-                    key='no-users-found'
-                    className='more-modal__placeholder-row no-users-found'
-                    data-testid='noUsersFound'
-                >
-                    <p>
-                        <FormattedMessage
-                            id='user_list.notFound'
-                            defaultMessage='No users found'
-                        />
-                    </p>
-                </div>
+    let content;
+    if (users == null) {
+        return <LoadingScreen/>;
+    } else if (users.length > 0 && RowComponentType && actionProps) {
+        content = users.map((user: UserProfile, index: number) => {
+            const userId = user.id;
+            return (
+                <RowComponentType
+                    key={user.id}
+                    user={user}
+                    extraInfo={extraInfo?.[userId]}
+                    actions={actions}
+                    actionProps={actionProps}
+                    actionUserProps={actionUserProps?.[userId]}
+                    index={index}
+                    totalUsers={users.length}
+                    userCount={index >= 0 ? index : -1}
+                    isDisabled={isDisabled}
+                />
             );
-        }
-
-        return (
-            <div ref={this.containerRef}>
-                {content}
+        });
+    } else {
+        content = (
+            <div
+                key='no-users-found'
+                className='more-modal__placeholder-row no-users-found'
+                data-testid='noUsersFound'
+            >
+                <p>
+                    <FormattedMessage
+                        id='user_list.notFound'
+                        defaultMessage='No users found'
+                    />
+                </p>
             </div>
         );
     }
-}
+
+    return (
+        <div ref={containerRef}>
+            {content}
+        </div>
+    );
+};
+
+export default memo(UserList);

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -1545,7 +1545,7 @@ export const Constants = {
     DEFAULT_CHARACTER_LIMIT: 4000,
     IMAGE_TYPE_GIF: 'gif',
     TEXT_TYPES: ['txt', 'rtf', 'vtt'],
-    IMAGE_TYPES: ['jpg', 'gif', 'bmp', 'png', 'jpeg', 'tiff', 'tif', 'psd', 'webp'],
+    IMAGE_TYPES: ['jpg', 'gif', 'bmp', 'png', 'jpeg', 'tiff', 'tif', 'webp'],
     AUDIO_TYPES: ['mp3', 'wav', 'wma', 'm4a', 'flac', 'aac', 'ogg', 'm4r'],
     VIDEO_TYPES: ['mp4', 'avi', 'webm', 'mkv', 'wmv', 'mpg', 'mov', 'flv'],
     PRESENTATION_TYPES: ['ppt', 'pptx'],

--- a/webapp/channels/src/utils/utils.test.tsx
+++ b/webapp/channels/src/utils/utils.test.tsx
@@ -94,6 +94,11 @@ describe('Utils.getFileType', () => {
         expect(getFileType('txt')).toBe(FileTypes.TEXT);
     });
 
+    test('should not classify PSD files as images (MM-67077)', () => {
+        // PSD preview support was removed due to memory vulnerability in oov/psd package
+        expect(getFileType('psd')).toBe(FileTypes.OTHER);
+    });
+
     test('should handle null or undefined input', () => {
         expect(getFileType(null as any)).toBe(FileTypes.OTHER);
         expect(getFileType(undefined as any)).toBe(FileTypes.OTHER);


### PR DESCRIPTION
## Summary

2026-01-15자 upstream 커밋 3개 처리.

- [Migrate UserList to a function component (#34511)](https://github.com/mattermost/mattermost/commit/52411cf613381fff286365b12faf6bc48f13042a) — cherry-pick. 순수 리팩터(클래스→함수형), 동작 변경 없음.
- [Update en.json (#34935)](https://github.com/mattermost/mattermost/commit/688e0c6c4e64a159e111d24648357a69e33e7f9f) — adapt. Chrome/Edge 최소 브라우저 버전 140+→142+ 안내 문구 갱신. `server/i18n/ko.json`의 같은 키(chrome/edge)도 함께 "142+"로 동반 갱신 — 기존에 en(140+)/ko(132+)가 어긋나 있던 drift도 이 두 키에 한해 같이 해소.
- [MM-67077: Remove PSD file previews (#34898)](https://github.com/mattermost/mattermost/commit/38b413a27604e8721fbe008f8ec4b4e6c47ad4f0) — cherry-pick. PSD 미리보기 지원 제거(`github.com/oov/psd` 의존성 삭제), 관련 NOTICE.txt/테스트 정리.

## Test plan
- [x] `go build ./...`, `go vet`(imaging, plugin 패키지) 클린
- [x] `TestPSDNotSupported` 포함 `channels/app/imaging` 패키지 테스트 전체 통과
- [x] 웹앱: `user_list.test.tsx`, `file_thumbnail.test.tsx`, `utils.test.tsx` 등 통과(17건 + 스냅샷 6건)
- [x] eslint(이번 세션이 건드린 파일 전체 스코프) — 0건
- [x] `npm run check-types` — 신규 오류 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)