### PR TITLE
i18n: sync ko min_browser_version with upstream 144+ bump

### DIFF
--- a/server/i18n/ko.json
+++ b/server/i18n/ko.json
@@ -10394,11 +10394,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "버전 142+"
+    "translation": "버전 144+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "버전 142+"
+    "translation": "버전 144+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",


### PR DESCRIPTION
en.json의 Chrome/Edge 최소 지원 버전이 142+ → 144+로 갱신됨(444ada72,
#35160)에 따라 ko.json 번역도 동일하게 맞춘다. weblate 아닌 PR의
비영어 i18n 수정은 pr-ci i18n 체크에서 실패로 표시되지만, 저장소
룰셋에 required status check로 등록되어 있지 않아 병합 자체는
막히지 않는다.
