### PR TITLE
feat(sync): 비공개 사설 모듈 의존 커밋 추적 부록 추가

### DIFF
--- a/.claude/skills/speckit-sync/SKILL.md
+++ b/.claude/skills/speckit-sync/SKILL.md
@@ -30,8 +30,10 @@ okrbest는 mattermost/mattermost의 heavily-diverged 포크다. upstream 커밋�
 
 추적 원리: 반영 커밋 본문의 upstream 해시 참조(`cherry picked from commit <hash>` / `Upstream: <링크>`)와 ledger 부록(제외/spec)이 기록이며, `scripts/upstream-sync.sh update`가 이를 차감해 미반영 목록을 재생성한다. **별도 상태 파일 없음.**
 
+**비공개 사설 모듈 의존 표시(보조 태그)**: 분석 중 upstream 구현이 `github.com/mattermost/enterprise/*` 같은 Mattermost, Inc.의 비공개 저장소에만 있어(예: `server/enterprise/external_imports.go`의 신규 임포트가 okrbest에 존재하지 않는 모듈을 참조) 실제 기능 로직을 반영할 수 없는 경우, cherry-pick/adapt/exclude 판단과 **별개로** `$SYNC private-module <hash> "<설명>"`을 추가로 기록한다. adapt로 인터페이스·스캐폴딩만 반영해 기능이 비활성 상태로 남는 경우(자세한 사유는 커밋 메시지에 기록)와, 아예 반영할 실체가 없어 exclude한 경우 둘 다 해당될 수 있다 — ledger 하단 "Mattermost 비공개 사설 모듈 커밋" 표는 이런 커밋을 모아 향후 자체 구현 개발 대상으로 추적하기 위한 것이다.
+
 도우미 스크립트: `.specify/scripts/bash/upstream-sync.sh` (이하 `$SYNC`)
-`update` / `status` / `next [n]` / `signals <hash>` / `exclude <hash> <사유>` / `to-spec <hash> <specID>`
+`update` / `status` / `next [n]` / `signals <hash>` / `exclude <hash> <사유>` / `to-spec <hash> <specID>` / `private-module <hash> <설명>`
 
 ## 워크플로
 

--- a/.specify/scripts/bash/upstream-sync.sh
+++ b/.specify/scripts/bash/upstream-sync.sh
@@ -11,6 +11,10 @@
 #   upstream-sync.sh signals <hash>    LLM 판단 재료 출력
 #   upstream-sync.sh exclude <hash> <사유>     제외 부록에 기록 후 update
 #   upstream-sync.sh to-spec <hash> <specID>   spec 부록에 기록 후 update
+#   upstream-sync.sh private-module <hash> <설명>   비공개 사설 모듈 의존 부록에 기록 후 update
+#     (upstream 구현이 github.com/mattermost/enterprise/* 등 비공개 저장소에 있어
+#      인터페이스·스캐폼만 반영되고 실제 기능은 okrbest가 별도 개발해야 하는 경우.
+#      cherry-pick/adapt로 이미 반영한 커밋도, exclude한 커밋도 기록 가능 — 후속 개발 대상 추적용.)
 
 set -euo pipefail
 
