### PR TITLE
upstream sync 2026-02-05 (picked 5, adapted 3)

### DIFF
--- a/.github/workflows/e2e-tests-ci.yml
+++ b/.github/workflows/e2e-tests-ci.yml
@@ -1,5 +1,5 @@
 ---
-name: E2E Tests
+name: E2E Tests (smoke-then-full)
 on:
   # Argo Events Trigger (automated):
   #   - Triggered by: Enterprise CI/docker-image status check (success)

--- a/.github/workflows/e2e-tests-override-status.yml
+++ b/.github/workflows/e2e-tests-override-status.yml
@@ -37,7 +37,7 @@ jobs:
           COMMIT_SHA: ${{ steps.pr-info.outputs.head_sha }}
         run: |
           # Only full tests can be overridden (smoke tests must pass)
-          FULL_TEST_CONTEXTS=("E2E Tests/playwright-full" "E2E Tests/cypress-full")
+          FULL_TEST_CONTEXTS=("E2E Tests / playwright-full" "E2E Tests / cypress-full")
 
           for CONTEXT_NAME in "${FULL_TEST_CONTEXTS[@]}"; do
             echo "Checking: $CONTEXT_NAME"

--- a/.github/workflows/e2e-tests-verified-label.yml
+++ b/.github/workflows/e2e-tests-verified-label.yml
@@ -19,13 +19,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           LABEL_AUTHOR: ${{ github.event.sender.login }}
         run: |
-          # Check if user is a member of mattermost org
-          HTTP_STATUS=$(gh api orgs/mattermost/members/${LABEL_AUTHOR} --silent -i 2>/dev/null | head -1 | awk '{print $2}')
-          if [[ "$HTTP_STATUS" != "204" ]]; then
-            echo "User ${LABEL_AUTHOR} is not a member of mattermost org (status: ${HTTP_STATUS})"
+          # Check if user has write permission to the repository
+          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${LABEL_AUTHOR}/permission --jq '.permission' 2>/dev/null || echo "none")
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
+            echo "User ${LABEL_AUTHOR} doesn't have write permission to the repository (permission: ${PERMISSION})"
             exit 1
           fi
-          echo "User ${LABEL_AUTHOR} is a member of mattermost org"
+          echo "User ${LABEL_AUTHOR} has ${PERMISSION} permission to the repository"
 
       - name: ci/override-failed-statuses
         id: override
@@ -34,7 +34,7 @@ jobs:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Only full tests can be overridden (smoke tests must pass)
-          FULL_TEST_CONTEXTS=("E2E Tests/playwright-full" "E2E Tests/cypress-full")
+          FULL_TEST_CONTEXTS=("E2E Tests / playwright-full" "E2E Tests / cypress-full")
           OVERRIDDEN=""
           WEBHOOK_DATA="[]"
 
@@ -62,18 +62,12 @@ jobs:
               continue
             fi
 
-            # Parse and construct new message
-            if [[ "$CURRENT_DESC" =~ ^([0-9]+)\ failed,\ ([0-9]+)\ passed ]]; then
-              FAILED="${BASH_REMATCH[1]}"
-              PASSED="${BASH_REMATCH[2]}"
-              NEW_MSG="${FAILED} failed (verified), ${PASSED} passed"
-            elif [[ "$CURRENT_DESC" =~ ^([0-9]+)\ failed\ \([^)]+\),\ ([0-9]+)\ passed ]]; then
-              FAILED="${BASH_REMATCH[1]}"
-              PASSED="${BASH_REMATCH[2]}"
-              NEW_MSG="${FAILED} failed (verified), ${PASSED} passed"
-            else
-              NEW_MSG="${CURRENT_DESC} (verified)"
-            fi
+          # Prefix existing description
+          if [ -n "$CURRENT_DESC" ]; then
+            NEW_MSG="(verified) ${CURRENT_DESC}"
+          else
+            NEW_MSG="(verified)"
+          fi
 
             echo "  New: $NEW_MSG"
 

--- a/api/v4/source/channels.yaml
+++ b/api/v4/source/channels.yaml
@@ -1600,6 +1600,61 @@
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  "/api/v4/channels/{channel_id}/members/{user_id}/autotranslation":
+    put:
+      tags:
+        - channels
+      summary: Update channel member autotranslation setting
+      description: >
+        Update a user's autotranslation setting for a channel. This controls whether
+        messages in the channel should not be automatically translated for the user.
+        By default, autotranslations are enabled for all users if the channel is enabled
+        for autotranslation.
+
+        ##### Permissions
+
+        Must be logged in as the user or have `edit_other_users` permission.
+      operationId: UpdateChannelMemberAutotranslation
+      parameters:
+        - name: channel_id
+          in: path
+          description: Channel GUID
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: path
+          description: User GUID
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - autotranslation_disabled
+              properties:
+                autotranslation_disabled:
+                  type: boolean
+                  description: Whether to disable autotranslation for the user in this channel
+        required: true
+      responses:
+        "200":
+          description: Channel member autotranslation setting update successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusOK"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   "/api/v4/channels/members/{user_id}/view":
     post:
       tags:

--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,22 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-04 15:01
+- 갱신일: 2026-08-04 15:47
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1100개
+- 남은 커밋: 1094개
 
