### PR TITLE
upstream sync 2026-01-31 (picked 1)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,15 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-04 09:41
+- 갱신일: 2026-08-04 09:50
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1118개
+- 남은 커밋: 1117개
 
-**마지막 반영 커밋:** `28881683` | [Bump playbooks to v2.7.0 (#35150)](https://github.com/mattermost/mattermost/commit/288816834d5519f12ac28f4fdb104f24eb2cf5aa) | 2026-01-30
+**마지막 반영 커밋:** `8db2ef6b` | [MM-67365 - adjust bor icons and priority labels in compact mode (#35121)](https://github.com/mattermost/mattermost/commit/8db2ef6b9f9d55ceb958b36595c9753befe1afed) | 2026-01-31
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 8db2ef6b | [MM-67365 - adjust bor icons and priority labels in compact mode (#35121)](https://github.com/mattermost/mattermost/commit/8db2ef6b9f9d55ceb958b36595c9753befe1afed) | 2026-01-31 |
 | 981ff0bc | [MM-66362 feat: run e2e full tests after successful smoke tests both in cypress and playwright (#34868)](https://github.com/mattermost/mattermost/commit/981ff0bc46f1b9445af4ad64ad4aa17d45c58cd6) | 2026-02-02 |
 | dc69319c | [Moved flag post option before delete post (#35019)](https://github.com/mattermost/mattermost/commit/dc69319c676083c6ad9a6288291ce248f4b4805b) | 2026-02-02 |
 | 990e9b34 | [Removed initial BOR post reveal WS event for post author (#34939)](https://github.com/mattermost/mattermost/commit/990e9b34bf4f410ed286a077b97804e7a3a4d87c) | 2026-02-02 |

--- a/webapp/channels/src/components/post_view/burn_on_read_badge/burn_on_read_badge.scss
+++ b/webapp/channels/src/components/post_view/burn_on_read_badge/burn_on_read_badge.scss
@@ -2,6 +2,8 @@
 // See LICENSE.txt for license information.
 
 .BurnOnReadBadge {
+    position: relative;
+    z-index: 25;
     display: inline-flex;
     align-items: center;
     padding: 0;
@@ -9,6 +11,7 @@
     margin-left: 8px;
     background: transparent;
     cursor: pointer;
+    pointer-events: auto;
     vertical-align: middle;
 
     &:disabled {

--- a/webapp/channels/src/components/post_view/burn_on_read_timer_chip/burn_on_read_timer_chip.scss
+++ b/webapp/channels/src/components/post_view/burn_on_read_timer_chip/burn_on_read_timer_chip.scss
@@ -2,6 +2,8 @@
 // See LICENSE.txt for license information.
 
 .BurnOnReadTimerChip {
+    position: relative;
+    z-index: 25;
     display: inline-flex;
     height: 16px;
     align-items: center;
@@ -15,6 +17,7 @@
     font-size: 10px;
     font-weight: 600;
     line-height: 12px;
+    pointer-events: auto;
     transition: all 0.2s ease;
 
     &:hover {

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -851,10 +851,15 @@
         .post__header,
         .post-preview__header {
             display: flex;
+            overflow: visible;
             width: auto;
             max-height: 22px;
             padding: 0;
             margin-bottom: 0;
+        }
+
+        .badges-wrapper {
+            margin-right: 5px;
         }
 
         .post__body {


### PR DESCRIPTION
## Summary
upstream(mattermost/mattermost) 2026-01-31 커밋 1개를 정밀 분석하여 반영 (`/speckit-sync`).

- cherry-pick 1건 (순수 SCSS 스타일 수정, 로직 변경 없음)

## Commits
- 46d668a396 MM-67365 - adjust bor icons and priority labels in compact mode (#35121) — cherry-pick
- 87cc383aa5 docs: upstream sync 진행 (picked 1)

## Test plan
- [x] 변경 파일(`burn_on_read_badge.scss`, `burn_on_read_timer_chip.scss`, `_post.scss`) 스코프 `stylelint` 통과
- [x] 전체 `npm run check:stylelint`에는 이 세션과 무관한 기존 실패 66건이 있음(변경 파일 목록에는 포함되지 않음, 사전 존재 이슈로 확인) — 변경 파일 범위 내에서는 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)