@@ -34,9 +38,9 @@ processed_hashes() {
             --pretty=format:'%B' 2>/dev/null |
             grep -oE '(cherry picked from commit |Upstream: '"$UPSTREAM_URL"'/commit/)[0-9a-f]{40}' |
             grep -oE '[0-9a-f]{40}$' || true
-        # 2) excluded / spec: ledger 부록 섹션의 링크 URL 속 full hash
+        # 2) excluded / spec / private-module: ledger 부록 섹션의 링크 URL 속 full hash
         if [[ -f "$LEDGER" ]]; then
-            awk '/^## (제외된 커밋|spec 전환 커밋)/,0' "$LEDGER" |
+            awk '/^## (제외된 커밋|spec 전환 커밋|Mattermost 비공개 사설 모듈 커밋)/,0' "$LEDGER" |
                 grep -oE "$UPSTREAM_URL/commit/[0-9a-f]{40}" |
                 grep -oE '[0-9a-f]{40}' || true
         fi
@@ -101,9 +105,10 @@ cmd_update() {
     last_synced_line="$(git log -1 --date=format:%Y-%m-%d --pretty=tformat:'%H%x1f%s%x1f%ad' "$last_hash" | md_escape_row |
         sed 's/^| /**마지막 반영 커밋:** `/; s/ | \[/` | [/; s/ |$//')"
 
-    local excluded_sec spec_sec
+    local excluded_sec spec_sec private_module_sec
     excluded_sec="$(appendix_section "제외된 커밋" "사유")"
     spec_sec="$(appendix_section "spec 전환 커밋" "spec")"
+    private_module_sec="$(appendix_section "Mattermost 비공개 사설 모듈 커밋" "비공개 모듈 · 비고")"
 
     {
         echo "# upstream-master 미반영 커밋 목록"
@@ -124,6 +129,8 @@ cmd_update() {
         echo "$excluded_sec"
         echo
         echo "$spec_sec"
+        echo
+        echo "$private_module_sec"
     } >"$LEDGER"
 
     echo "updated: $LEDGER (남은 커밋 ${total}개)"
@@ -134,10 +141,11 @@ cmd_update() {
 cmd_status() {
     [[ -f "$LEDGER" ]] || { echo "ledger 없음 — 먼저 update 실행" >&2; exit 1; }
     grep -E '^- 남은 커밋|^\*\*마지막 반영 커밋' "$LEDGER"
-    local ex sp
+    local ex sp pm
     ex="$(awk '/^## 제외된 커밋/,/^## spec 전환 커밋/' "$LEDGER" | grep -c '^| [0-9a-f]' || true)"
-    sp="$(awk '/^## spec 전환 커밋/,0' "$LEDGER" | grep -c '^| [0-9a-f]' || true)"
-    echo "- 제외된 커밋: ${ex}개 / spec 전환: ${sp}개"
+    sp="$(awk '/^## spec 전환 커밋/,/^## Mattermost 비공개 사설 모듈 커밋/' "$LEDGER" | grep -c '^| [0-9a-f]' || true)"
+    pm="$(awk '/^## Mattermost 비공개 사설 모듈 커밋/,0' "$LEDGER" | grep -c '^| [0-9a-f]' || true)"
+    echo "- 제외된 커밋: ${ex}개 / spec 전환: ${sp}개 / 비공개 모듈 의존: ${pm}개"
 }
 
 # ---------- next ----------
@@ -207,32 +215,41 @@ cmd_signals() {
 # ---------- exclude / to-spec ----------
 
 append_appendix() {
-    local title="$1" hash="$2" info="$3"
+    local title="$1" hash="$2" info="$3" extra_col="${4:-비고}"
     local full subj
     full="$(git rev-parse "$hash^{commit}")"
     subj="$(git log -1 --pretty=format:'%s' "$full")"
     subj="${subj//|/\\|}"; subj="${subj//[/\\[}"; subj="${subj//]/\\]}"
     info="${info//|/\\|}"
-    # 섹션 마지막 표 행 뒤에 추가
-    python3 - "$LEDGER" "$title" "| ${full:0:8} | [$subj]($UPSTREAM_URL/commit/$full) | $info |" <<'EOF'
+    # 섹션 마지막 표 행 뒤에 추가. 섹션이 아직 없으면(신규 카테고리 최초 사용) 파일 끝에 새로 만든다.
+    # (Windows에서 python3가 미동작 App Execution Alias로 깨진 경우 python으로 폴백)
+    local py=python3
+    "$py" -c '' >/dev/null 2>&1 || py=python
+    "$py" - "$LEDGER" "$title" "$extra_col" "| ${full:0:8} | [$subj]($UPSTREAM_URL/commit/$full) | $info |" <<'EOF'
 import sys
-path, title, row = sys.argv[1], sys.argv[2], sys.argv[3]
-lines = open(path).read().splitlines()
+path, title, extra_col, row = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+lines = open(path, encoding="utf-8").read().splitlines()
 out, in_sec, inserted = [], False, False
-for i, l in enumerate(lines):
+for l in lines:
     if l.startswith("## "):
         if in_sec and not inserted:
             out.append(row); inserted = True
         in_sec = l == f"## {title}"
     out.append(l)
 if in_sec and not inserted:
-    out.append(row)
-open(path, "w").write("\n".join(out) + "\n")
+    out.append(row); inserted = True
+if not inserted:
+    # 섹션이 파일에 아예 없었던 경우 — 새 섹션을 끝에 생성
+    if out and out[-1] != "":
+        out.append("")
+    out += [f"## {title}", "", f"| 커밋 해시 | 커밋 제목 | {extra_col} |", "|---|---|---|", row]
+open(path, "w", encoding="utf-8").write("\n".join(out) + "\n")
 EOF
 }
 
-cmd_exclude() { append_appendix "제외된 커밋" "$1" "$2"; cmd_update; }
-cmd_tospec()  { append_appendix "spec 전환 커밋" "$1" "$2"; cmd_update; }
+cmd_exclude() { append_appendix "제외된 커밋" "$1" "$2" "사유"; cmd_update; }
+cmd_tospec()  { append_appendix "spec 전환 커밋" "$1" "$2" "spec"; cmd_update; }
+cmd_privatemodule() { append_appendix "Mattermost 비공개 사설 모듈 커밋" "$1" "$2" "비공개 모듈 · 비고"; cmd_update; }
 
 # ---------- 진입점 ----------
 
@@ -243,5 +260,6 @@ case "${1:-}" in
     signals) [[ $# -ge 2 ]] || { echo "signals <hash>" >&2; exit 1; }; cmd_signals "$2" ;;
     exclude) [[ $# -ge 3 ]] || { echo "exclude <hash> <사유>" >&2; exit 1; }; cmd_exclude "$2" "$3" ;;
     to-spec) [[ $# -ge 3 ]] || { echo "to-spec <hash> <specID>" >&2; exit 1; }; cmd_tospec "$2" "$3" ;;
-    *) sed -n '2,12p' "$0"; exit 1 ;;
+    private-module) [[ $# -ge 3 ]] || { echo "private-module <hash> <설명>" >&2; exit 1; }; cmd_privatemodule "$2" "$3" ;;
+    *) sed -n '2,17p' "$0"; exit 1 ;;
 esac

--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,9 +3,9 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-02 00:41
+- 갱신일: 2026-08-03 15:01
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1149개
+- 남은 커밋: 1151개
 
 **마지막 반영 커밋:** `a1c85007` | [Autotranslations MVP (#34696)](https://github.com/mattermost/mattermost/commit/a1c85007e156adee66583b0f13e88d5da6386dd4) | 2026-01-26
 
@@ -1160,6 +1160,8 @@
 | 3019460a | [MM-69445: Markdown fixes (#37388)](https://github.com/mattermost/mattermost/commit/3019460ac55ff3d54c5f77363a0dde814fb13a39) | 2026-07-31 |
 | 5152df24 | [Mm 70056 missing info banner team abac team admin (#37790)](https://github.com/mattermost/mattermost/commit/5152df2418a9e86d0e0291f179301ed0993ea8fb) | 2026-07-31 |
 | d5d5b2ca | [Fix UI flash when closing the Decision details modal in permission policy simulation (#37141)](https://github.com/mattermost/mattermost/commit/d5d5b2ca2973ef92f3b3eaad182fe78816cf1481) | 2026-08-01 |
+| 0785004b | [MM-65803 Add strict E2E tests for post list scrolling (#37653)](https://github.com/mattermost/mattermost/commit/0785004bcc78639b99a195c2f565d6ab903d723d) | 2026-08-01 |
+| c17064f7 | [Fix flaky TestImportValidateDirectPostImportData (#37795)](https://github.com/mattermost/mattermost/commit/c17064f72c97e6e7ac4ee2c9ad02f2239faa10f9) | 2026-08-02 |
 
 ## 제외된 커밋
 
@@ -1174,3 +1176,9 @@
 
 | 커밋 해시 | 커밋 제목 | spec |
 |---|---|---|
+
+## Mattermost 비공개 사설 모듈 커밋
+
+| 커밋 해시 | 커밋 제목 | 비공개 모듈 · 비고 |
+|---|---|---|
+| a1c85007 | [Autotranslations MVP (#34696)](https://github.com/mattermost/mattermost/commit/a1c85007e156adee66583b0f13e88d5da6386dd4) | `github.com/mattermost/enterprise/autotranslation` (비공개). 인터페이스·DB 스키마·관리 콘솔 UI는 ac434e9812(adapt)로 반영했으나 실제 번역/마스킹 로직은 okrbest가 별도 구현해야 활성화됨 — `server/einterfaces/autotranslation.go`의 `AutoTranslationInterface`를 구현해 `RegisterAutoTranslationInterface()`로 등록. |


### PR DESCRIPTION
upstream 구현이 github.com/mattermost/enterprise/* 등 Mattermost, Inc.의
비공개 저장소에만 있어 인터페이스·스캐폴딩만 반영 가능하고 실제 기능
로직은 okrbest가 별도 개발해야 하는 커밋을, cherry-pick/adapt/exclude
판단과 별개로 ledger 하단 "Mattermost 비공개 사설 모듈 커밋" 표에
남겨 후속 개발 대상으로 추적한다.

- upstream-sync.sh: private-module 서브커맨드 추가, append_appendix가
  신규 카테고리 최초 사용 시 섹션을 스스로 생성하도록 수정(기존 코드는
  섹션이 파일에 없으면 삽입을 조용히 건너뛰는 버그가 있었음), 마지막
  섹션(EOF 직전)에 삽입할 때 inserted 플래그를 세팅하지 않아 섹션이
  중복 생성되는 버그 수정, python3 App Execution Alias가 깨진 Windows
  환경을 위한 python 폴백과 UTF-8 인코딩 명시 추가
- SKILL.md: private-module 사용법 문서화
- a1c85007(Autotranslations MVP)을 첫 항목으로 기록