-**마지막 반영 커밋:** `4887c501` | [chore: Update zoom version to 1.12.0 (#35167)](https://github.com/mattermost/mattermost/commit/4887c501e187527223d5bf0f9d512dac150f8094) | 2026-02-04
+**마지막 반영 커밋:** `197fa160` | [\[MM-67126\] harden checks (#35171)](https://github.com/mattermost/mattermost/commit/197fa160b4a596f441942fbb233e3247611064b9) | 2026-02-05
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 5a408b75 | [(fix): verified by label and playwright rerun on failed specs (#35161)](https://github.com/mattermost/mattermost/commit/5a408b757c5e7990829cf63ffa73ad8b89a0926e) | 2026-02-05 |
-| 444ada72 | [Update en.json (#35160)](https://github.com/mattermost/mattermost/commit/444ada7251e87173f52d41485ce0a40daf888579) | 2026-02-05 |
-| a06d5065 | [apply view restrcitions while fetching group members (#35172)](https://github.com/mattermost/mattermost/commit/a06d5065e709e26baed531a528d4b9950f26e3ea) | 2026-02-05 |
-| 1273632d | [Add endpoint to update channel member autotranslations (#35072)](https://github.com/mattermost/mattermost/commit/1273632d1afd12c2bc84738e84f347361247c8d9) | 2026-02-05 |
-| 22e4e9c1 | [Improve mmctl output by filtering escape sequences (#35191)](https://github.com/mattermost/mattermost/commit/22e4e9c171dcf9b447a56c7d9a45e5714fb24536) | 2026-02-05 |
-| 9ac02ecf | [Update translation primary key to include objectType (#35040)](https://github.com/mattermost/mattermost/commit/9ac02ecfddbdd50125d84355558bc8392cbfda3c) | 2026-02-05 |
-| c31fe3f2 | [invalidate channel cache after deleting a channel access control policy (#35174)](https://github.com/mattermost/mattermost/commit/c31fe3f2440ed5161e79216bd0aeaae860b0126a) | 2026-02-05 |
-| 197fa160 | [\[MM-67126\] harden checks (#35171)](https://github.com/mattermost/mattermost/commit/197fa160b4a596f441942fbb233e3247611064b9) | 2026-02-05 |
 | f6574143 | [Document URL search in Postgres through tests (#35194)](https://github.com/mattermost/mattermost/commit/f6574143a8ec0f9a9735ce31f6bda80740e1746b) | 2026-02-06 |
 | 2bd29c03 | [Add the ability to patch channel autotranslations (#35078)](https://github.com/mattermost/mattermost/commit/2bd29c03593643821144d59ae57725c30db7a07a) | 2026-02-06 |
 | 9f40d051 | [\[MM-66942\] Ensure consistent option ID generation across all field creation paths (#34725)](https://github.com/mattermost/mattermost/commit/9f40d051eea34436741aa4d85d8855bfd0baf605) | 2026-02-06 |
@@ -1111,6 +1103,8 @@
 | c17064f7 | [Fix flaky TestImportValidateDirectPostImportData (#37795)](https://github.com/mattermost/mattermost/commit/c17064f72c97e6e7ac4ee2c9ad02f2239faa10f9) | 2026-08-02 |
 | acf883c8 | [chore: Update NOTICE.txt file with updated dependencies (#37814)](https://github.com/mattermost/mattermost/commit/acf883c825a6f59be1f6301c0f84c6f8f5df8ddc) | 2026-08-03 |
 | ae0bec4d | [Add MFI plugin signature public key behind feature flag (#37793)](https://github.com/mattermost/mattermost/commit/ae0bec4d6741cafea7eca7beafbac1929826e20b) | 2026-08-03 |
+| 7130ae59 | [MM-70054 - Enable Team Membership ABAC feature flag by default (#37781)](https://github.com/mattermost/mattermost/commit/7130ae598f8291bd5d5e39473bd2df370b69c3d8) | 2026-08-04 |
+| b4beed37 | [MM-69974: keep focus in the WYSIWYG composer and stop the Enter crash (#37815)](https://github.com/mattermost/mattermost/commit/b4beed37f88b15d6eb50d4dff0be082043077b55) | 2026-08-04 |
 
 ## 제외된 커밋
 

--- a/server/channels/api4/access_control.go
+++ b/server/channels/api4/access_control.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/v8/channels/app"
 )
 
 func (api *API) InitAccessControlPolicy() {
@@ -392,9 +393,11 @@ func updateActiveStatus(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// CSRF barrier: only allow header-based auth (reject cookie-only sessions)
-	if r.Header.Get(model.HeaderAuth) == "" {
-		c.SetInvalidParam("Authorization")
+	// CSRF barrier: only allow header-based auth (reject cookie sessions)
+	token, tokenLocation := app.ParseAuthTokenFromRequest(r)
+	if token == "" || tokenLocation == app.TokenLocationCookie {
+		c.Err = model.NewAppError("updateActiveStatus", "api.context.session_cookie_not_allowed.app_error", nil,
+			"This endpoint requires header-based authentication", http.StatusUnauthorized)
 		return
 	}
 

--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -79,6 +79,7 @@ func (api *API) InitChannel() {
 	api.BaseRoutes.ChannelMember.Handle("/roles", api.APISessionRequired(updateChannelMemberRoles)).Methods(http.MethodPut)
 	api.BaseRoutes.ChannelMember.Handle("/schemeRoles", api.APISessionRequired(updateChannelMemberSchemeRoles)).Methods(http.MethodPut)
 	api.BaseRoutes.ChannelMember.Handle("/notify_props", api.APISessionRequired(updateChannelMemberNotifyProps)).Methods(http.MethodPut)
+	api.BaseRoutes.ChannelMember.Handle("/autotranslation", api.APISessionRequired(updateChannelMemberAutotranslation)).Methods(http.MethodPut)
 
 	api.BaseRoutes.ChannelModerations.Handle("", api.APISessionRequired(getChannelModerations)).Methods(http.MethodGet)
 	api.BaseRoutes.ChannelModerations.Handle("/patch", api.APISessionRequired(patchChannelModerations)).Methods(http.MethodPut)
@@ -1839,6 +1840,66 @@ func updateChannelMemberNotifyProps(c *Context, w http.ResponseWriter, r *http.R
 	_, err := c.App.UpdateChannelMemberNotifyProps(c.AppContext, props, c.Params.ChannelId, c.Params.UserId)
 	if err != nil {
 		c.Err = err
+		return
+	}
+
+	auditRec.Success()
+
+	ReturnStatusOK(w)
+}
+
+type UpdateChannelMemberAutotranslationProps struct {
+	AutoTranslationDisabled bool `json:"autotranslation_disabled"`
+}
+
+func updateChannelMemberAutotranslation(c *Context, w http.ResponseWriter, r *http.Request) {
+	if c.App.AutoTranslation() == nil || !c.App.AutoTranslation().IsFeatureAvailable() {
+		c.Err = model.NewAppError("updateChannelMemberAutotranslation", "api.channel.update_channel_member_autotranslation.feature_not_available.app_error", nil, "", http.StatusForbidden)
+		return
+	}
+
+	c.RequireUserId().RequireChannelId()
+	if c.Err != nil {
+		return
+	}
+
+	props := UpdateChannelMemberAutotranslationProps{}
+	if err := json.NewDecoder(r.Body).Decode(&props); err != nil {
+		c.SetInvalidParamWithErr("autotranslation_disabled", err)
+		return
+	}
+
+	auditRec := c.MakeAuditRecord(model.AuditEventUpdateChannelMemberAutotranslation, model.AuditStatusFail)
+	defer c.LogAuditRec(auditRec)
+	model.AddEventParameterToAuditRec(auditRec, "channel_id", c.Params.ChannelId)
+	model.AddEventParameterToAuditRec(auditRec, "autotranslation_disabled", props.AutoTranslationDisabled)
+	model.AddEventParameterToAuditRec(auditRec, "user_id", c.Params.UserId)
+
+	if !c.App.SessionHasPermissionToUser(*c.AppContext.Session(), c.Params.UserId) {
+		c.SetPermissionError(model.PermissionEditOtherUsers)
+		return
+	}
+
+	_, err := c.App.GetChannelMember(c.AppContext, c.Params.ChannelId, c.Params.UserId)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	channelEnabled, err := c.App.AutoTranslation().IsChannelEnabled(c.Params.ChannelId)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	if !channelEnabled {
+		c.Err = model.NewAppError("updateChannelMemberAutotranslation", "api.channel.update_channel_member_autotranslation.channel_not_enabled.app_error", nil, "", http.StatusBadRequest)
+		return
+	}
+
+	_, appErr := c.App.UpdateChannelMemberAutotranslation(c.AppContext, c.Params.ChannelId, c.Params.UserId, props.AutoTranslationDisabled)
+	if appErr != nil {
+		c.Err = appErr
 		return
 	}
 

--- a/server/channels/api4/channel_test.go
+++ b/server/channels/api4/channel_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/app"
 	"github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
 	"github.com/mattermost/mattermost/server/v8/channels/utils/testutils"
+	einterfacesmocks "github.com/mattermost/mattermost/server/v8/einterfaces/mocks"
 )
 
 func TestCreateChannel(t *testing.T) {
@@ -4154,6 +4155,124 @@ func TestUpdateChannelMemberSchemeRoles(t *testing.T) {
 	resp, err = SystemAdminClient.UpdateChannelMemberSchemeRoles(context.Background(), th.BasicChannel.Id, th.SystemAdminUser.Id, s4)
 	require.Error(t, err)
 	CheckUnauthorizedStatus(t, resp)
+}
+
+func TestUpdateChannelMemberAutotranslation(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+	client := th.Client
+
+	mockAutotranslation := &einterfacesmocks.AutoTranslationInterface{}
+	mockAutotranslation.On("IsFeatureAvailable").Return(true)
+	mockAutotranslation.On("IsChannelEnabled", mock.Anything).Return(true, nil)
+	mockAutotranslation.On("Translate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+	originalAutoTranslation := th.Server.AutoTranslation
+	th.Server.AutoTranslation = mockAutotranslation
+	defer func() {
+		th.Server.AutoTranslation = originalAutoTranslation
+	}()
+
+	channel := th.CreatePublicChannel(t)
+	_, appErr := th.App.AddUserToChannel(th.Context, th.BasicUser2, channel, false)
+	require.Nil(t, appErr)
+
+	t.Run("user can disable own autotranslation", func(t *testing.T) {
+		_, err := client.UpdateChannelMemberAutotranslation(context.Background(), channel.Id, th.BasicUser.Id, true)
+		require.NoError(t, err)
+
+		member, _, err := client.GetChannelMember(context.Background(), channel.Id, th.BasicUser.Id, "")
+		require.NoError(t, err)
+		require.True(t, member.AutoTranslationDisabled, "autotranslation should be disabled")
+	})
+
+	t.Run("user can enable own autotranslation", func(t *testing.T) {
+		_, err := client.UpdateChannelMemberAutotranslation(context.Background(), channel.Id, th.BasicUser.Id, false)
+		require.NoError(t, err)
+
+		member, _, err := client.GetChannelMember(context.Background(), channel.Id, th.BasicUser.Id, "")
+		require.NoError(t, err)
+		require.False(t, member.AutoTranslationDisabled, "autotranslation should be enabled")
+	})
+
+	t.Run("user cannot update other user autotranslation without permission", func(t *testing.T) {
+		resp, err := client.UpdateChannelMemberAutotranslation(context.Background(), channel.Id, th.BasicUser2.Id, true)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+
+		member, _, err := client.GetChannelMember(context.Background(), channel.Id, th.BasicUser2.Id, "")
+		require.NoError(t, err)
+		require.False(t, member.AutoTranslationDisabled, "autotranslation should remain enabled when update is forbidden")
+	})
+
+	t.Run("user with PermissionEditOtherUsers can update other user autotranslation", func(t *testing.T) {
+		_, err := th.SystemAdminClient.UpdateChannelMemberAutotranslation(context.Background(), channel.Id, th.BasicUser2.Id, true)
+		require.NoError(t, err)
+
+		member, _, err := th.SystemAdminClient.GetChannelMember(context.Background(), channel.Id, th.BasicUser2.Id, "")
+		require.NoError(t, err)
+		require.True(t, member.AutoTranslationDisabled, "autotranslation should be disabled")
+	})
+
+	t.Run("feature is disabled returns forbidden response", func(t *testing.T) {
+		// Use a dedicated mock so IsFeatureAvailable returns false. The handler returns
+		// before calling IsChannelEnabled/Translate, so we only need this expectation.
+		featureDisabledMock := &einterfacesmocks.AutoTranslationInterface{}
+		featureDisabledMock.On("IsFeatureAvailable").Return(false)
+		th.Server.AutoTranslation = featureDisabledMock
+		defer func() { th.Server.AutoTranslation = mockAutotranslation }()
+
+		resp, err := client.UpdateChannelMemberAutotranslation(context.Background(), channel.Id, th.BasicUser.Id, true)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("channel autotranslation is disabled returns bad request", func(t *testing.T) {
+		// Use a dedicated mock so IsChannelEnabled returns false.
+		channelDisabledMock := &einterfacesmocks.AutoTranslationInterface{}
+		channelDisabledMock.On("IsFeatureAvailable").Return(true)
+		channelDisabledMock.On("IsChannelEnabled", channel.Id).Return(false, nil)
+		th.Server.AutoTranslation = channelDisabledMock
+		defer func() { th.Server.AutoTranslation = mockAutotranslation }()
+
+		resp, err := client.UpdateChannelMemberAutotranslation(context.Background(), channel.Id, th.BasicUser.Id, true)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+	})
+
+	t.Run("invalid channel id returns bad request", func(t *testing.T) {
+		resp, err := client.UpdateChannelMemberAutotranslation(context.Background(), "junk", th.BasicUser.Id, true)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+	})
+
+	t.Run("invalid user id returns bad request", func(t *testing.T) {
+		resp, err := client.UpdateChannelMemberAutotranslation(context.Background(), channel.Id, "junk", true)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+	})
+
+	t.Run("nonexistent channel returns not found", func(t *testing.T) {
+		resp, err := client.UpdateChannelMemberAutotranslation(context.Background(), model.NewId(), th.BasicUser.Id, true)
+		require.Error(t, err)
+		CheckNotFoundStatus(t, resp)
+	})
+
+	t.Run("nonexistent user returns not found", func(t *testing.T) {
+		// Use SystemAdminClient so permission check passes and we get the "member not found" error from the app
+		resp, err := th.SystemAdminClient.UpdateChannelMemberAutotranslation(context.Background(), channel.Id, model.NewId(), true)
+		require.Error(t, err)
+		CheckNotFoundStatus(t, resp)
+	})
+
+	t.Run("unauthorized when not logged in", func(t *testing.T) {
+		_, err := client.Logout(context.Background())
+		require.NoError(t, err)
+		defer th.LoginBasic(t)
+
+		resp, err := client.UpdateChannelMemberAutotranslation(context.Background(), channel.Id, th.BasicUser.Id, true)
+		require.Error(t, err)
+		CheckUnauthorizedStatus(t, resp)
+	})
 }
 
 func TestUpdateChannelNotifyProps(t *testing.T) {

--- a/server/channels/app/access_control.go
+++ b/server/channels/app/access_control.go
@@ -229,6 +229,8 @@ func (a *App) UnassignPoliciesFromChannels(rctx request.CTX, policyID string, ch
 			if err := acs.DeletePolicy(rctx, child.ID); err != nil {
 				return model.NewAppError("UnassignPoliciesFromChannels", "app.pap.unassign_access_control_policy_from_channels.app_error", nil, err.Error(), http.StatusInternalServerError)
 			}
+			// invalidate the channel cache
+			a.Srv().Store().Channel().InvalidateChannel(channelID)
 			continue
 		}
 		_, appErr = acs.SavePolicy(rctx, child)

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -1587,6 +1587,23 @@ func (a *App) UpdateChannelMemberNotifyProps(rctx request.CTX, data map[string]s
 	return member, nil
 }
 
+func (a *App) UpdateChannelMemberAutotranslation(rctx request.CTX, channelID string, userID string, autoTranslationDisabled bool) (*model.ChannelMember, *model.AppError) {
+	member, err := a.GetChannelMember(rctx, channelID, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	member.AutoTranslationDisabled = autoTranslationDisabled
+	member, err = a.updateChannelMember(rctx, member)
+	if err != nil {
+		return nil, err
+	}
+
+	a.Srv().Store().AutoTranslation().InvalidateUserAutoTranslation(userID, channelID)
+
+	return member, nil
+}
+
 func (a *App) PatchChannelMembersNotifyProps(rctx request.CTX, members []*model.ChannelMemberIdentifier, notifyProps map[string]string) ([]*model.ChannelMember, *model.AppError) {
 	if len(members) > UpdateMultipleMaximum {
 		return nil, model.NewAppError("PatchChannelMembersNotifyProps", "app.channel.patch_channel_members_notify_props.too_many", map[string]any{"Max": UpdateMultipleMaximum}, "", http.StatusBadRequest)

--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -1680,6 +1680,46 @@ func TestUpdateChannelMemberRolesRequireUser(t *testing.T) {
 	})
 }
 
+func TestUpdateChannelMemberAutotranslation(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	t.Run("disable autotranslation", func(t *testing.T) {
+		updatedMember, appErr := th.App.UpdateChannelMemberAutotranslation(th.Context, th.BasicChannel.Id, th.BasicUser.Id, true)
+		require.Nil(t, appErr)
+		require.True(t, updatedMember.AutoTranslationDisabled, "autotranslation should be disabled")
+
+		member, appErr := th.App.GetChannelMember(th.Context, th.BasicChannel.Id, th.BasicUser.Id)
+		require.Nil(t, appErr)
+		require.True(t, member.AutoTranslationDisabled, "autotranslation disabled should persist as true")
+	})
+
+	t.Run("enable autotranslation", func(t *testing.T) {
+		_, appErr := th.App.UpdateChannelMemberAutotranslation(th.Context, th.BasicChannel.Id, th.BasicUser.Id, true)
+		require.Nil(t, appErr)
+
+		updatedMember, appErr := th.App.UpdateChannelMemberAutotranslation(th.Context, th.BasicChannel.Id, th.BasicUser.Id, false)
+		require.Nil(t, appErr)
+		require.False(t, updatedMember.AutoTranslationDisabled, "autotranslation should be enabled")
+
+		member, appErr := th.App.GetChannelMember(th.Context, th.BasicChannel.Id, th.BasicUser.Id)
+		require.Nil(t, appErr)
+		require.False(t, member.AutoTranslationDisabled, "autotranslation disabled should persist as false")
+	})
+
+	t.Run("nonexistent channel returns not found", func(t *testing.T) {
+		_, appErr := th.App.UpdateChannelMemberAutotranslation(th.Context, model.NewId(), th.BasicUser.Id, true)
+		require.NotNil(t, appErr)
+		require.Equal(t, http.StatusNotFound, appErr.StatusCode)
+	})
+
+	t.Run("nonexistent user returns not found", func(t *testing.T) {
+		_, appErr := th.App.UpdateChannelMemberAutotranslation(th.Context, th.BasicChannel.Id, model.NewId(), true)
+		require.NotNil(t, appErr)
+		require.Equal(t, http.StatusNotFound, appErr.StatusCode)
+	})
+}
+
 func TestDefaultChannelNames(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t)

--- a/server/channels/app/group.go
+++ b/server/channels/app/group.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/utils"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 )
 
@@ -25,7 +26,10 @@ func (a *App) GetGroup(id string, opts *model.GetGroupOpts, viewRestrictions *mo
 	}
 
 	if opts != nil && opts.IncludeMemberIDs {
-		users, err := a.Srv().Store().Group().GetMemberUsers(id)
+		perPage := 100
+		users, err := utils.Pager(func(page int) ([]*model.User, error) {
+			return a.Srv().Store().Group().GetMemberUsersPage(id, page, perPage, viewRestrictions)
+		}, perPage)
 		if err != nil {
 			return nil, model.NewAppError("GetGroup", "app.member_count", nil, "", http.StatusInternalServerError).Wrap(err)
 		}

--- a/server/channels/app/post_metadata.go
+++ b/server/channels/app/post_metadata.go
@@ -130,7 +130,7 @@ func (a *App) populatePostListTranslations(rctx request.CTX, list *model.PostLis
 			continue
 		}
 
-		translationsMap, err := a.AutoTranslation().GetBatch(postIDs, userLang)
+		translationsMap, err := a.AutoTranslation().GetBatch(model.TranslationObjectTypePost, postIDs, userLang)
 		if err != nil {
 			var notAvailErr *model.ErrAutoTranslationNotAvailable
 			if errors.As(err, &notAvailErr) {

--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -311,3 +311,5 @@ channels/db/migrations/postgres/000155_add_translation_state.down.sql
 channels/db/migrations/postgres/000155_add_translation_state.up.sql
 channels/db/migrations/postgres/000156_add_autotranslationdisabled_to_channelmembers.down.sql
 channels/db/migrations/postgres/000156_add_autotranslationdisabled_to_channelmembers.up.sql
+channels/db/migrations/postgres/000157_translations_primary_key_change.down.sql
+channels/db/migrations/postgres/000157_translations_primary_key_change.up.sql

--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -309,3 +309,5 @@ channels/db/migrations/postgres/000154_create_recaps.down.sql
 channels/db/migrations/postgres/000154_create_recaps.up.sql
 channels/db/migrations/postgres/000155_add_translation_state.down.sql
 channels/db/migrations/postgres/000155_add_translation_state.up.sql
+channels/db/migrations/postgres/000156_add_autotranslationdisabled_to_channelmembers.down.sql
+channels/db/migrations/postgres/000156_add_autotranslationdisabled_to_channelmembers.up.sql

--- a/server/channels/db/migrations/postgres/000156_add_autotranslationdisabled_to_channelmembers.down.sql
+++ b/server/channels/db/migrations/postgres/000156_add_autotranslationdisabled_to_channelmembers.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE channelmembers DROP COLUMN IF EXISTS autotranslationdisabled;

--- a/server/channels/db/migrations/postgres/000156_add_autotranslationdisabled_to_channelmembers.up.sql
+++ b/server/channels/db/migrations/postgres/000156_add_autotranslationdisabled_to_channelmembers.up.sql
@@ -1,0 +1,4 @@
+-- Add new autotranslationdisabled column (opt-out semantics)
+-- Default false means autotranslation is ENABLED by default
+ALTER TABLE channelmembers
+    ADD COLUMN IF NOT EXISTS autotranslationdisabled boolean NOT NULL DEFAULT false;

--- a/server/channels/db/migrations/postgres/000157_translations_primary_key_change.down.sql
+++ b/server/channels/db/migrations/postgres/000157_translations_primary_key_change.down.sql
@@ -1,0 +1,6 @@
+-- Revert primary key (WARNING: will fail if duplicate objectId+dstLang exist)
+ALTER TABLE translations DROP CONSTRAINT translations_pkey;
+ALTER TABLE translations ADD PRIMARY KEY (objectId, dstLang);
+
+-- Allow NULL objectType again
+ALTER TABLE translations ALTER COLUMN objectType DROP NOT NULL;

--- a/server/channels/db/migrations/postgres/000157_translations_primary_key_change.up.sql
+++ b/server/channels/db/migrations/postgres/000157_translations_primary_key_change.up.sql
@@ -1,0 +1,9 @@
+-- Safety: Set objectType to 'post' for any NULL rows (table should be empty)
+UPDATE translations SET objectType = 'post' WHERE objectType IS NULL;
+
+-- Make objectType NOT NULL
+ALTER TABLE translations ALTER COLUMN objectType SET NOT NULL;
+
+-- Change primary key to include objectType
+ALTER TABLE translations DROP CONSTRAINT translations_pkey;
+ALTER TABLE translations ADD PRIMARY KEY (objectId, objectType, dstLang);

--- a/server/channels/store/localcachelayer/autotranslation_layer.go
+++ b/server/channels/store/localcachelayer/autotranslation_layer.go
@@ -88,28 +88,6 @@ func (s LocalCacheAutoTranslationStore) IsUserEnabled(userID, channelID string) 
 	return enabled, nil
 }
 
-// SetUserEnabled sets auto-translation status for a user in a channel and invalidates cache
-func (s LocalCacheAutoTranslationStore) SetUserEnabled(userID, channelID string, enabled bool) error {
-	err := s.AutoTranslationStore.SetUserEnabled(userID, channelID, enabled)
-	if err != nil {
-		return err
-	}
-
-	// Invalidate user auto-translation cache
-	userKey := userAutoTranslationKey(userID, channelID)
-	s.rootStore.doInvalidateCacheCluster(s.rootStore.userAutoTranslationCache, userKey, nil)
-
-	// Invalidate user language cache (for safety, in case locale changed while disabled)
-	langKey := userLanguageKey(userID, channelID)
-	s.rootStore.doInvalidateCacheCluster(s.rootStore.userAutoTranslationCache, langKey, nil)
-
-	if s.rootStore.metrics != nil {
-		s.rootStore.metrics.IncrementMemCacheInvalidationCounter(s.rootStore.userAutoTranslationCache.Name())
-	}
-
-	return nil
-}
-
 // GetUserLanguage gets the user's language preference for a channel (with caching)
 func (s LocalCacheAutoTranslationStore) GetUserLanguage(userID, channelID string) (string, error) {
 	key := userLanguageKey(userID, channelID)

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -1115,27 +1115,6 @@ func (s *RetryLayerAutoTranslationStore) SetChannelEnabled(channelID string, ena
 
 }
 
-func (s *RetryLayerAutoTranslationStore) SetUserEnabled(userID string, channelID string, enabled bool) error {
-
-	tries := 0
-	for {
-		err := s.AutoTranslationStore.SetUserEnabled(userID, channelID, enabled)
-		if err == nil {
-			return nil
-		}
-		if !isRepeatableError(err) {
-			return err
-		}
-		tries++
-		if tries >= 3 {
-			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
-			return err
-		}
-		timepkg.Sleep(100 * timepkg.Millisecond)
-	}
-
-}
-
 func (s *RetryLayerBotStore) Get(userID string, includeDeleted bool) (*model.Bot, error) {
 
 	tries := 0

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -872,11 +872,11 @@ func (s *RetryLayerAutoTranslationStore) ClearCaches() {
 
 }
 
-func (s *RetryLayerAutoTranslationStore) Get(objectID string, dstLang string) (*model.Translation, error) {
+func (s *RetryLayerAutoTranslationStore) Get(objectType string, objectID string, dstLang string) (*model.Translation, error) {
 
 	tries := 0
 	for {
-		result, err := s.AutoTranslationStore.Get(objectID, dstLang)
+		result, err := s.AutoTranslationStore.Get(objectType, objectID, dstLang)
 		if err == nil {
 			return result, nil
 		}
@@ -935,11 +935,11 @@ func (s *RetryLayerAutoTranslationStore) GetAllByStatePage(state model.Translati
 
 }
 
-func (s *RetryLayerAutoTranslationStore) GetAllForObject(objectID string) ([]*model.Translation, error) {
+func (s *RetryLayerAutoTranslationStore) GetAllForObject(objectType string, objectID string) ([]*model.Translation, error) {
 
 	tries := 0
 	for {
-		result, err := s.AutoTranslationStore.GetAllForObject(objectID)
+		result, err := s.AutoTranslationStore.GetAllForObject(objectType, objectID)
 		if err == nil {
 			return result, nil
 		}
@@ -956,11 +956,11 @@ func (s *RetryLayerAutoTranslationStore) GetAllForObject(objectID string) ([]*mo
 
 }
 
-func (s *RetryLayerAutoTranslationStore) GetBatch(objectIDs []string, dstLang string) (map[string]*model.Translation, error) {
+func (s *RetryLayerAutoTranslationStore) GetBatch(objectType string, objectIDs []string, dstLang string) (map[string]*model.Translation, error) {
 
 	tries := 0
 	for {
-		result, err := s.AutoTranslationStore.GetBatch(objectIDs, dstLang)
+		result, err := s.AutoTranslationStore.GetBatch(objectType, objectIDs, dstLang)
 		if err == nil {
 			return result, nil
 		}

--- a/server/channels/store/sqlstore/autotranslation_store.go
+++ b/server/channels/store/sqlstore/autotranslation_store.go
@@ -102,44 +102,21 @@ func (s *SqlAutoTranslationStore) SetChannelEnabled(channelID string, enabled bo
 
 func (s *SqlAutoTranslationStore) IsUserEnabled(userID, channelID string) (bool, error) {
 	query := s.getQueryBuilder().
-		Select("cm.AutoTranslation").
+		Select("cm.AutoTranslationDisabled").
 		From("ChannelMembers cm").
 		Join("Channels c ON cm.Channelid = c.id").
 		Where(sq.Eq{"cm.UserId": userID, "cm.ChannelId": channelID}).
 		Where("c.AutoTranslation = true")
 
-	var enabled bool
-	if err := s.GetReplica().GetBuilder(&enabled, query); err != nil {
+	var disabled bool
+	if err := s.GetReplica().GetBuilder(&disabled, query); err != nil {
 		if err == sql.ErrNoRows {
 			return false, nil
 		}
 		return false, errors.Wrapf(err, "failed to get user enabled status for user_id=%s, channel_id=%s", userID, channelID)
 	}
 
-	return enabled, nil
-}
-
-func (s *SqlAutoTranslationStore) SetUserEnabled(userID, channelID string, enabled bool) error {
-	query := s.getQueryBuilder().
-		Update("ChannelMembers").
-		Set("AutoTranslation", enabled).
-		Where(sq.Eq{"UserId": userID, "ChannelId": channelID})
-
-	result, err := s.GetMaster().ExecBuilder(query)
-	if err != nil {
-		return errors.Wrapf(err, "failed to set user enabled for user_id=%s, channel_id=%s", userID, channelID)
-	}
-
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return errors.Wrap(err, "failed to get rows affected for SetUserEnabled")
-	}
-
-	if rowsAffected == 0 {
-		return store.NewErrNotFound("ChannelMember", userID+":"+channelID)
-	}
-
-	return nil
+	return !disabled, nil
 }
 
 func (s *SqlAutoTranslationStore) GetUserLanguage(userID, channelID string) (string, error) {
@@ -150,7 +127,7 @@ func (s *SqlAutoTranslationStore) GetUserLanguage(userID, channelID string) (str
 		Join("Channels c ON cm.ChannelId = c.Id").
 		Where(sq.Eq{"u.Id": userID, "c.Id": channelID}).
 		Where("c.AutoTranslation = true").
-		Where("cm.AutoTranslation = true")
+		Where("cm.AutoTranslationDisabled = false")
 
 	var locale string
 	if err := s.GetReplica().GetBuilder(&locale, query); err != nil {
@@ -171,7 +148,7 @@ func (s *SqlAutoTranslationStore) GetActiveDestinationLanguages(channelID, exclu
 		Join("Users u ON u.Id = cm.UserId").
 		Where(sq.Eq{"cm.ChannelId": channelID}).
 		Where("c.AutoTranslation = true").
-		Where("cm.AutoTranslation = true")
+		Where("cm.AutoTranslationDisabled = false")
 
 	// Filter to specific user IDs if provided (e.g., users with active WebSocket connections)
 	// When filterUserIDs is non-nil and non-empty, squirrel converts it to an IN clause

--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -52,20 +52,21 @@ type channelMember struct {
 
 func NewMapFromChannelMemberModel(cm *model.ChannelMember) map[string]any {
 	return map[string]any{
-		"ChannelId":          cm.ChannelId,
-		"UserId":             cm.UserId,
-		"Roles":              cm.ExplicitRoles,
-		"LastViewedAt":       cm.LastViewedAt,
-		"MsgCount":           cm.MsgCount,
-		"MentionCount":       cm.MentionCount,
-		"MentionCountRoot":   cm.MentionCountRoot,
-		"UrgentMentionCount": cm.UrgentMentionCount,
-		"MsgCountRoot":       cm.MsgCountRoot,
-		"NotifyProps":        cm.NotifyProps,
-		"LastUpdateAt":       cm.LastUpdateAt,
-		"SchemeGuest":        sql.NullBool{Valid: true, Bool: cm.SchemeGuest},
-		"SchemeUser":         sql.NullBool{Valid: true, Bool: cm.SchemeUser},
-		"SchemeAdmin":        sql.NullBool{Valid: true, Bool: cm.SchemeAdmin},
+		"ChannelId":               cm.ChannelId,
+		"UserId":                  cm.UserId,
+		"Roles":                   cm.ExplicitRoles,
+		"LastViewedAt":            cm.LastViewedAt,
+		"MsgCount":                cm.MsgCount,
+		"MentionCount":            cm.MentionCount,
+		"MentionCountRoot":        cm.MentionCountRoot,
+		"UrgentMentionCount":      cm.UrgentMentionCount,
+		"MsgCountRoot":            cm.MsgCountRoot,
+		"NotifyProps":             cm.NotifyProps,
+		"LastUpdateAt":            cm.LastUpdateAt,
+		"SchemeGuest":             sql.NullBool{Valid: true, Bool: cm.SchemeGuest},
+		"SchemeUser":              sql.NullBool{Valid: true, Bool: cm.SchemeUser},
+		"SchemeAdmin":             sql.NullBool{Valid: true, Bool: cm.SchemeAdmin},
+		"AutoTranslationDisabled": cm.AutoTranslationDisabled,
 	}
 }
 
@@ -90,6 +91,7 @@ type channelMemberWithSchemeRoles struct {
 	ChannelSchemeDefaultUserRole  sql.NullString
 	ChannelSchemeDefaultAdminRole sql.NullString
 	MsgCountRoot                  int64
+	AutoTranslationDisabled       bool
 }
 
 type channelMemberWithTeamWithSchemeRoles struct {
@@ -102,7 +104,7 @@ type channelMemberWithTeamWithSchemeRoles struct {
 type channelMemberWithTeamWithSchemeRolesList []channelMemberWithTeamWithSchemeRoles
 
 func channelMemberSliceColumns() []string {
-	return []string{"ChannelId", "UserId", "Roles", "LastViewedAt", "MsgCount", "MsgCountRoot", "MentionCount", "MentionCountRoot", "UrgentMentionCount", "NotifyProps", "LastUpdateAt", "SchemeUser", "SchemeAdmin", "SchemeGuest"}
+	return []string{"ChannelId", "UserId", "Roles", "LastViewedAt", "MsgCount", "MsgCountRoot", "MentionCount", "MentionCountRoot", "UrgentMentionCount", "NotifyProps", "LastUpdateAt", "SchemeUser", "SchemeAdmin", "SchemeGuest", "AutoTranslationDisabled"}
 }
 
 // channelSliceColumns returns fields of the channel as a string slice.
@@ -195,6 +197,7 @@ func channelMemberToSlice(member *model.ChannelMember) []any {
 	resultSlice = append(resultSlice, member.SchemeUser)
 	resultSlice = append(resultSlice, member.SchemeAdmin)
 	resultSlice = append(resultSlice, member.SchemeGuest)
+	resultSlice = append(resultSlice, member.AutoTranslationDisabled)
 	return resultSlice
 }
 
@@ -310,21 +313,22 @@ func (db channelMemberWithSchemeRoles) ToModel() *model.ChannelMember {
 		strings.Fields(db.Roles),
 	)
 	return &model.ChannelMember{
-		ChannelId:          db.ChannelId,
-		UserId:             db.UserId,
-		Roles:              strings.Join(rolesResult.roles, " "),
-		LastViewedAt:       db.LastViewedAt,
-		MsgCount:           db.MsgCount,
-		MsgCountRoot:       db.MsgCountRoot,
-		MentionCount:       db.MentionCount,
-		MentionCountRoot:   db.MentionCountRoot,
-		UrgentMentionCount: db.UrgentMentionCount,
-		NotifyProps:        db.NotifyProps,
-		LastUpdateAt:       db.LastUpdateAt,
-		SchemeAdmin:        rolesResult.schemeAdmin,
-		SchemeUser:         rolesResult.schemeUser,
-		SchemeGuest:        rolesResult.schemeGuest,
-		ExplicitRoles:      strings.Join(rolesResult.explicitRoles, " "),
+		ChannelId:               db.ChannelId,
+		UserId:                  db.UserId,
+		Roles:                   strings.Join(rolesResult.roles, " "),
+		LastViewedAt:            db.LastViewedAt,
+		MsgCount:                db.MsgCount,
+		MsgCountRoot:            db.MsgCountRoot,
+		MentionCount:            db.MentionCount,
+		MentionCountRoot:        db.MentionCountRoot,
+		UrgentMentionCount:      db.UrgentMentionCount,
+		NotifyProps:             db.NotifyProps,
+		LastUpdateAt:            db.LastUpdateAt,
+		SchemeAdmin:             rolesResult.schemeAdmin,
+		SchemeUser:              rolesResult.schemeUser,
+		SchemeGuest:             rolesResult.schemeGuest,
+		ExplicitRoles:           strings.Join(rolesResult.explicitRoles, " "),
+		AutoTranslationDisabled: db.AutoTranslationDisabled,
 	}
 }
 
@@ -374,21 +378,22 @@ func (db channelMemberWithTeamWithSchemeRoles) ToModel() *model.ChannelMemberWit
 	)
 	return &model.ChannelMemberWithTeamData{
 		ChannelMember: model.ChannelMember{
-			ChannelId:          db.ChannelId,
-			UserId:             db.UserId,
-			Roles:              strings.Join(rolesResult.roles, " "),
-			LastViewedAt:       db.LastViewedAt,
-			MsgCount:           db.MsgCount,
-			MsgCountRoot:       db.MsgCountRoot,
-			MentionCount:       db.MentionCount,
-			MentionCountRoot:   db.MentionCountRoot,
-			UrgentMentionCount: db.UrgentMentionCount,
-			NotifyProps:        db.NotifyProps,
-			LastUpdateAt:       db.LastUpdateAt,
-			SchemeAdmin:        rolesResult.schemeAdmin,
-			SchemeUser:         rolesResult.schemeUser,
-			SchemeGuest:        rolesResult.schemeGuest,
-			ExplicitRoles:      strings.Join(rolesResult.explicitRoles, " "),
+			ChannelId:               db.ChannelId,
+			UserId:                  db.UserId,
+			Roles:                   strings.Join(rolesResult.roles, " "),
+			LastViewedAt:            db.LastViewedAt,
+			MsgCount:                db.MsgCount,
+			MsgCountRoot:            db.MsgCountRoot,
+			MentionCount:            db.MentionCount,
+			MentionCountRoot:        db.MentionCountRoot,
+			UrgentMentionCount:      db.UrgentMentionCount,
+			NotifyProps:             db.NotifyProps,
+			LastUpdateAt:            db.LastUpdateAt,
+			SchemeAdmin:             rolesResult.schemeAdmin,
+			SchemeUser:              rolesResult.schemeUser,
+			SchemeGuest:             rolesResult.schemeGuest,
+			ExplicitRoles:           strings.Join(rolesResult.explicitRoles, " "),
+			AutoTranslationDisabled: db.AutoTranslationDisabled,
 		},
 		TeamName:        db.TeamName,
 		TeamDisplayName: db.TeamDisplayName,
@@ -530,6 +535,7 @@ func (s *SqlChannelStore) initializeQueries() {
 			"ChannelScheme.DefaultChannelGuestRole ChannelSchemeDefaultGuestRole",
 			"ChannelScheme.DefaultChannelUserRole ChannelSchemeDefaultUserRole",
 			"ChannelScheme.DefaultChannelAdminRole ChannelSchemeDefaultAdminRole",
+			"ChannelMembers.AutoTranslationDisabled",
 		).
 		From("ChannelMembers").
 		InnerJoin("Channels ON ChannelMembers.ChannelId = Channels.Id").
@@ -1628,6 +1634,7 @@ var channelMembersWithSchemeSelectQuery = `
 		ChannelMembers.SchemeUser,
 		ChannelMembers.SchemeAdmin,
 		ChannelMembers.SchemeGuest,
+		ChannelMembers.AutoTranslationDisabled,
 		COALESCE(Teams.DisplayName, '') TeamDisplayName,
 		COALESCE(Teams.Name, '') TeamName,
 		COALESCE(Teams.UpdateAt, 0) TeamUpdateAt,
@@ -2189,6 +2196,7 @@ func (s SqlChannelStore) GetMemberForPost(postId string, userId string) (*model.
 			ChannelMembers.SchemeUser,
 			ChannelMembers.SchemeAdmin,
 			ChannelMembers.SchemeGuest,
+			ChannelMembers.AutoTranslationDisabled,
 			TeamScheme.DefaultChannelGuestRole TeamSchemeDefaultGuestRole,
 			TeamScheme.DefaultChannelUserRole TeamSchemeDefaultUserRole,
 			TeamScheme.DefaultChannelAdminRole TeamSchemeDefaultAdminRole,
@@ -3968,7 +3976,8 @@ func (s SqlChannelStore) GetChannelMembersForExport(userId string, teamId string
 		ChannelMembers.SchemeUser,
 		ChannelMembers.SchemeAdmin,
 		(ChannelMembers.SchemeGuest IS NOT NULL AND ChannelMembers.SchemeGuest) as SchemeGuest,
-		Channels.Name as ChannelName
+		Channels.Name as ChannelName,
+		ChannelMembers.AutoTranslationDisabled
 	FROM
 		ChannelMembers
 	INNER JOIN
@@ -4019,7 +4028,7 @@ func (s SqlChannelStore) GetAllDirectChannelsForExportAfter(limit int, afterId s
 		channelIds = append(channelIds, channel.Id)
 	}
 	query = s.getQueryBuilder().
-		Select("u.Username as Username, ChannelId, UserId, cm.Roles as Roles, LastViewedAt, MsgCount, MsgCountRoot, MentionCount, MentionCountRoot, COALESCE(UrgentMentionCount, 0) UrgentMentionCount, cm.NotifyProps as NotifyProps, LastUpdateAt, SchemeUser, SchemeAdmin, (SchemeGuest IS NOT NULL AND SchemeGuest) as SchemeGuest").
+		Select("u.Username as Username, ChannelId, UserId, cm.Roles as Roles, LastViewedAt, MsgCount, MsgCountRoot, MentionCount, MentionCountRoot, COALESCE(UrgentMentionCount, 0) UrgentMentionCount, cm.NotifyProps as NotifyProps, LastUpdateAt, SchemeUser, SchemeAdmin, (SchemeGuest IS NOT NULL AND SchemeGuest) as SchemeGuest, cm.AutoTranslationDisabled as AutoTranslationDisabled").
 		From("ChannelMembers cm").
 		Join("Users u ON ( u.Id = cm.UserId )").
 		Where(sq.Eq{"cm.ChannelId": channelIds})

--- a/server/channels/store/sqlstore/channel_store_test.go
+++ b/server/channels/store/sqlstore/channel_store_test.go
@@ -80,6 +80,7 @@ func testNewMapFromChannelMemberModel(t *testing.T) {
 	assert.Equal(t, sql.NullBool{Bool: true, Valid: true}, db["SchemeUser"])
 	assert.Equal(t, sql.NullBool{Bool: true, Valid: true}, db["SchemeAdmin"])
 	assert.Equal(t, m.ExplicitRoles, db["Roles"])
+	assert.Equal(t, m.AutoTranslationDisabled, db["AutoTranslationDisabled"])
 }
 
 func testChannelMemberWithSchemeRolesToModel(t *testing.T) {

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -1163,7 +1163,6 @@ type AutoTranslationStore interface {
 	IsChannelEnabled(channelID string) (bool, error)
 	SetChannelEnabled(channelID string, enabled bool) error
 	IsUserEnabled(userID, channelID string) (bool, error)
-	SetUserEnabled(userID, channelID string, enabled bool) error
 	GetUserLanguage(userID, channelID string) (string, error)
 	// GetActiveDestinationLanguages returns distinct locales of users who have auto-translation enabled.
 	GetActiveDestinationLanguages(channelID, excludeUserID string, filterUserIDs []string) ([]string, error)

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -1166,9 +1166,9 @@ type AutoTranslationStore interface {
 	GetUserLanguage(userID, channelID string) (string, error)
 	// GetActiveDestinationLanguages returns distinct locales of users who have auto-translation enabled.
 	GetActiveDestinationLanguages(channelID, excludeUserID string, filterUserIDs []string) ([]string, error)
-	Get(objectID, dstLang string) (*model.Translation, error)
-	GetBatch(objectIDs []string, dstLang string) (map[string]*model.Translation, error)
-	GetAllForObject(objectID string) ([]*model.Translation, error)
+	Get(objectType, objectID, dstLang string) (*model.Translation, error)
+	GetBatch(objectType string, objectIDs []string, dstLang string) (map[string]*model.Translation, error)
+	GetAllForObject(objectType, objectID string) ([]*model.Translation, error)
 	Save(translation *model.Translation) error
 	GetAllByStatePage(state model.TranslationState, offset, limit int) ([]*model.Translation, error)
 	GetByStateOlderThan(state model.TranslationState, olderThanMillis int64, limit int) ([]*model.Translation, error)

--- a/server/channels/store/storetest/autotranslation.go
+++ b/server/channels/store/storetest/autotranslation.go
@@ -18,7 +18,6 @@ func TestAutoTranslationStore(t *testing.T, rctx request.CTX, ss store.Store, s 
 	t.Run("IsChannelEnabled", func(t *testing.T) { testAutoTranslationIsChannelEnabled(t, rctx, ss) })
 	t.Run("SetChannelEnabled", func(t *testing.T) { testAutoTranslationSetChannelEnabled(t, rctx, ss) })
 	t.Run("IsUserEnabled", func(t *testing.T) { testAutoTranslationIsUserEnabled(t, rctx, ss) })
-	t.Run("SetUserEnabled", func(t *testing.T) { testAutoTranslationSetUserEnabled(t, rctx, ss) })
 	t.Run("GetUserLanguage", func(t *testing.T) { testAutoTranslationGetUserLanguage(t, rctx, ss) })
 	t.Run("GetActiveDestinationLanguages", func(t *testing.T) { testAutoTranslationGetActiveDestinationLanguages(t, rctx, ss) })
 }
@@ -207,7 +206,11 @@ func testAutoTranslationIsUserEnabled(t *testing.T, rctx request.CTX, ss store.S
 		appErr := ss.AutoTranslation().SetChannelEnabled(channel.Id, true)
 		require.NoError(t, appErr)
 
-		// User autotranslation is disabled by default
+		// Disable user autotranslation (AutoTranslationDisabled = true means disabled)
+		member.AutoTranslationDisabled = true
+		_, appErr = ss.Channel().UpdateMember(rctx, member)
+		require.NoError(t, appErr)
+
 		enabled, appErr := ss.AutoTranslation().IsUserEnabled(user.Id, channel.Id)
 		require.NoError(t, appErr)
 		assert.False(t, enabled)
@@ -219,7 +222,8 @@ func testAutoTranslationIsUserEnabled(t *testing.T, rctx request.CTX, ss store.S
 		require.NoError(t, appErr)
 
 		// Enable user autotranslation
-		appErr = ss.AutoTranslation().SetUserEnabled(user.Id, channel.Id, true)
+		member.AutoTranslationDisabled = false
+		_, appErr = ss.Channel().UpdateMember(rctx, member)
 		require.NoError(t, appErr)
 
 		// Verify both are enabled
@@ -234,7 +238,8 @@ func testAutoTranslationIsUserEnabled(t *testing.T, rctx request.CTX, ss store.S
 		require.NoError(t, appErr)
 
 		// Disable user autotranslation
-		appErr = ss.AutoTranslation().SetUserEnabled(user.Id, channel.Id, false)
+		member.AutoTranslationDisabled = true
+		_, appErr = ss.Channel().UpdateMember(rctx, member)
 		require.NoError(t, appErr)
 
 		// Verify user is disabled
@@ -247,66 +252,6 @@ func testAutoTranslationIsUserEnabled(t *testing.T, rctx request.CTX, ss store.S
 		enabled, appErr := ss.AutoTranslation().IsUserEnabled("nonexistent", channel.Id)
 		require.NoError(t, appErr)
 		assert.False(t, enabled)
-	})
-}
-
-func testAutoTranslationSetUserEnabled(t *testing.T, rctx request.CTX, ss store.Store) {
-	// Setup: Create team, channel, and user
-	team := &model.Team{
-		DisplayName: "Test Team",
-		Name:        "test-team-" + model.NewId(),
-		Email:       "test@example.com",
-		Type:        model.TeamOpen,
-	}
-	team, err := ss.Team().Save(team)
-	require.NoError(t, err)
-
-	channel := &model.Channel{
-		TeamId:      team.Id,
-		DisplayName: "Test Channel",
-		Name:        "test-channel-" + model.NewId(),
-		Type:        model.ChannelTypeOpen,
-	}
-	channel, nErr := ss.Channel().Save(rctx, channel, 999)
-	require.NoError(t, nErr)
-
-	user := &model.User{
-		Email:    "test@example.com",
-		Username: "testuser" + model.NewId(),
-		Locale:   "en",
-	}
-	user, nErr = ss.User().Save(rctx, user)
-	require.NoError(t, nErr)
-
-	defer func() {
-		_ = ss.Team().PermanentDelete(team.Id)
-		_ = ss.Channel().PermanentDelete(rctx, channel.Id)
-		_ = ss.User().PermanentDelete(rctx, user.Id)
-	}()
-
-	// Add user to channel
-	member := &model.ChannelMember{
-		ChannelId:   channel.Id,
-		UserId:      user.Id,
-		NotifyProps: model.GetDefaultChannelNotifyProps(),
-	}
-	_, nErr = ss.Channel().SaveMember(rctx, member)
-	require.NoError(t, nErr)
-
-	t.Run("successfully enables user autotranslation", func(t *testing.T) {
-		appErr := ss.AutoTranslation().SetUserEnabled(user.Id, channel.Id, true)
-		require.NoError(t, appErr)
-	})
-
-	t.Run("successfully disables user autotranslation", func(t *testing.T) {
-		appErr := ss.AutoTranslation().SetUserEnabled(user.Id, channel.Id, false)
-		require.NoError(t, appErr)
-	})
-
-	t.Run("returns error for non-existent user or channel", func(t *testing.T) {
-		err := ss.AutoTranslation().SetUserEnabled("nonexistent", channel.Id, true)
-		assert.Error(t, err)
-		assert.True(t, store.IsErrNotFound(err))
 	})
 }
 
@@ -353,6 +298,7 @@ func testAutoTranslationGetUserLanguage(t *testing.T, rctx request.CTX, ss store
 		_ = ss.User().PermanentDelete(rctx, userES.Id)
 	}()
 
+	members := make(map[string]*model.ChannelMember)
 	// Add users to channel
 	for _, user := range []*model.User{userEN, userES} {
 		member := &model.ChannelMember{
@@ -362,6 +308,7 @@ func testAutoTranslationGetUserLanguage(t *testing.T, rctx request.CTX, ss store
 		}
 		_, nErr = ss.Channel().SaveMember(rctx, member)
 		require.NoError(t, nErr)
+		members[user.Id] = member
 	}
 
 	t.Run("returns empty when channel disabled", func(t *testing.T) {
@@ -374,6 +321,11 @@ func testAutoTranslationGetUserLanguage(t *testing.T, rctx request.CTX, ss store
 		appErr := ss.AutoTranslation().SetChannelEnabled(channel.Id, true)
 		require.NoError(t, appErr)
 
+		// Disable user autotranslation (AutoTranslationDisabled = true means disabled)
+		members[userEN.Id].AutoTranslationDisabled = true
+		_, appErr = ss.Channel().UpdateMember(rctx, members[userEN.Id])
+		require.NoError(t, appErr)
+
 		locale, appErr := ss.AutoTranslation().GetUserLanguage(userEN.Id, channel.Id)
 		require.NoError(t, appErr)
 		assert.Empty(t, locale)
@@ -384,8 +336,9 @@ func testAutoTranslationGetUserLanguage(t *testing.T, rctx request.CTX, ss store
 		appErr := ss.AutoTranslation().SetChannelEnabled(channel.Id, true)
 		require.NoError(t, appErr)
 
-		// Enable user
-		appErr = ss.AutoTranslation().SetUserEnabled(userEN.Id, channel.Id, true)
+		// Enable user (set AutoTranslationDisabled = false)
+		members[userEN.Id].AutoTranslationDisabled = false
+		_, appErr = ss.Channel().UpdateMember(rctx, members[userEN.Id])
 		require.NoError(t, appErr)
 
 		// Get language
@@ -399,10 +352,12 @@ func testAutoTranslationGetUserLanguage(t *testing.T, rctx request.CTX, ss store
 		appErr := ss.AutoTranslation().SetChannelEnabled(channel.Id, true)
 		require.NoError(t, appErr)
 
-		// Enable both users
-		appErr = ss.AutoTranslation().SetUserEnabled(userEN.Id, channel.Id, true)
+		// Enable both users (set AutoTranslationDisabled = false)
+		members[userEN.Id].AutoTranslationDisabled = false
+		_, appErr = ss.Channel().UpdateMember(rctx, members[userEN.Id])
 		require.NoError(t, appErr)
-		appErr = ss.AutoTranslation().SetUserEnabled(userES.Id, channel.Id, true)
+		members[userES.Id].AutoTranslationDisabled = false
+		_, appErr = ss.Channel().UpdateMember(rctx, members[userES.Id])
 		require.NoError(t, appErr)
 
 		// Verify English user
@@ -465,14 +420,11 @@ func testAutoTranslationGetActiveDestinationLanguages(t *testing.T, rctx request
 			UserId:      user.Id,
 			NotifyProps: model.GetDefaultChannelNotifyProps(),
 		}
+		if i >= 4 { // Disable autotranslation for 5th user only
+			member.AutoTranslationDisabled = true
+		}
 		_, nErr = ss.Channel().SaveMember(rctx, member)
 		require.NoError(t, nErr)
-
-		// Enable autotranslation for first 4 users only
-		if i < 4 {
-			appErr := ss.AutoTranslation().SetUserEnabled(user.Id, channel.Id, true)
-			require.NoError(t, appErr)
-		}
 	}
 
 	t.Run("returns empty when channel disabled", func(t *testing.T) {

--- a/server/channels/store/storetest/mocks/AutoTranslationStore.go
+++ b/server/channels/store/storetest/mocks/AutoTranslationStore.go
@@ -19,9 +19,9 @@ func (_m *AutoTranslationStore) ClearCaches() {
 	_m.Called()
 }
 
-// Get provides a mock function with given fields: objectID, dstLang
-func (_m *AutoTranslationStore) Get(objectID string, dstLang string) (*model.Translation, error) {
-	ret := _m.Called(objectID, dstLang)
+// Get provides a mock function with given fields: objectType, objectID, dstLang
+func (_m *AutoTranslationStore) Get(objectType string, objectID string, dstLang string) (*model.Translation, error) {
+	ret := _m.Called(objectType, objectID, dstLang)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
@@ -29,19 +29,19 @@ func (_m *AutoTranslationStore) Get(objectID string, dstLang string) (*model.Tra
 
 	var r0 *model.Translation
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string) (*model.Translation, error)); ok {
-		return rf(objectID, dstLang)
+	if rf, ok := ret.Get(0).(func(string, string, string) (*model.Translation, error)); ok {
+		return rf(objectType, objectID, dstLang)
 	}
-	if rf, ok := ret.Get(0).(func(string, string) *model.Translation); ok {
-		r0 = rf(objectID, dstLang)
+	if rf, ok := ret.Get(0).(func(string, string, string) *model.Translation); ok {
+		r0 = rf(objectType, objectID, dstLang)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Translation)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(objectID, dstLang)
+	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = rf(objectType, objectID, dstLang)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -109,9 +109,9 @@ func (_m *AutoTranslationStore) GetAllByStatePage(state model.TranslationState, 
 	return r0, r1
 }
 
-// GetAllForObject provides a mock function with given fields: objectID
-func (_m *AutoTranslationStore) GetAllForObject(objectID string) ([]*model.Translation, error) {
-	ret := _m.Called(objectID)
+// GetAllForObject provides a mock function with given fields: objectType, objectID
+func (_m *AutoTranslationStore) GetAllForObject(objectType string, objectID string) ([]*model.Translation, error) {
+	ret := _m.Called(objectType, objectID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllForObject")
@@ -119,19 +119,19 @@ func (_m *AutoTranslationStore) GetAllForObject(objectID string) ([]*model.Trans
 
 	var r0 []*model.Translation
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) ([]*model.Translation, error)); ok {
-		return rf(objectID)
+	if rf, ok := ret.Get(0).(func(string, string) ([]*model.Translation, error)); ok {
+		return rf(objectType, objectID)
 	}
-	if rf, ok := ret.Get(0).(func(string) []*model.Translation); ok {
-		r0 = rf(objectID)
+	if rf, ok := ret.Get(0).(func(string, string) []*model.Translation); ok {
+		r0 = rf(objectType, objectID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.Translation)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(objectID)
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(objectType, objectID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -139,9 +139,9 @@ func (_m *AutoTranslationStore) GetAllForObject(objectID string) ([]*model.Trans
 	return r0, r1
 }
 
-// GetBatch provides a mock function with given fields: objectIDs, dstLang
-func (_m *AutoTranslationStore) GetBatch(objectIDs []string, dstLang string) (map[string]*model.Translation, error) {
-	ret := _m.Called(objectIDs, dstLang)
+// GetBatch provides a mock function with given fields: objectType, objectIDs, dstLang
+func (_m *AutoTranslationStore) GetBatch(objectType string, objectIDs []string, dstLang string) (map[string]*model.Translation, error) {
+	ret := _m.Called(objectType, objectIDs, dstLang)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetBatch")
@@ -149,19 +149,19 @@ func (_m *AutoTranslationStore) GetBatch(objectIDs []string, dstLang string) (ma
 
 	var r0 map[string]*model.Translation
 	var r1 error
-	if rf, ok := ret.Get(0).(func([]string, string) (map[string]*model.Translation, error)); ok {
-		return rf(objectIDs, dstLang)
+	if rf, ok := ret.Get(0).(func(string, []string, string) (map[string]*model.Translation, error)); ok {
+		return rf(objectType, objectIDs, dstLang)
 	}
-	if rf, ok := ret.Get(0).(func([]string, string) map[string]*model.Translation); ok {
-		r0 = rf(objectIDs, dstLang)
+	if rf, ok := ret.Get(0).(func(string, []string, string) map[string]*model.Translation); ok {
+		r0 = rf(objectType, objectIDs, dstLang)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]*model.Translation)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func([]string, string) error); ok {
-		r1 = rf(objectIDs, dstLang)
+	if rf, ok := ret.Get(1).(func(string, []string, string) error); ok {
+		r1 = rf(objectType, objectIDs, dstLang)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -804,10 +804,10 @@ func (s *TimerLayerAutoTranslationStore) ClearCaches() {
 	}
 }
 
-func (s *TimerLayerAutoTranslationStore) Get(objectID string, dstLang string) (*model.Translation, error) {
+func (s *TimerLayerAutoTranslationStore) Get(objectType string, objectID string, dstLang string) (*model.Translation, error) {
 	start := time.Now()
 
-	result, err := s.AutoTranslationStore.Get(objectID, dstLang)
+	result, err := s.AutoTranslationStore.Get(objectType, objectID, dstLang)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -852,10 +852,10 @@ func (s *TimerLayerAutoTranslationStore) GetAllByStatePage(state model.Translati
 	return result, err
 }
 
-func (s *TimerLayerAutoTranslationStore) GetAllForObject(objectID string) ([]*model.Translation, error) {
+func (s *TimerLayerAutoTranslationStore) GetAllForObject(objectType string, objectID string) ([]*model.Translation, error) {
 	start := time.Now()
 
-	result, err := s.AutoTranslationStore.GetAllForObject(objectID)
+	result, err := s.AutoTranslationStore.GetAllForObject(objectType, objectID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -868,10 +868,10 @@ func (s *TimerLayerAutoTranslationStore) GetAllForObject(objectID string) ([]*mo
 	return result, err
 }
 
-func (s *TimerLayerAutoTranslationStore) GetBatch(objectIDs []string, dstLang string) (map[string]*model.Translation, error) {
+func (s *TimerLayerAutoTranslationStore) GetBatch(objectType string, objectIDs []string, dstLang string) (map[string]*model.Translation, error) {
 	start := time.Now()
 
-	result, err := s.AutoTranslationStore.GetBatch(objectIDs, dstLang)
+	result, err := s.AutoTranslationStore.GetBatch(objectType, objectIDs, dstLang)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -1010,22 +1010,6 @@ func (s *TimerLayerAutoTranslationStore) SetChannelEnabled(channelID string, ena
 	return err
 }
 
-func (s *TimerLayerAutoTranslationStore) SetUserEnabled(userID string, channelID string, enabled bool) error {
-	start := time.Now()
-
-	err := s.AutoTranslationStore.SetUserEnabled(userID, channelID, enabled)
-
-	elapsed := float64(time.Since(start)) / float64(time.Second)
-	if s.Root.Metrics != nil {
-		success := "false"
-		if err == nil {
-			success = "true"
-		}
-		s.Root.Metrics.ObserveStoreMethodDuration("AutoTranslationStore.SetUserEnabled", success, elapsed)
-	}
-	return err
-}
-
 func (s *TimerLayerBotStore) Get(userID string, includeDeleted bool) (*model.Bot, error) {
 	start := time.Now()
 

--- a/server/cmd/mmctl/commands/report.go
+++ b/server/cmd/mmctl/commands/report.go
@@ -149,7 +149,7 @@ func printReportPost(post *model.Post) {
 		fmt.Fprintf(os.Stdout, "Channel ID: %s\n", post.ChannelId)
 		fmt.Fprintf(os.Stdout, "Created At: %s\n", createdAt)
 		fmt.Fprintf(os.Stdout, "Updated At: %s\n", updatedAt)
-		fmt.Fprintf(os.Stdout, "Message: %s\n", post.Message)
+		fmt.Fprintf(os.Stdout, "Message: %s\n", printer.SanitizeForTerminal(post.Message))
 		if post.DeleteAt > 0 {
 			deletedAt := time.Unix(post.DeleteAt/1000, 0).Format("2006-01-02 15:04:05")
 			fmt.Fprintf(os.Stdout, "Deleted At: %s\n", deletedAt)

--- a/server/cmd/mmctl/printer/printer.go
+++ b/server/cmd/mmctl/printer/printer.go
@@ -273,7 +273,10 @@ func (p Printer) linesToBytes(opts printOpts) (b []byte, err error) {
 	case FormatPlain:
 		var buf bytes.Buffer
 		for i := range p.Lines {
-			fmt.Fprintf(&buf, "%s%s", p.Lines[i], newline)
+			// Sanitize output to prevent terminal escape injection attacks
+			// when writing user-controlled content to the terminal
+			line := fmt.Sprintf("%s", p.Lines[i])
+			fmt.Fprintf(&buf, "%s%s", SanitizeForTerminal(line), newline)
 		}
 		b = buf.Bytes()
 	case FormatJSON:

--- a/server/cmd/mmctl/printer/printer_helpers.go
+++ b/server/cmd/mmctl/printer/printer_helpers.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package printer
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Precompiled regex for terminal escape sequence sanitization.
+// References:
+// - XTerm Control Sequences: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+var (
+	// csiRegex matches ANSI CSI sequences (colors, cursor movement, etc).
+	csiRegex = regexp.MustCompile(`\x1b\[[0-9;?]*[A-Za-z]`)
+
+	// oscRegex matches OSC sequences (window title, clipboard, etc).
+	oscRegex = regexp.MustCompile(`\x1b\]([^\x07\x1b]|\x1b[^\\])*(\x07|\x1b\\)`)
+
+	// dcsRegex matches DCS sequences (device control).
+	dcsRegex = regexp.MustCompile(`\x1bP([^\x1b]|\x1b[^\\])*\x1b\\`)
+
+	// otherEscRegex matches other escape sequences (APC, PM, single-char).
+	otherEscRegex = regexp.MustCompile(`\x1b[_^X]([^\x1b]|\x1b[^\\])*\x1b\\|\x1b[^\[\]P0-9]`)
+)
+
+// SanitizeForTerminal strips ANSI escape sequences and control characters from
+// user-controlled content to prevent terminal injection attacks.
+// It preserves tabs, newlines, and carriage returns for readability.
+func SanitizeForTerminal(s string) string {
+	// Remove ANSI CSI sequences
+	result := csiRegex.ReplaceAllString(s, "")
+
+	// Remove OSC sequences
+	result = oscRegex.ReplaceAllString(result, "")
+
+	// Remove DCS sequences
+	result = dcsRegex.ReplaceAllString(result, "")
+
+	// Remove other escape sequences
+	result = otherEscRegex.ReplaceAllString(result, "")
+
+	// Remove remaining control characters (0x00-0x1F, 0x7F) except tab, newline, carriage return.
+	var cleaned strings.Builder
+	cleaned.Grow(len(result))
+	for _, r := range result {
+		switch {
+		case r == '\t' || r == '\n' || r == '\r':
+			// Keep whitespace
+			cleaned.WriteRune(r)
+		case r < 0x20 || r == 0x7F:
+			// Skip control characters
+			continue
+		default:
+			cleaned.WriteRune(r)
+		}
+	}
+
+	return cleaned.String()
+}

--- a/server/cmd/mmctl/printer/printer_helpers_test.go
+++ b/server/cmd/mmctl/printer/printer_helpers_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package printer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeForTerminal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "plain text unchanged",
+			input:    "Hello, World!",
+			expected: "Hello, World!",
+		},
+		{
+			name:     "preserves newlines and tabs",
+			input:    "Line 1\nLine 2\tTabbed",
+			expected: "Line 1\nLine 2\tTabbed",
+		},
+		{
+			name:     "removes ANSI color codes",
+			input:    "\x1b[31mRed Text\x1b[0m",
+			expected: "Red Text",
+		},
+		{
+			name:     "removes cursor movement sequences",
+			input:    "\x1b[2J\x1b[H\x1b[1;1HMalicious content",
+			expected: "Malicious content",
+		},
+		{
+			name:     "removes OSC clipboard hijacking (BEL terminated)",
+			input:    "Normal text\x1b]52;c;SGVsbG8gV29ybGQ=\x07more text",
+			expected: "Normal textmore text",
+		},
+		{
+			name:     "removes OSC clipboard hijacking (ST terminated)",
+			input:    "Normal text\x1b]52;c;SGVsbG8gV29ybGQ=\x1b\\more text",
+			expected: "Normal textmore text",
+		},
+		{
+			name:     "removes OSC window title manipulation",
+			input:    "\x1b]0;Fake Terminal Title\x07Real content",
+			expected: "Real content",
+		},
+		{
+			name:     "removes screen clearing sequences",
+			input:    "\x1b[2J\x1b[3JCleared screen",
+			expected: "Cleared screen",
+		},
+		{
+			name:     "removes bold/underline formatting",
+			input:    "\x1b[1mBold\x1b[0m \x1b[4mUnderline\x1b[0m",
+			expected: "Bold Underline",
+		},
+		{
+			name:     "removes multiple escape sequences",
+			input:    "\x1b[31m\x1b[1m\x1b[4mStyled\x1b[0m",
+			expected: "Styled",
+		},
+		{
+			name:     "removes control characters (NUL, BEL, etc)",
+			input:    "Hello\x00World\x07Test\x08Back",
+			expected: "HelloWorldTestBack",
+		},
+		{
+			name:     "removes DEL character",
+			input:    "Hello\x7fWorld",
+			expected: "HelloWorld",
+		},
+		{
+			name:     "handles complex attack payload",
+			input:    "\x1b[2J\x1b[H\x1b]0;HACKED\x07\x1b[31mFake error!\x1b[0m\nEnter password: ",
+			expected: "Fake error!\nEnter password: ",
+		},
+		{
+			name:     "removes DCS sequences",
+			input:    "Before\x1bPsome DCS content\x1b\\After",
+			expected: "BeforeAfter",
+		},
+		{
+			name:     "handles empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "handles unicode text with escape sequences",
+			input:    "\x1b[31m你好世界\x1b[0m emoji: 🎉",
+			expected: "你好世界 emoji: 🎉",
+		},
+		{
+			name:     "removes CSI with parameters",
+			input:    "\x1b[38;5;196mExtended color\x1b[0m",
+			expected: "Extended color",
+		},
+		{
+			name:     "removes CSI with question mark",
+			input:    "\x1b[?25lHide cursor\x1b[?25h",
+			expected: "Hide cursor",
+		},
+		{
+			name:     "preserves carriage return",
+			input:    "Line with\rcarriage return",
+			expected: "Line with\rcarriage return",
+		},
+		{
+			name:     "removes APC sequences",
+			input:    "Before\x1b_APC content\x1b\\After",
+			expected: "BeforeAfter",
+		},
+		{
+			name:     "removes nested escape attempts",
+			input:    "\x1b[31m\x1b]0;title\x07nested\x1b[0m",
+			expected: "nested",
+		},
+		{
+			name:     "handles realistic malicious message",
+			input:    "Please run: \x1b[2J\x1b[Hsudo rm -rf /\x1b]52;c;cm0gLXJmIC8=\x07",
+			expected: "Please run: sudo rm -rf /",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeForTerminal(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/server/einterfaces/autotranslation.go
+++ b/server/einterfaces/autotranslation.go
@@ -32,10 +32,6 @@ type AutoTranslationInterface interface {
 	// Returns false if the feature is unavailable or the user hasn't opted in.
 	IsUserEnabled(channelID, userID string) (bool, *model.AppError)
 
-	// SetUserEnabled enables or disables auto-translation for a user in a channel.
-	// Only available when the feature is properly licensed and configured.
-	SetUserEnabled(channelID, userID string, enabled bool) *model.AppError
-
 	// Translate translates content in a channel.
 	//
 	// Parameters:

--- a/server/einterfaces/autotranslation.go
+++ b/server/einterfaces/autotranslation.go
@@ -53,7 +53,7 @@ type AutoTranslationInterface interface {
 	// GetBatch fetches a batch of translations for a list of object IDs and a destination language.
 	// This is used for efficiently populating translations for list views (e.g., channel history).
 	// Returns error if the feature is unavailable.
-	GetBatch(objectIDs []string, dstLang string) (map[string]*model.Translation, *model.AppError)
+	GetBatch(objectType string, objectIDs []string, dstLang string) (map[string]*model.Translation, *model.AppError)
 
 	// GetUserLanguage returns the preferred language for a user in a channel if auto-translation is enabled.
 	// Returns the language code or error if feature is unavailable.

--- a/server/einterfaces/mocks/AutoTranslationInterface.go
+++ b/server/einterfaces/mocks/AutoTranslationInterface.go
@@ -76,9 +76,9 @@ func (_m *AutoTranslationInterface) DetectRemote(ctx context.Context, text strin
 	return r0, r1, r2
 }
 
-// GetBatch provides a mock function with given fields: objectIDs, dstLang
-func (_m *AutoTranslationInterface) GetBatch(objectIDs []string, dstLang string) (map[string]*model.Translation, *model.AppError) {
-	ret := _m.Called(objectIDs, dstLang)
+// GetBatch provides a mock function with given fields: objectType, objectIDs, dstLang
+func (_m *AutoTranslationInterface) GetBatch(objectType string, objectIDs []string, dstLang string) (map[string]*model.Translation, *model.AppError) {
+	ret := _m.Called(objectType, objectIDs, dstLang)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetBatch")
@@ -86,19 +86,19 @@ func (_m *AutoTranslationInterface) GetBatch(objectIDs []string, dstLang string)
 
 	var r0 map[string]*model.Translation
 	var r1 *model.AppError
-	if rf, ok := ret.Get(0).(func([]string, string) (map[string]*model.Translation, *model.AppError)); ok {
-		return rf(objectIDs, dstLang)
+	if rf, ok := ret.Get(0).(func(string, []string, string) (map[string]*model.Translation, *model.AppError)); ok {
+		return rf(objectType, objectIDs, dstLang)
 	}
-	if rf, ok := ret.Get(0).(func([]string, string) map[string]*model.Translation); ok {
-		r0 = rf(objectIDs, dstLang)
+	if rf, ok := ret.Get(0).(func(string, []string, string) map[string]*model.Translation); ok {
+		r0 = rf(objectType, objectIDs, dstLang)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]*model.Translation)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func([]string, string) *model.AppError); ok {
-		r1 = rf(objectIDs, dstLang)
+	if rf, ok := ret.Get(1).(func(string, []string, string) *model.AppError); ok {
+		r1 = rf(objectType, objectIDs, dstLang)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -1922,6 +1922,10 @@
     "translation": "Server is busy, non-critical services are temporarily unavailable."
   },
   {
+    "id": "api.context.session_cookie_not_allowed.app_error",
+    "translation": "Cookie-based authentication is not allowed for this endpoint. Please use header-based authentication."
+  },
+  {
     "id": "api.context.session_expired.app_error",
     "translation": "Invalid or expired session, please login again."
   },

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -572,6 +572,14 @@
     "translation": "You are not allowed to update the name, display_name, and purpose of direct or group messages."
   },
   {
+    "id": "api.channel.update_channel_member_autotranslation.channel_not_enabled.app_error",
+    "translation": "Auto-translation is not enabled for this channel."
+  },
+  {
+    "id": "api.channel.update_channel_member_autotranslation.feature_not_available.app_error",
+    "translation": "Auto-translation is not available."
+  },
+  {
     "id": "api.channel.update_channel_member_roles.changing_guest_role.app_error",
     "translation": "Invalid channel member update: You can't add or remove the guest role manually."
   },

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -11746,11 +11746,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "Version 142+"
+    "translation": "Version 144+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "Version 142+"
+    "translation": "Version 144+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",

--- a/server/i18n/ko.json
+++ b/server/i18n/ko.json
@@ -10394,11 +10394,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "버전 142+"
+    "translation": "버전 144+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "버전 142+"
+    "translation": "버전 144+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",

--- a/server/i18n/ko.json
+++ b/server/i18n/ko.json
@@ -10394,11 +10394,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "버전 144+"
+    "translation": "버전 142+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "버전 144+"
+    "translation": "버전 142+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",

--- a/server/public/model/audit_events.go
+++ b/server/public/model/audit_events.go
@@ -58,32 +58,33 @@ const (
 
 // Channels
 const (
-	AuditEventAddChannelMember               = "addChannelMember"               // add member to channel
-	AuditEventConvertGroupMessageToChannel   = "convertGroupMessageToChannel"   // convert group message to private channel
-	AuditEventCreateChannel                  = "createChannel"                  // create public or private channel
-	AuditEventCreateDirectChannel            = "createDirectChannel"            // create direct message channel between two users
-	AuditEventCreateGroupChannel             = "createGroupChannel"             // create group message channel with multiple users
-	AuditEventDeleteChannel                  = "deleteChannel"                  // delete channel
-	AuditEventGetPinnedPosts                 = "getPinnedPosts"                 // get pinned posts
-	AuditEventLocalAddChannelMember          = "localAddChannelMember"          // add channel member locally
-	AuditEventLocalCreateChannel             = "localCreateChannel"             // create channel locally
-	AuditEventLocalDeleteChannel             = "localDeleteChannel"             // delete channel locally
-	AuditEventLocalMoveChannel               = "localMoveChannel"               // move channel locally
-	AuditEventLocalPatchChannel              = "localPatchChannel"              // patch channel locally
-	AuditEventLocalRemoveChannelMember       = "localRemoveChannelMember"       // remove channel member locally
-	AuditEventLocalRestoreChannel            = "localRestoreChannel"            // restore channel locally
-	AuditEventLocalUpdateChannelPrivacy      = "localUpdateChannelPrivacy"      // update channel privacy locally
-	AuditEventMoveChannel                    = "moveChannel"                    // move channel to different team
-	AuditEventPatchChannel                   = "patchChannel"                   // update channel properties
-	AuditEventPatchChannelModerations        = "patchChannelModerations"        // update channel moderation settings
-	AuditEventRemoveChannelMember            = "removeChannelMember"            // remove member from channel
-	AuditEventRestoreChannel                 = "restoreChannel"                 // restore previously deleted channel
-	AuditEventUpdateChannel                  = "updateChannel"                  // update channel properties
-	AuditEventUpdateChannelMemberNotifyProps = "updateChannelMemberNotifyProps" // update notification preferences
-	AuditEventUpdateChannelMemberRoles       = "updateChannelMemberRoles"       // update roles and permissions
-	AuditEventUpdateChannelMemberSchemeRoles = "updateChannelMemberSchemeRoles" // update scheme-based roles
-	AuditEventUpdateChannelPrivacy           = "updateChannelPrivacy"           // change channel privacy settings
-	AuditEventUpdateChannelScheme            = "updateChannelScheme"            // update permission scheme applied to channel
+	AuditEventAddChannelMember                   = "addChannelMember"                   // add member to channel
+	AuditEventConvertGroupMessageToChannel       = "convertGroupMessageToChannel"       // convert group message to private channel
+	AuditEventCreateChannel                      = "createChannel"                      // create public or private channel
+	AuditEventCreateDirectChannel                = "createDirectChannel"                // create direct message channel between two users
+	AuditEventCreateGroupChannel                 = "createGroupChannel"                 // create group message channel with multiple users
+	AuditEventDeleteChannel                      = "deleteChannel"                      // delete channel
+	AuditEventGetPinnedPosts                     = "getPinnedPosts"                     // get pinned posts
+	AuditEventLocalAddChannelMember              = "localAddChannelMember"              // add channel member locally
+	AuditEventLocalCreateChannel                 = "localCreateChannel"                 // create channel locally
+	AuditEventLocalDeleteChannel                 = "localDeleteChannel"                 // delete channel locally
+	AuditEventLocalMoveChannel                   = "localMoveChannel"                   // move channel locally
+	AuditEventLocalPatchChannel                  = "localPatchChannel"                  // patch channel locally
+	AuditEventLocalRemoveChannelMember           = "localRemoveChannelMember"           // remove channel member locally
+	AuditEventLocalRestoreChannel                = "localRestoreChannel"                // restore channel locally
+	AuditEventLocalUpdateChannelPrivacy          = "localUpdateChannelPrivacy"          // update channel privacy locally
+	AuditEventMoveChannel                        = "moveChannel"                        // move channel to different team
+	AuditEventPatchChannel                       = "patchChannel"                       // update channel properties
+	AuditEventPatchChannelModerations            = "patchChannelModerations"            // update channel moderation settings
+	AuditEventRemoveChannelMember                = "removeChannelMember"                // remove member from channel
+	AuditEventRestoreChannel                     = "restoreChannel"                     // restore previously deleted channel
+	AuditEventUpdateChannel                      = "updateChannel"                      // update channel properties
+	AuditEventUpdateChannelMemberNotifyProps     = "updateChannelMemberNotifyProps"     // update notification preferences
+	AuditEventUpdateChannelMemberAutotranslation = "updateChannelMemberAutotranslation" // update autotranslation setting
+	AuditEventUpdateChannelMemberRoles           = "updateChannelMemberRoles"           // update roles and permissions
+	AuditEventUpdateChannelMemberSchemeRoles     = "updateChannelMemberSchemeRoles"     // update scheme-based roles
+	AuditEventUpdateChannelPrivacy               = "updateChannelPrivacy"               // change channel privacy settings
+	AuditEventUpdateChannelScheme                = "updateChannelScheme"                // update permission scheme applied to channel
 )
 
 // Commands

--- a/server/public/model/channel_member.go
+++ b/server/public/model/channel_member.go
@@ -52,21 +52,22 @@ type ChannelUnreadAt struct {
 }
 
 type ChannelMember struct {
-	ChannelId          string    `json:"channel_id"`
-	UserId             string    `json:"user_id"`
-	Roles              string    `json:"roles"`
-	LastViewedAt       int64     `json:"last_viewed_at"`
-	MsgCount           int64     `json:"msg_count"`
-	MentionCount       int64     `json:"mention_count"`
-	MentionCountRoot   int64     `json:"mention_count_root"`
-	UrgentMentionCount int64     `json:"urgent_mention_count"`
-	MsgCountRoot       int64     `json:"msg_count_root"`
-	NotifyProps        StringMap `json:"notify_props"`
-	LastUpdateAt       int64     `json:"last_update_at"`
-	SchemeGuest        bool      `json:"scheme_guest"`
-	SchemeUser         bool      `json:"scheme_user"`
-	SchemeAdmin        bool      `json:"scheme_admin"`
-	ExplicitRoles      string    `json:"explicit_roles"`
+	ChannelId               string    `json:"channel_id"`
+	UserId                  string    `json:"user_id"`
+	Roles                   string    `json:"roles"`
+	LastViewedAt            int64     `json:"last_viewed_at"`
+	MsgCount                int64     `json:"msg_count"`
+	MentionCount            int64     `json:"mention_count"`
+	MentionCountRoot        int64     `json:"mention_count_root"`
+	UrgentMentionCount      int64     `json:"urgent_mention_count"`
+	MsgCountRoot            int64     `json:"msg_count_root"`
+	NotifyProps             StringMap `json:"notify_props"`
+	LastUpdateAt            int64     `json:"last_update_at"`
+	SchemeGuest             bool      `json:"scheme_guest"`
+	SchemeUser              bool      `json:"scheme_user"`
+	SchemeAdmin             bool      `json:"scheme_admin"`
+	ExplicitRoles           string    `json:"explicit_roles"`
+	AutoTranslationDisabled bool      `json:"autotranslation_disabled"`
 }
 
 func (o *ChannelMember) Auditable() map[string]any {

--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -3261,6 +3261,17 @@ func (c *Client4) UpdateChannelNotifyProps(ctx context.Context, channelId, userI
 	return BuildResponse(r), nil
 }
 
+// UpdateChannelMemberAutotranslation will update the autotranslation setting for a user in a channel.
+func (c *Client4) UpdateChannelMemberAutotranslation(ctx context.Context, channelId, userId string, autoTranslationDisabled bool) (*Response, error) {
+	requestBody := map[string]any{"autotranslation_disabled": autoTranslationDisabled}
+	r, err := c.doAPIPutJSON(ctx, c.channelMemberRoute(channelId, userId).Join("autotranslation"), requestBody)
+	if err != nil {
+		return BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return BuildResponse(r), nil
+}
+
 // AddChannelMember adds user to channel and return a channel member.
 func (c *Client4) AddChannelMember(ctx context.Context, channelId, userId string) (*ChannelMember, *Response, error) {
 	requestBody := map[string]string{"user_id": userId}


### PR DESCRIPTION
## Summary
- upstream-master 2026-02-05자 커밋 8건 정밀 분석 후 반영 (cherry-pick 5 / adapt 3)
- adapt 2건은 DB 마이그레이션 번호 충돌(우리 자체 마이그레이션과 겹침)을 재번호로 해결: 000151→000156, 000152→000157
- i18n 후속: en.json 브라우저 최소버전(142+→144+) 갱신에 맞춰 ko.json 동기화

## Commits
- (fix): verified by label and playwright rerun on failed specs (#35161)
- Update en.json (#35160)
- apply view restrcitions while fetching group members (#35172)
- Add endpoint to update channel member autotranslations (#35072) — adapt, migration 000151→000156
- Improve mmctl output by filtering escape sequences (#35191)
- Update translation primary key to include objectType (#35040) — adapt, migration 000152→000157
- invalidate channel cache after deleting a channel access control policy (#35174)
- [MM-67126] harden checks (#35171)
- i18n: sync ko min_browser_version with upstream 144+ bump
- docs: upstream sync 진행 (picked 5, adapted 3)

## Test plan
- [x] 접촉 패키지 `go build` / `go vet` 통과 (channels/api4, channels/app, channels/store, cmd/mmctl, einterfaces, public/model)
- [x] `golangci-lint run` 결과 이번 세션 변경 파일에 신규 이슈 없음 확인 (기존 gofmt/CRLF 노이즈·무관 파일의 사전 존재 이슈만 검출)
- [ ] server go test 미실행 — 이 환경은 testlib.MainHelper의 symlink 생성이 Windows에서 panic하는 알려진 제약으로 실행 불가