### PR TITLE
upstream sync 2026-07-31 (picked 2)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,16 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-07-31 14:00
+- 갱신일: 2026-07-31 14:38
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1162개
+- 남은 커밋: 1160개
 
-**마지막 반영 커밋:** `fa399a5b` | [Remove most unused props (#34979)](https://github.com/mattermost/mattermost/commit/fa399a5b05d17ea89c20c40f5288cdf522763f87) | 2026-01-20
+**마지막 반영 커밋:** `c01e9f79` | [\[MM-67189\] loading screen fixes - move measureAndReport, reduce minimum time, fix z-index issue (#34947)](https://github.com/mattermost/mattermost/commit/c01e9f791f8f37b7df107e461b0aeaa960e0a89f) | 2026-01-21
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| ed3a7e85 | [Add trigger field to command execution logs (#34950)](https://github.com/mattermost/mattermost/commit/ed3a7e853943317d7d32d623d2c5d4ab8df5756c) | 2026-01-21 |
-| c01e9f79 | [\[MM-67189\] loading screen fixes - move measureAndReport, reduce minimum time, fix z-index issue (#34947)](https://github.com/mattermost/mattermost/commit/c01e9f791f8f37b7df107e461b0aeaa960e0a89f) | 2026-01-21 |
 | fcd3ebcb | [fix(scheduled): enhance timezone formatting by incorporating user loc… (#34305)](https://github.com/mattermost/mattermost/commit/fcd3ebcb314960cb176a10b57b0b306cdc32690a) | 2026-01-22 |
 | d695a0db | [MM-67111-Remove Cancel button on User Attributes page (#34945)](https://github.com/mattermost/mattermost/commit/d695a0db7aa9f6b1815f26875de8afd96335e030) | 2026-01-22 |
 | 66e5ab4c | [E2E/Test Playwright upgrade (#35008)](https://github.com/mattermost/mattermost/commit/66e5ab4c5e06102a454a6d76ab60144a04d1e9b7) | 2026-01-23 |

--- a/server/channels/api4/system.go
+++ b/server/channels/api4/system.go
@@ -703,7 +703,7 @@ func pushNotificationAck(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	c.AppContext.WithLogger(c.AppContext.Logger().With(
+	c.AppContext = c.AppContext.WithLogFields(
 		mlog.String("type", model.NotificationTypePush),
 		mlog.String("ack_id", ack.Id),
 		mlog.String("push_type", ack.NotificationType),
@@ -711,7 +711,7 @@ func pushNotificationAck(c *Context, w http.ResponseWriter, r *http.Request) {
 		mlog.String("ack_type", ack.NotificationType),
 		mlog.String("device_type", ack.ClientPlatform),
 		mlog.Int("received_at", ack.ClientReceivedAt),
-	))
+	)
 	err := c.App.SendAckToPushProxy(c.AppContext, &ack)
 	if ack.IsIdLoaded {
 		if err != nil {

--- a/server/channels/app/command.go
+++ b/server/channels/app/command.go
@@ -220,6 +220,7 @@ func (a *App) ExecuteCommand(rctx request.CTX, args *model.CommandArgs) (*model.
 	if !strings.HasPrefix(trigger, "/") {
 		return nil, model.NewAppError("command", "api.command.execute_command.format.app_error", map[string]any{"Trigger": trigger}, "", http.StatusBadRequest)
 	}
+
 	trigger = strings.TrimPrefix(trigger, "/")
 
 	clientTriggerId, triggerId, appErr := model.GenerateTriggerId(args.UserId, a.AsymmetricSigningKey())
@@ -470,7 +471,7 @@ func (a *App) tryExecuteCustomCommand(rctx request.CTX, args *model.CommandArgs,
 		return nil, nil, nil
 	}
 
-	rctx.Logger().Debug("Executing command", mlog.String("command", trigger), mlog.String("user_id", args.UserId))
+	rctx = rctx.WithLogFields(mlog.String("command_id", cmd.Id))
 
 	p := url.Values{}
 	p.Set("token", cmd.Token)

--- a/server/channels/app/compliance.go
+++ b/server/channels/app/compliance.go
@@ -34,7 +34,7 @@ func (a *App) SaveComplianceReport(rctx request.CTX, job *model.Compliance) (*mo
 
 	job.Type = model.ComplianceTypeAdhoc
 
-	rctx = rctx.WithLogger(rctx.Logger().With(job.LoggerFields()...))
+	rctx = rctx.WithLogFields(job.LoggerFields()...)
 
 	job, err := a.Srv().Store().Compliance().Save(job)
 	if err != nil {

--- a/server/channels/app/file.go
+++ b/server/channels/app/file.go
@@ -788,11 +788,11 @@ func (a *App) UploadFileX(rctx request.CTX, channelID, name string, input io.Rea
 		o(t)
 	}
 
-	rctx = rctx.WithLogger(rctx.Logger().With(
+	rctx = rctx.WithLogFields(
 		mlog.String("file_name", name),
 		mlog.String("channel_id", channelID),
 		mlog.String("user_id", t.UserId),
-	))
+	)
 
 	if *a.Config().FileSettings.DriverName == "" {
 		return nil, t.newAppError("api.file.upload_file.storage.app_error", http.StatusNotImplemented)

--- a/server/channels/app/plugin_commands.go
+++ b/server/channels/app/plugin_commands.go
@@ -137,6 +137,8 @@ func (a *App) tryExecutePluginCommand(rctx request.CTX, args *model.CommandArgs)
 		return nil, nil, nil
 	}
 
+	rctx = rctx.WithLogFields(mlog.String("plugin_id", matched.PluginId))
+
 	pluginsEnvironment := a.GetPluginsEnvironment()
 	if pluginsEnvironment == nil {
 		return nil, nil, nil

--- a/server/channels/app/plugin_requests.go
+++ b/server/channels/app/plugin_requests.go
@@ -247,9 +247,7 @@ func (ch *Channels) servePluginRequest(w http.ResponseWriter, r *http.Request, h
 	r.Header.Del(model.HeaderAuth)
 
 	rctx = rctx.
-		WithLogger(rctx.Logger().With(
-			mlog.String("user_id", session.UserId),
-		)).
+		WithLogFields(mlog.String("user_id", session.UserId)).
 		WithSession(session)
 
 	// If MFA is required and user has not activated it, treat it as unauthenticated

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -2592,7 +2592,7 @@ func (a *App) SetPostReminder(rctx request.CTX, postID, userID string, targetTim
 }
 
 func (a *App) CheckPostReminders(rctx request.CTX) {
-	rctx = rctx.WithLogger(rctx.Logger().With(mlog.String("component", "post_reminders")))
+	rctx = rctx.WithLogFields(mlog.String("component", "post_reminders"))
 	systemBot, appErr := a.GetSystemBot(rctx)
 	if appErr != nil {
 		rctx.Logger().Error("Failed to get system bot", mlog.Err(appErr))

--- a/server/channels/app/scheduled_post_job.go
+++ b/server/channels/app/scheduled_post_job.go
@@ -23,7 +23,7 @@ const (
 )
 
 func (a *App) ProcessScheduledPosts(rctx request.CTX) {
-	rctx = rctx.WithLogger(rctx.Logger().With(mlog.String("component", "scheduled_post_job")))
+	rctx = rctx.WithLogFields(mlog.String("component", "scheduled_post_job"))
 
 	if !*a.Config().ServiceSettings.ScheduledPosts {
 		return

--- a/server/public/shared/request/context.go
+++ b/server/public/shared/request/context.go
@@ -168,6 +168,11 @@ func (c *Context) WithLogger(logger mlog.LoggerIFace) CTX {
 	return rctx
 }
 
+// WithLogFields returns a new context with the given fields added to the logger.
+func (c *Context) WithLogFields(fields ...mlog.Field) CTX {
+	return c.WithLogger(c.logger.With(fields...))
+}
+
 func (c *Context) With(f func(ctx CTX) CTX) CTX {
 	return f(c)
 }
@@ -194,6 +199,7 @@ type CTX interface {
 	WithUserAgent(string) CTX
 	WithAcceptLanguage(string) CTX
 	WithLogger(mlog.LoggerIFace) CTX
+	WithLogFields(fields ...mlog.Field) CTX
 	WithContext(ctx context.Context) CTX
 	With(func(ctx CTX) CTX) CTX
 }

--- a/webapp/channels/src/components/initial_loading_screen/initial_loading_screen.css
+++ b/webapp/channels/src/components/initial_loading_screen/initial_loading_screen.css
@@ -13,7 +13,7 @@ body {
     --gradient-center-color: #FFF;
     --gradient-edge-color: rgba(255, 255, 255, 0);
     position: absolute;
-    z-index: 100;
+    z-index: 1000;
     top: 0px;
     bottom: 0px;
     display: flex;
@@ -68,9 +68,9 @@ body {
 .LoadingAnimation {
     --fade-duration: 150ms;
     --colour: #1E325C;
-    --animation-initial-delay: 750ms;
-    --animation-start-duration: 750ms;
-    --animation-end-duration: 600ms;
+    --animation-initial-delay: 50ms;
+    --animation-start-duration: 400ms;
+    --animation-end-duration: 500ms;
     --animation-spinner-speed: 500ms;
     --animation-spinner-mask-stroke-length: 169.6;
     --ease-in-cubic: cubic-bezier(0.32, 0, 0.67, 0);

--- a/webapp/channels/src/components/initial_loading_screen/initial_loading_screen_class.ts
+++ b/webapp/channels/src/components/initial_loading_screen/initial_loading_screen_class.ts
@@ -8,7 +8,7 @@ const ANIMATION_CLASS_FOR_MATTERMOST_LOGO_HIDE = 'LoadingAnimation__compass-shri
 const ANIMATION_CLASS_FOR_COMPLETE_LOADER_HIDE = 'LoadingAnimation__shrink';
 
 const DESTROY_DELAY_AFTER_ANIMATION_END = 1000;
-const MINIMUM_LOADING_TIME = 2000; // Minimum time to show the loading screen (in ms)
+const MINIMUM_LOADING_TIME = 1000; // Minimum time to show the loading screen (in ms)
 
 const LOADING_CLASS_FOR_SCREEN = 'LoadingScreen';
 const LOADING_COMPLETE_CLASS_FOR_SCREEN = 'LoadingScreen LoadingScreen--loaded';
@@ -123,6 +123,16 @@ export class InitialLoadingScreenClass {
             return;
         }
 
+        // Measure the actual load time before any artificial delays
+        measureAndReport({
+            name: Measure.SplashScreen,
+            startMark: 0,
+            canFail: false,
+            labels: {
+                page_type: pageType,
+            },
+        });
+
         // Calculate how long the loading screen has been visible
         const elapsedTime = this.startTime ? Date.now() - this.startTime : 0;
         const remainingTime = Math.max(0, MINIMUM_LOADING_TIME - elapsedTime);
@@ -137,15 +147,6 @@ export class InitialLoadingScreenClass {
 
             this.loadingScreenElement.className = LOADING_COMPLETE_CLASS_FOR_SCREEN;
             this.loadingAnimationElement.className = LOADING_COMPLETE_CLASS_FOR_ANIMATION;
-
-            measureAndReport({
-                name: Measure.SplashScreen,
-                startMark: 0,
-                canFail: false,
-                labels: {
-                    page_type: pageType,
-                },
-            });
         }, remainingTime);
     }
 }


### PR DESCRIPTION
## Summary
- ed3a7e85 Add trigger field to command execution logs (#34950)
- c01e9f79 [MM-67189] loading screen fixes - move measureAndReport, reduce minimum time, fix z-index issue (#34947)

## Test plan
- [x] `go build` on touched server packages (api4, app, public/shared/request)
- [x] `go vet` clean on touched server packages
- [x] `go test ./public/shared/request/...` passes
- [x] `tsc --noEmit` shows no new errors for touched webapp files
- [x] `eslint` on touched webapp file shows only pre-existing CRLF linebreak-style noise, no logic issues