### PR TITLE
upstream sync 2026-08-06 (picked 6, excluded 3)

### DIFF
--- a/.github/actions/check-e2e-test-only/action.yml
+++ b/.github/actions/check-e2e-test-only/action.yml
@@ -18,7 +18,7 @@ outputs:
     description: Whether the PR contains only E2E test changes (true/false)
     value: ${{ steps.check.outputs.e2e_test_only }}
   image_tag:
-    description: Docker image tag to use (master for E2E-only, short SHA for mixed)
+    description: Docker image tag to use (base branch ref for E2E-only, short SHA for mixed)
     value: ${{ steps.check.outputs.image_tag }}
 
 runs:
@@ -33,7 +33,8 @@ runs:
         INPUT_HEAD_SHA: ${{ inputs.head_sha }}
         INPUT_PR_NUMBER: ${{ inputs.pr_number }}
       run: |
-        # Resolve SHAs from PR number if not provided
+        # Resolve SHAs and base branch from PR number if not provided
+        BASE_REF=""
         if [ -z "$INPUT_BASE_SHA" ] || [ -z "$INPUT_HEAD_SHA" ]; then
           if [ -z "$INPUT_PR_NUMBER" ]; then
             echo "::error::Either base_sha/head_sha or pr_number must be provided"
@@ -44,13 +45,23 @@ runs:
           PR_DATA=$(gh api "repos/${{ github.repository }}/pulls/${INPUT_PR_NUMBER}")
           INPUT_BASE_SHA=$(echo "$PR_DATA" | jq -r '.base.sha')
           INPUT_HEAD_SHA=$(echo "$PR_DATA" | jq -r '.head.sha')
+          BASE_REF=$(echo "$PR_DATA" | jq -r '.base.ref')
 
           if [ -z "$INPUT_BASE_SHA" ] || [ "$INPUT_BASE_SHA" = "null" ] || \
              [ -z "$INPUT_HEAD_SHA" ] || [ "$INPUT_HEAD_SHA" = "null" ]; then
             echo "::error::Could not resolve SHAs for PR #${INPUT_PR_NUMBER}"
             exit 1
           fi
+        elif [ -n "$INPUT_PR_NUMBER" ]; then
+          # SHAs provided but we still need the base branch ref
+          BASE_REF=$(gh api "repos/${{ github.repository }}/pulls/${INPUT_PR_NUMBER}" --jq '.base.ref')
         fi
+
+        # Default to master if base ref could not be determined
+        if [ -z "$BASE_REF" ] || [ "$BASE_REF" = "null" ]; then
+          BASE_REF="master"
+        fi
+        echo "PR base branch: ${BASE_REF}"
 
         SHORT_SHA="${INPUT_HEAD_SHA::7}"
 
@@ -85,8 +96,9 @@ runs:
 
         # Set outputs
         echo "e2e_test_only=${E2E_TEST_ONLY}" >> $GITHUB_OUTPUT
-        if [ "$E2E_TEST_ONLY" = "true" ]; then
-          echo "image_tag=master" >> $GITHUB_OUTPUT
+        if [ "$E2E_TEST_ONLY" = "true" ] && \
+           { [ "$BASE_REF" = "master" ] || [[ "$BASE_REF" =~ ^release-[0-9]+\.[0-9]+$ ]]; }; then
+          echo "image_tag=${BASE_REF}" >> $GITHUB_OUTPUT
         else
           echo "image_tag=${SHORT_SHA}" >> $GITHUB_OUTPUT
         fi

--- a/.github/workflows/e2e-tests-ci.yml
+++ b/.github/workflows/e2e-tests-ci.yml
@@ -1,5 +1,5 @@
 ---
-name: E2E Tests (full)
+name: E2E Tests (pull request)
 on:
   # Argo Events Trigger (automated):
   #   - Triggered by: Enterprise CI/docker-image status check (success)
@@ -72,16 +72,31 @@ jobs:
           # Argo Events trigger: commit SHA provided, resolve PR number
           if [ -n "$INPUT_COMMIT_SHA" ]; then
             echo "Automated trigger: resolving PR number from commit ${INPUT_COMMIT_SHA}"
-            PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${INPUT_COMMIT_SHA}/pulls" \
-              --jq '.[0].number // empty' 2>/dev/null || echo "")
-            if [ -n "$PR_NUMBER" ]; then
-              echo "Found PR #${PR_NUMBER} for commit ${INPUT_COMMIT_SHA}"
-              echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_OUTPUT
-              echo "COMMIT_SHA=${INPUT_COMMIT_SHA}" >> $GITHUB_OUTPUT
-            else
+            PR_DATA=$(gh api "repos/${{ github.repository }}/commits/${INPUT_COMMIT_SHA}/pulls" \
+              --jq '.[0] // empty' 2>/dev/null || echo "")
+            PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number // empty' 2>/dev/null || echo "")
+            if [ -z "$PR_NUMBER" ]; then
               echo "::error::No PR found for commit ${INPUT_COMMIT_SHA}. This workflow is for PRs only."
               exit 1
             fi
+
+            echo "Found PR #${PR_NUMBER} for commit ${INPUT_COMMIT_SHA}"
+
+            # Skip if PR is already merged to master or a release branch.
+            # The e2e-tests-on-merge workflow handles post-merge E2E tests.
+            PR_MERGED=$(echo "$PR_DATA" | jq -r '.merged_at // empty' 2>/dev/null || echo "")
+            PR_BASE_REF=$(echo "$PR_DATA" | jq -r '.base.ref // empty' 2>/dev/null || echo "")
+            if [ -n "$PR_MERGED" ]; then
+              if [ "$PR_BASE_REF" = "master" ] || [[ "$PR_BASE_REF" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
+                echo "PR #${PR_NUMBER} is already merged to ${PR_BASE_REF}. Skipping - handled by e2e-tests-on-merge workflow."
+                echo "PR_NUMBER=" >> $GITHUB_OUTPUT
+                echo "COMMIT_SHA=" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+            fi
+
+            echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_OUTPUT
+            echo "COMMIT_SHA=${INPUT_COMMIT_SHA}" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -90,6 +105,7 @@ jobs:
           exit 1
 
       - name: ci/check-e2e-test-only
+        if: steps.resolve.outputs.PR_NUMBER != ''
         id: e2e-check
         uses: ./.github/actions/check-e2e-test-only
         with:
@@ -98,6 +114,7 @@ jobs:
 
   check-changes:
     needs: resolve-pr
+    if: needs.resolve-pr.outputs.PR_NUMBER != ''
     runs-on: ubuntu-24.04
     outputs:
       should_run: "${{ steps.check.outputs.should_run }}"

--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,23 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-06 14:23
+- 갱신일: 2026-08-06 15:58
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1024개
+- 남은 커밋: 1015개
 
-**마지막 반영 커밋:** `5d3a0476` | [\[MM-67605\] Add DCR redirect URI allowlist for OAuth DCR (#35291)](https://github.com/mattermost/mattermost/commit/5d3a04760b83fae43abc9e4aabf7ef1de54c7770) | 2026-02-18
+**마지막 반영 커밋:** `7590aff7` | [MM-64490 - Add ABAC system console E2E tests (#35066)](https://github.com/mattermost/mattermost/commit/7590aff7abf5f34d26c154ad203b52adc03da929) | 2026-02-19
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 31ebadd0 | [MM-66410 - standardize abac suggestions (#34446)](https://github.com/mattermost/mattermost/commit/31ebadd0b7ea5240d5dd6d3c30441bfcd6cf769a) | 2026-02-19 |
-| 0fa5e235 | [Fix Permission Request for Docs Agent (#35373)](https://github.com/mattermost/mattermost/commit/0fa5e235bc061a089ecf17830c71b7c5fe8f7c4e) | 2026-02-19 |
-| 5f9ecb7e | [MM-67091 Fixing notification titles rendering encoded values as-is (#35001)](https://github.com/mattermost/mattermost/commit/5f9ecb7e550586d807a2197cadf50df4b23f43b7) | 2026-02-19 |
-| 7ccafd79 | [Fix PR Checkout (#35375)](https://github.com/mattermost/mattermost/commit/7ccafd79886ad26a2cf71f1f845e207793d19057) | 2026-02-19 |
-| 202334aa | [Allow GH Bash Invocations (#35376)](https://github.com/mattermost/mattermost/commit/202334aaa01fba88c11e3764b6b2568ebece2870) | 2026-02-19 |
-| 4e81e504 | [Fix E2E-only PRs and duplicate E2E test runs after PR merges (#35368)](https://github.com/mattermost/mattermost/commit/4e81e504c4086b4470731ef77c2a058f253aecd5) | 2026-02-19 |
-| c45ba961 | [\[MM-67565\] Prevent setting protected=true on fields without source_plugin_id (#35265)](https://github.com/mattermost/mattermost/commit/c45ba96139d661cbf807b0874e91ee19038f48dd) | 2026-02-19 |
-| 8309cb6a | [Fix: Channels header disappears in Find Channels dialog during search (#35202)](https://github.com/mattermost/mattermost/commit/8309cb6a075a7fc76106aedd26d559a1d71fca63) | 2026-02-19 |
-| 7590aff7 | [MM-64490 - Add ABAC system console E2E tests (#35066)](https://github.com/mattermost/mattermost/commit/7590aff7abf5f34d26c154ad203b52adc03da929) | 2026-02-19 |
 | e80dec22 | [GetAllForObject, use Master instead of replica (#35356)](https://github.com/mattermost/mattermost/commit/e80dec22600820bfbdb32178e313b6cd2388dcd9) | 2026-02-20 |
 | 392253a1 | [MM-67539 Fix 'Last login' column in System Console Users table never being populated (#35239)](https://github.com/mattermost/mattermost/commit/392253a168942d09603a908e75cdddf5e39cff88) | 2026-02-20 |
 | 100cde3a | [\[MM-67587\] Exclude system messages from autotranslation queue (#35267)](https://github.com/mattermost/mattermost/commit/100cde3a1aeee2faf5a537d1cb1a280b4c24f594) | 2026-02-20 |
@@ -1052,6 +1043,12 @@
 | a8dc8baa | [\[MM-67235\] Add support for autotranslations on GM and DM (#35255)](https://github.com/mattermost/mattermost/commit/a8dc8baa905630d28c9d6966aca67c3ee01df16c) | 자동번역(AutoTranslation)을 GM/DM으로 확장하는 프론트엔드 배선(selector 리네이밍 + 채널 헤더/설정 모달 UI). 실제 번역 실행 로직은 github.com/mattermost/enterprise/autotranslation(비공개 저장소)에만 있어 okrbest에서는 작동 불가. d87527b3(flag 비활성 유지)와 동일 계열. 또한 충돌 파일(channel_header/index.ts, channel_settings_info_tab.tsx, post_list/index.tsx)이 우리 자체 커스텀 기능(봇 메시지 필터 #164/#161, 멤버 필터링 #159/#156, 채널 북마크 메뉴 개편 #195)과 겹쳐 반영 비용 대비 실익 없음. |
 
 | 45f54a0e | [Implementation of Documentation Impact Review Workflow via GH Actions (#35358)](https://github.com/mattermost/mattermost/commit/45f54a0e3fbf1c1d92af52bb228a54f027d6b1c9) | PR 코멘트 /docs-review 트리거로 Mattermost, Inc. 소유의 mattermost/docs(공식 문서 사이트 docs.mattermost.com 소스) 저장소를 체크아웃해 문서 반영 필요 여부를 분석하는 GH Actions 워크플로. 프롬프트 전체가 'Mattermost project'/docs.mattermost.com 문맥에 하드코딩돼 있어 okrbest에 그대로 켜도 우리와 무관한 upstream 공개 문서를 분석하는 무의미한 결과만 생성(ANTHROPIC_API_KEY만 소모). okrbest는 대응하는 자체 공개 문서 저장소를 운영하지 않아 adapt 대상도 없음. |
+
+| 0fa5e235 | [Fix Permission Request for Docs Agent (#35373)](https://github.com/mattermost/mattermost/commit/0fa5e235bc061a089ecf17830c71b7c5fe8f7c4e) | 부모 워크플로 45f54a0e(Documentation Impact Review Workflow)와 동일 사유로 제외 — okrbest에 docs-impact-review.yml 자체가 없어(Mattermost 공식 docs 저장소 전용, adapt 대상 없음) 그 후속 권한 수정(id-token: write 추가)도 반영할 대상이 없음. |
+
+| 7ccafd79 | [Fix PR Checkout (#35375)](https://github.com/mattermost/mattermost/commit/7ccafd79886ad26a2cf71f1f845e207793d19057) | 부모 워크플로 45f54a0e(Documentation Impact Review Workflow)와 동일 사유로 제외 — okrbest에 docs-impact-review.yml 자체가 없어 PR checkout 로직 수정(6줄)도 반영할 대상이 없음. |
+
+| 202334aa | [Allow GH Bash Invocations (#35376)](https://github.com/mattermost/mattermost/commit/202334aaa01fba88c11e3764b6b2568ebece2870) | 부모 워크플로 45f54a0e(Documentation Impact Review Workflow)와 동일 사유로 제외 — okrbest에 docs-impact-review.yml 자체가 없어 GH Bash 실행 허용 수정도 반영할 대상이 없음. |
 
 ## spec 전환 커밋
 

--- a/e2e-tests/playwright/lib/src/index.ts
+++ b/e2e-tests/playwright/lib/src/index.ts
@@ -62,3 +62,19 @@ export {
 } from './ui/components';
 
 export {TestArgs, ScreenshotOptions} from './types';
+
+// ABAC (Attribute-Based Access Control) helpers
+export {
+    createUserWithAttributes,
+    enableABAC,
+    disableABAC,
+    navigateToABACPage,
+    createBasicPolicy,
+    createAdvancedPolicy,
+    editPolicy,
+    deletePolicy,
+    runSyncJob,
+    verifyUserInChannel,
+    verifyUserNotInChannel,
+    updateUserAttributes,
+} from './server';

--- a/e2e-tests/playwright/lib/src/server/abac_helpers.ts
+++ b/e2e-tests/playwright/lib/src/server/abac_helpers.ts
@@ -1,0 +1,331 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {Page} from '@playwright/test';
+import type {Client4} from '@mattermost/client';
+import type {UserProfile} from '@mattermost/types/users';
+
+import {getRandomId} from '../util';
+
+/**
+ * Create a user with custom profile attributes
+ * IMPORTANT: This creates the user first, then sets attributes by field ID
+ */
+export async function createUserWithAttributes(
+    client: Client4,
+    attributes: Record<string, string>,
+): Promise<UserProfile> {
+    const randomId = await getRandomId();
+    // Ensure username starts with a letter (Mattermost requirement)
+    const username = `user${randomId}`.toLowerCase();
+
+    // Create user without attributes first
+    const user = await client.createUser(
+        {
+            email: `${username}@example.com`,
+            username: username,
+            password: 'Password123!',
+        } as any,
+        '',
+        '',
+    );
+
+    // Set attributes using field IDs (if any provided)
+    if (Object.keys(attributes).length > 0) {
+        const fields = await client.getCustomProfileAttributeFields();
+
+        // Convert attribute names to field IDs
+        const valuesByFieldId: Record<string, string> = {};
+        for (const [attrName, attrValue] of Object.entries(attributes)) {
+            const field = fields.find((f: any) => f.name === attrName);
+            if (field) {
+                valuesByFieldId[field.id] = attrValue;
+            } else {
+                throw new Error(
+                    `Attribute field "${attrName}" not found. Available fields: ${fields.map((f: any) => f.name).join(', ')}`,
+                );
+            }
+        }
+
+        // Set the attribute values
+        if (Object.keys(valuesByFieldId).length > 0) {
+            await client.updateUserCustomProfileAttributesValues(user.id, valuesByFieldId);
+        }
+    }
+
+    return user;
+}
+
+/**
+ * Enable ABAC in System Console
+ */
+export async function enableABAC(page: Page): Promise<void> {
+    const enableRadio = page.locator('#AccessControlSettings\\.EnableAttributeBasedAccessControltrue');
+    await enableRadio.click();
+
+    // Wait for Save button to become enabled (indicates change detected)
+    const saveButton = page.getByRole('button', {name: 'Save'});
+    await saveButton.waitFor({state: 'visible', timeout: 5000});
+
+    // Check if already enabled (button stays disabled if no change needed)
+    const isDisabled = await saveButton.isDisabled();
+    if (isDisabled) {
+        return;
+    }
+
+    await saveButton.click();
+    await page.waitForLoadState('networkidle');
+}
+
+/**
+ * Disable ABAC in System Console
+ */
+export async function disableABAC(page: Page): Promise<void> {
+    const disableRadio = page.locator('#AccessControlSettings\\.EnableAttributeBasedAccessControlfalse');
+    await disableRadio.click();
+
+    // Wait for Save button to become enabled (indicates change detected)
+    const saveButton = page.getByRole('button', {name: 'Save'});
+    await saveButton.waitFor({state: 'visible', timeout: 5000});
+
+    // Check if already disabled (button stays disabled if no change needed)
+    const isDisabled = await saveButton.isDisabled();
+    if (isDisabled) {
+        return;
+    }
+
+    await saveButton.click();
+    await page.waitForLoadState('networkidle');
+}
+
+/**
+ * Navigate to ABAC page in System Console
+ */
+export async function navigateToABACPage(page: Page): Promise<void> {
+    await page.goto('/admin_console/system_attributes/attribute_based_access_control');
+    await page.waitForLoadState('networkidle');
+}
+
+/**
+ * Create a basic policy using Table Editor (Basic mode)
+ */
+export async function createBasicPolicy(
+    page: Page,
+    options: {
+        name: string;
+        attribute: string;
+        operator: string;
+        value: string;
+        autoSync?: boolean;
+        channels?: string[];
+    },
+): Promise<void> {
+    const addPolicyButton = page.getByRole('button', {name: 'Add policy'});
+    await addPolicyButton.click();
+    await page.waitForLoadState('networkidle');
+
+    // Fill policy name
+    const nameInput = page.locator('input[name="name"]').first();
+    await nameInput.fill(options.name);
+
+    // Set auto-sync if specified
+    if (options.autoSync) {
+        const autoSyncToggle = page
+            .locator('input[type="checkbox"]')
+            .filter({hasText: /auto|sync/i})
+            .first();
+        if (await autoSyncToggle.isVisible({timeout: 1000})) {
+            await autoSyncToggle.check();
+        }
+    }
+
+    // Set policy expression using table editor
+    const attributeDropdown = page.locator('select').first();
+    const operatorDropdown = page.locator('select').nth(1);
+    const valueInput = page.locator('input[type="text"]').last();
+
+    await attributeDropdown.selectOption(options.attribute);
+    await operatorDropdown.selectOption(options.operator);
+    await valueInput.fill(options.value);
+
+    // Add channels if specified
+    if (options.channels && options.channels.length > 0) {
+        const addChannelsButton = page.getByRole('button', {name: /add.*channel/i});
+        if (await addChannelsButton.isVisible({timeout: 1000})) {
+            await addChannelsButton.click();
+
+            const channelModal = page.locator('.modal, [role="dialog"]').first();
+            for (const channelName of options.channels) {
+                await channelModal.getByText(channelName, {exact: false}).click();
+            }
+
+            const modalSaveButton = channelModal.getByRole('button', {name: 'Save'});
+            await modalSaveButton.click();
+        }
+    }
+
+    // Save policy
+    const saveButton = page.getByRole('button', {name: 'Save'}).last();
+    await saveButton.click();
+    await page.waitForLoadState('networkidle');
+}
+
+/**
+ * Create an advanced policy using CEL Editor (Advanced mode)
+ */
+export async function createAdvancedPolicy(
+    page: Page,
+    options: {
+        name: string;
+        celExpression: string;
+        autoSync?: boolean;
+        channels?: string[];
+    },
+): Promise<void> {
+    const addPolicyButton = page.getByRole('button', {name: 'Add policy'});
+    await addPolicyButton.click();
+    await page.waitForLoadState('networkidle');
+
+    // Fill policy name
+    const nameInput = page.locator('input[name="name"]').first();
+    await nameInput.fill(options.name);
+
+    // Set auto-sync if specified
+    if (options.autoSync) {
+        const autoSyncToggle = page
+            .locator('input[type="checkbox"]')
+            .filter({hasText: /auto|sync/i})
+            .first();
+        if (await autoSyncToggle.isVisible({timeout: 1000})) {
+            await autoSyncToggle.check();
+        }
+    }
+
+    // Switch to Advanced mode
+    const modeToggle = page.getByRole('button', {name: /advanced|basic/i});
+    if (await modeToggle.isVisible({timeout: 1000})) {
+        await modeToggle.click();
+        await page.waitForTimeout(500);
+    }
+
+    // Fill CEL expression
+    const celEditor = page.locator('textarea').first();
+    await celEditor.fill(options.celExpression);
+
+    // Add channels if specified
+    if (options.channels && options.channels.length > 0) {
+        const addChannelsButton = page.getByRole('button', {name: /add.*channel/i});
+        if (await addChannelsButton.isVisible({timeout: 1000})) {
+            await addChannelsButton.click();
+
+            const channelModal = page.locator('.modal, [role="dialog"]').first();
+            for (const channelName of options.channels) {
+                await channelModal.getByText(channelName, {exact: false}).click();
+            }
+
+            const modalSaveButton = channelModal.getByRole('button', {name: 'Save'});
+            await modalSaveButton.click();
+        }
+    }
+
+    // Save policy
+    const saveButton = page.getByRole('button', {name: 'Save'}).last();
+    await saveButton.click();
+    await page.waitForLoadState('networkidle');
+}
+
+/**
+ * Edit an existing policy
+ */
+export async function editPolicy(page: Page, policyName: string): Promise<void> {
+    const policyRow = page.locator('.policy-name').filter({hasText: policyName}).locator('..').locator('..');
+    const menuButton = policyRow.locator('button[id*="policy-menu"]');
+    await menuButton.click();
+
+    const editButton = page.getByRole('menuitem', {name: 'Edit'});
+    await editButton.click();
+    await page.waitForLoadState('networkidle');
+}
+
+/**
+ * Delete a policy
+ */
+export async function deletePolicy(page: Page, policyName: string): Promise<void> {
+    const policyRow = page.locator('.policy-name').filter({hasText: policyName}).locator('..').locator('..');
+    const menuButton = policyRow.locator('button[id*="policy-menu"]');
+    await menuButton.click();
+
+    const deleteButton = page.getByRole('menuitem', {name: 'Delete'});
+    await deleteButton.click();
+
+    // Confirm deletion if modal appears
+    const confirmButton = page.getByRole('button', {name: /delete|confirm/i});
+    if (await confirmButton.isVisible({timeout: 1000})) {
+        await confirmButton.click();
+    }
+
+    await page.waitForLoadState('networkidle');
+}
+
+/**
+ * Run ABAC sync job
+ */
+export async function runSyncJob(page: Page, waitForCompletion: boolean = true): Promise<void> {
+    const runSyncButton = page.getByRole('button', {name: 'Run Sync Job'});
+    await runSyncButton.click();
+    await page.waitForLoadState('networkidle');
+
+    // Wait for job to process if requested
+    if (waitForCompletion) {
+        await page.waitForTimeout(3000);
+    }
+}
+
+/**
+ * Verify user is member of channel
+ */
+export async function verifyUserInChannel(client: Client4, userId: string, channelId: string): Promise<boolean> {
+    try {
+        const members = await client.getChannelMembers(channelId);
+        return members.some((m: any) => m.user_id === userId);
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Verify user is NOT member of channel
+ */
+export async function verifyUserNotInChannel(client: Client4, userId: string, channelId: string): Promise<boolean> {
+    return !(await verifyUserInChannel(client, userId, channelId));
+}
+
+/**
+ * Update user's custom profile attributes
+ * Converts attribute names to field IDs and uses the correct API
+ */
+export async function updateUserAttributes(
+    client: Client4,
+    userId: string,
+    attributes: Record<string, string>,
+): Promise<void> {
+    const fields = await client.getCustomProfileAttributeFields();
+
+    // Convert attribute names to field IDs
+    const valuesByFieldId: Record<string, string> = {};
+    for (const [attrName, attrValue] of Object.entries(attributes)) {
+        const field = fields.find((f: any) => f.name === attrName);
+        if (field) {
+            valuesByFieldId[field.id] = attrValue;
+        } else {
+            throw new Error(
+                `Attribute field "${attrName}" not found. Available fields: ${fields.map((f: any) => f.name).join(', ')}`,
+            );
+        }
+    }
+
+    // Update attributes using field IDs
+    if (Object.keys(valuesByFieldId).length > 0) {
+        await client.updateUserCustomProfileAttributesValues(userId, valuesByFieldId);
+    }
+}

--- a/e2e-tests/playwright/lib/src/server/index.ts
+++ b/e2e-tests/playwright/lib/src/server/index.ts
@@ -8,4 +8,18 @@ export {initSetup, getAdminClient} from './init';
 export {createRandomPost} from './post';
 export {createNewTeam, createRandomTeam} from './team';
 export {createNewUserProfile, createRandomUser, getDefaultAdminUser, isOutsideRemoteUserHour} from './user';
+export {
+    createUserWithAttributes,
+    enableABAC,
+    disableABAC,
+    navigateToABACPage,
+    createBasicPolicy,
+    createAdvancedPolicy,
+    editPolicy,
+    deletePolicy,
+    runSyncJob,
+    verifyUserInChannel,
+    verifyUserNotInChannel,
+    updateUserAttributes,
+} from './abac_helpers';
 export {installAndEnablePlugin, isPluginActive, getPluginStatus} from './plugin';

--- a/e2e-tests/playwright/lib/src/test_fixture.ts
+++ b/e2e-tests/playwright/lib/src/test_fixture.ts
@@ -24,6 +24,7 @@ import {
     createRandomPost,
     createRandomTeam,
     createRandomUser,
+    createUserWithAttributes,
     getAdminClient,
     initSetup,
     isOutsideRemoteUserHour,
@@ -192,6 +193,7 @@ export class PlaywrightExtended {
             post: createRandomPost,
             team: createRandomTeam,
             user: createRandomUser,
+            userWithAttributes: createUserWithAttributes,
         };
 
         this.hasSeenLandingPage = async () => {

--- a/e2e-tests/playwright/specs/functional/system_console/abac/basic/enable_disable.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/basic/enable_disable.spec.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+import {ensureUserAttributes} from '../support';
+
+/**
+ * ABAC Basic Operations - Enable/Disable
+ * Tests basic ABAC system-wide enable/disable functionality
+ */
+test.describe('ABAC Basic Operations - Enable/Disable', () => {
+    test('MM-T5782 System admin can enable or disable system-wide ABAC', async ({pw}) => {
+        // # Skip test if no license for ABAC
+        await pw.skipIfNoLicense();
+
+        // # Set up admin user and login
+        const {adminUser, adminClient} = await pw.initSetup();
+
+        // # Ensure user attributes exist BEFORE logging in
+        await ensureUserAttributes(adminClient);
+
+        // # Now login - this ensures the UI will have the attributes loaded
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+
+        // # Navigate to ABAC page
+        await systemConsolePage.goto();
+        await systemConsolePage.toBeVisible();
+        await systemConsolePage.sidebar.systemAttributes.attributeBasedAccess.click();
+
+        // * Verify we're on the correct page
+        const abacSection = systemConsolePage.page.getByTestId('sysconsole_section_AttributeBasedAccessControl');
+        await expect(abacSection).toBeVisible();
+
+        const enableRadio = systemConsolePage.page.locator(
+            '#AccessControlSettings\\.EnableAttributeBasedAccessControltrue',
+        );
+        const disableRadio = systemConsolePage.page.locator(
+            '#AccessControlSettings\\.EnableAttributeBasedAccessControlfalse',
+        );
+        const saveButton = systemConsolePage.page.getByRole('button', {name: 'Save'});
+
+        // # Test enable ABAC
+        await enableRadio.click();
+        await expect(enableRadio).toBeChecked();
+        await saveButton.click();
+        await systemConsolePage.page.waitForLoadState('networkidle');
+
+        // * Verify policy management UI is visible when enabled
+        const addPolicyButton = systemConsolePage.page.getByRole('button', {name: 'Add policy'});
+        const runSyncJobButton = systemConsolePage.page.getByRole('button', {name: 'Run Sync Job'});
+        await expect(addPolicyButton).toBeVisible();
+        await expect(runSyncJobButton).toBeVisible();
+
+        // # Test disable ABAC
+        await disableRadio.click();
+        await expect(disableRadio).toBeChecked();
+        await saveButton.click();
+        await systemConsolePage.page.waitForLoadState('networkidle');
+
+        // * Verify policy management UI is hidden when disabled
+        await expect(addPolicyButton).not.toBeVisible();
+        await expect(runSyncJobButton).not.toBeVisible();
+
+        // # Re-enable ABAC for subsequent tests
+        await enableRadio.click();
+        await saveButton.click();
+        await systemConsolePage.page.waitForLoadState('networkidle');
+    });
+});

--- a/e2e-tests/playwright/specs/functional/system_console/abac/ldap/ldap_sync.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/ldap/ldap_sync.spec.ts
@@ -1,0 +1,632 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {
+    expect,
+    test,
+    enableABAC,
+    navigateToABACPage,
+    runSyncJob,
+    verifyUserInChannel,
+    updateUserAttributes,
+    createUserWithAttributes,
+} from '@mattermost/playwright-lib';
+
+import {
+    ensureUserAttributes,
+    createPrivateChannelForABAC,
+    createBasicPolicy,
+    createAdvancedPolicy,
+    activatePolicy,
+    waitForLatestSyncJob,
+} from '../support';
+
+/**
+ * ABAC LDAP Integration - Sync
+ * Tests for LDAP sync behavior with ABAC policies
+ */
+test.describe('ABAC LDAP Integration - Sync', () => {
+    /**
+     * MM-T5797: LDAP sync - User is auto-added to channel when qualifying attribute syncs to their profile (auto-add true)
+     *
+     * Step 1: Single attribute with `= is` operator
+     * 1. Policy with one attribute (Department == Engineering), auto-add=true exists
+     * 2. User NOT in channel, lacking required attribute
+     */
+    test('MM-T5797 LDAP sync - User auto-added when attribute syncs (auto-add true)', async ({pw}) => {
+        test.setTimeout(180000);
+
+        await pw.skipIfNoLicense();
+
+        // ============================================================
+        // SETUP
+        // ============================================================
+        const {adminUser, adminClient, team} = await pw.initSetup();
+
+        // Ensure Department attribute exists
+        await ensureUserAttributes(adminClient, ['Department']);
+
+        // ============================================================
+        // STEP 1: Single attribute with == operator, auto-add TRUE
+        // ============================================================
+
+        // Create user with NON-qualifying attribute (simulating LDAP user before sync)
+        const user1 = await createUserWithAttributes(adminClient, {Department: 'Sales'});
+        await adminClient.addToTeam(team.id, user1.id);
+
+        // Create channel and policy
+        const channel1 = await createPrivateChannelForABAC(adminClient, team.id);
+
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        await navigateToABACPage(systemConsolePage.page);
+        await enableABAC(systemConsolePage.page);
+
+        const policy1Name = `LDAP AutoAdd Single ${await pw.random.id()}`;
+        await createBasicPolicy(systemConsolePage.page, {
+            name: policy1Name,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: true, // Auto-add TRUE
+            channels: [channel1.display_name],
+        });
+
+        // Wait for page to load completely and job table to appear
+        await systemConsolePage.page.waitForTimeout(2000);
+
+        // Activate policy
+        await waitForLatestSyncJob(systemConsolePage.page);
+        const searchInput = systemConsolePage.page.locator('input[placeholder*="Search" i]').first();
+        await searchInput.waitFor({state: 'visible', timeout: 5000});
+        await searchInput.fill(policy1Name.match(/([a-z0-9]+)$/i)?.[1] || policy1Name);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        const policyRow1 = systemConsolePage.page.locator('.policy-name').first();
+        const policyId1 = (await policyRow1.getAttribute('id'))?.replace('customDescription-', '');
+        if (policyId1) {
+            await activatePolicy(adminClient, policyId1);
+        }
+        await searchInput.clear();
+
+        // Run initial sync - user should NOT be in channel (doesn't have qualifying attribute)
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        const user1InitialCheck = await verifyUserInChannel(adminClient, user1.id, channel1.id);
+        expect(user1InitialCheck).toBe(false);
+
+        // Simulate LDAP sync by updating user's attribute to qualifying value
+        await updateUserAttributes(adminClient, user1.id, {Department: 'Engineering'});
+
+        // Run ABAC sync job to apply policy with new attribute value
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        // Verify user IS NOW in channel (auto-added)
+        const user1AfterSync = await verifyUserInChannel(adminClient, user1.id, channel1.id);
+        expect(user1AfterSync).toBe(true);
+
+        // Verify system message
+        const posts1 = await adminClient.getPosts(channel1.id, 0, 10);
+        const postList1 = posts1.order.map((postId: string) => posts1.posts[postId]);
+        const addMessage1 = postList1.find((post: any) => {
+            return post.type === 'system_add_to_channel' && post.props?.addedUserId === user1.id;
+        });
+        if (addMessage1) {
+            // System message found
+        } else {
+            // System message not found (may be disabled in test env)
+        }
+
+        // ============================================================
+        // STEP 2: Single attribute using "contains" operator
+        // ============================================================
+
+        // Create user with Department that doesn't contain "Eng"
+        const user2 = await createUserWithAttributes(adminClient, {
+            Department: 'Sales', // Doesn't contain "Eng"
+        });
+        await adminClient.addToTeam(team.id, user2.id);
+
+        // Create second channel
+        const channel2 = await createPrivateChannelForABAC(adminClient, team.id);
+
+        await navigateToABACPage(systemConsolePage.page);
+
+        // Create policy with contains operator: Department contains "Eng"
+        const policy2Name = `LDAP AutoAdd Contains ${await pw.random.id()}`;
+        await createAdvancedPolicy(systemConsolePage.page, {
+            name: policy2Name,
+            celExpression: 'user.attributes.Department.contains("Eng")',
+            autoSync: true, // Auto-add TRUE
+            channels: [channel2.display_name],
+        });
+
+        // Activate policy
+        await waitForLatestSyncJob(systemConsolePage.page);
+        await searchInput.fill(policy2Name.match(/([a-z0-9]+)$/i)?.[1] || policy2Name);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        const policyRow2 = systemConsolePage.page.locator('.policy-name').first();
+        const policyId2 = (await policyRow2.getAttribute('id'))?.replace('customDescription-', '');
+        if (policyId2) {
+            await activatePolicy(adminClient, policyId2);
+        }
+        await searchInput.clear();
+
+        // Run initial sync - user should NOT be in channel (has Department but Skills missing Python)
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        const user2InitialCheck = await verifyUserInChannel(adminClient, user2.id, channel2.id);
+        expect(user2InitialCheck).toBe(false);
+
+        // Simulate LDAP sync by updating Department to "Engineering" (contains "Eng")
+        await updateUserAttributes(adminClient, user2.id, {Department: 'Engineering'});
+
+        // Run ABAC sync job
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        // Verify user IS NOW in channel (auto-added)
+        const user2AfterSync = await verifyUserInChannel(adminClient, user2.id, channel2.id);
+        expect(user2AfterSync).toBe(true);
+
+        // Verify system message
+        const posts2 = await adminClient.getPosts(channel2.id, 0, 10);
+        const postList2 = posts2.order.map((postId: string) => posts2.posts[postId]);
+        const addMessage2 = postList2.find((post: any) => {
+            return post.type === 'system_add_to_channel' && post.props?.addedUserId === user2.id;
+        });
+        if (addMessage2) {
+            // System message found
+        } else {
+            // System message not found (may be disabled in test env)
+        }
+    });
+
+    /**
+     * MM-T5798: LDAP sync - User can be added to channel by admin after editing qualifying attribute (auto-add false)
+     *
+     * Step 1: Using `= is` operator
+     * 1. Policy with auto-add=false exists and is applied to a channel
+     * 2. User has wrong attribute value (non-qualifying)
+     * 3. Simulate LDAP sync by updating user's attribute to qualifying value
+     * 4. Run ABAC sync job (updates qualification state but doesn't auto-add due to auto-add=false)
+     * 5. Verify user NOT auto-added
+     * 6. Admin manually adds user to channel
+     *
+     * Step 2: Using `∈ in` operator
+     * 1. Policy with `in` operator exists
+     * 2. User has attribute but not a qualifying value
+     * 3. Simulate LDAP sync by updating to qualifying value
+     * 4. Admin adds user to channel
+     *
+     * Expected:
+     * - User who satisfies policy can be added by admin
+     * - `User added` message posted in channel
+     *
+     * NOTE: This test simulates LDAP attribute sync behavior via API.
+     *       In production, attributes would be synced from LDAP server.
+     */
+    test('MM-T5798 User added by admin after LDAP attribute sync (auto-add false)', async ({pw}) => {
+        // NOTE: This test documents current ABAC behavior with auto-add=false:
+        // - The test verifies that with auto-add=false, sync jobs DON'T automatically add users
+        // - Instead, admin must manually add qualifying users to channels
+        // - However, current implementation requires sync job to run first so server knows who qualifies
+        test.setTimeout(180000);
+
+        await pw.skipIfNoLicense();
+
+        // ============================================================
+        // SETUP
+        // ============================================================
+        const {adminUser, adminClient, team} = await pw.initSetup();
+
+        await ensureUserAttributes(adminClient);
+
+        // ============================================================
+        // STEP 1: Test with `= is` operator
+        // ============================================================
+
+        // Create user with NON-qualifying attribute (simulating LDAP user before sync)
+        const user1 = await createUserWithAttributes(adminClient, {Department: 'Sales'});
+        await adminClient.addToTeam(team.id, user1.id);
+
+        // Create channel and policy
+        const channel1 = await createPrivateChannelForABAC(adminClient, team.id);
+
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        await navigateToABACPage(systemConsolePage.page);
+        await enableABAC(systemConsolePage.page);
+
+        const policy1Name = `LDAP Sync Equals ${await pw.random.id()}`;
+        await createBasicPolicy(systemConsolePage.page, {
+            name: policy1Name,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: false, // Auto-add FALSE
+            channels: [channel1.display_name],
+        });
+
+        // Activate policy
+        await waitForLatestSyncJob(systemConsolePage.page);
+        const searchInput = systemConsolePage.page.locator('input[placeholder*="Search" i]').first();
+        await searchInput.waitFor({state: 'visible', timeout: 5000});
+        await searchInput.fill(policy1Name.match(/([a-z0-9]+)$/i)?.[1] || policy1Name);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        const policyRow1 = systemConsolePage.page.locator('.policy-name').first();
+        const policyId1 = (await policyRow1.getAttribute('id'))?.replace('customDescription-', '');
+        if (policyId1) {
+            await activatePolicy(adminClient, policyId1);
+        }
+        await searchInput.clear();
+
+        // Run initial sync - user should NOT be in channel
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        const user1InitialCheck = await verifyUserInChannel(adminClient, user1.id, channel1.id);
+        expect(user1InitialCheck).toBe(false);
+
+        // Simulate LDAP sync by updating user's attribute to qualifying value
+        // In real LDAP scenario, this would happen during LDAP sync from external server
+        await updateUserAttributes(adminClient, user1.id, {Department: 'Engineering'});
+
+        // Run sync job - with auto-add=false, this tests whether users are auto-added or not
+        // The expected behavior: sync job should NOT auto-add users when autoSync=false
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        // Verify user behavior after sync
+        const user1AfterSync = await verifyUserInChannel(adminClient, user1.id, channel1.id);
+
+        if (user1AfterSync) {
+            // If user WAS auto-added, this documents current behavior
+        } else {
+            // If user was NOT auto-added, then admin can manually add
+            await adminClient.addToChannel(user1.id, channel1.id);
+
+            const user1AfterAdminAdd = await verifyUserInChannel(adminClient, user1.id, channel1.id);
+            expect(user1AfterAdminAdd).toBe(true);
+        }
+
+        // Final verification
+        const user1Final = await verifyUserInChannel(adminClient, user1.id, channel1.id);
+        expect(user1Final).toBe(true);
+
+        // ============================================================
+        // STEP 2: Test with `∈ in` operator
+        // ============================================================
+
+        // Create user with attribute that has non-qualifying value for 'in' check
+        const user2 = await createUserWithAttributes(adminClient, {Department: 'Marketing'});
+        await adminClient.addToTeam(team.id, user2.id);
+
+        // Create second channel
+        const channel2 = await createPrivateChannelForABAC(adminClient, team.id);
+
+        await navigateToABACPage(systemConsolePage.page);
+
+        // Create policy with 'in' operator (user.attributes.Department in ["Engineering", "Product"])
+        const policy2Name = `LDAP Sync In ${await pw.random.id()}`;
+        await createAdvancedPolicy(systemConsolePage.page, {
+            name: policy2Name,
+            celExpression: 'user.attributes.Department in ["Engineering", "Product"]',
+            autoSync: false, // Auto-add FALSE
+            channels: [channel2.display_name],
+        });
+
+        // Activate policy
+        await waitForLatestSyncJob(systemConsolePage.page);
+        await searchInput.fill(policy2Name.match(/([a-z0-9]+)$/i)?.[1] || policy2Name);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        const policyRow2 = systemConsolePage.page.locator('.policy-name').first();
+        const policyId2 = (await policyRow2.getAttribute('id'))?.replace('customDescription-', '');
+        if (policyId2) {
+            await activatePolicy(adminClient, policyId2);
+        }
+        await searchInput.clear();
+
+        // Run initial sync - user should NOT be in channel
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        const user2InitialCheck = await verifyUserInChannel(adminClient, user2.id, channel2.id);
+        expect(user2InitialCheck).toBe(false);
+
+        // Simulate LDAP sync by updating to qualifying value
+        await updateUserAttributes(adminClient, user2.id, {Department: 'Product'});
+
+        // Run sync job - testing same behavior as Step 1
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        // Verify user behavior after sync
+        const user2AfterSync = await verifyUserInChannel(adminClient, user2.id, channel2.id);
+
+        if (user2AfterSync) {
+            // User was auto-added
+        } else {
+            await adminClient.addToChannel(user2.id, channel2.id);
+
+            const user2AfterAdminAdd = await verifyUserInChannel(adminClient, user2.id, channel2.id);
+            expect(user2AfterAdminAdd).toBe(true);
+        }
+
+        // Final verification
+        const user2Final = await verifyUserInChannel(adminClient, user2.id, channel2.id);
+        expect(user2Final).toBe(true);
+    });
+
+    /**
+     * MM-T5799: LDAP sync - User removed from channel after required attribute removed (auto-add true)
+     *
+     * Step 1: Using `ƒ starts with` operator
+     * 1. Policy with startsWith operator, auto-add=true exists and is applied to a channel
+     * 2. User IN channel with attribute that starts with required value
+     * 3. Simulate LDAP sync by removing the attribute (or changing to non-qualifying value)
+     * 4. Run ABAC sync job
+     *
+     * Expected:
+     * - User who no longer satisfies policy is removed from channel
+     * - `User removed` message posted in channel by System
+     *
+     * Step 2: Two attributes using `= is` operator
+     * 1. Policy with two attributes (both using ==), auto-add=true
+     * 2. User IN channel with both required attributes
+     * 3. Simulate LDAP sync by removing one attribute
+     * 4. Run ABAC sync job
+     *
+     * Expected:
+     * - User who no longer satisfies policy is removed from channel
+     * - `User removed` message posted in channel by System
+     *
+     * NOTE: This test simulates LDAP attribute sync behavior via API.
+     *       In production, attributes would be synced from LDAP server.
+     */
+    test('MM-T5799 LDAP sync - User removed after attribute removed', async ({pw}) => {
+        test.setTimeout(180000);
+
+        await pw.skipIfNoLicense();
+
+        // ============================================================
+        // SETUP
+        // ============================================================
+        const {adminUser, adminClient, team} = await pw.initSetup();
+
+        // Ensure Department attribute exists
+        await ensureUserAttributes(adminClient, ['Department']);
+
+        // ============================================================
+        // STEP 1: Single attribute with startsWith operator
+        // ============================================================
+
+        // Create user with qualifying attribute (Department starts with "Eng")
+        const user1 = await createUserWithAttributes(adminClient, {Department: 'Engineering'});
+        await adminClient.addToTeam(team.id, user1.id);
+
+        // Create channel and policy
+        const channel1 = await createPrivateChannelForABAC(adminClient, team.id);
+
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        await navigateToABACPage(systemConsolePage.page);
+        await enableABAC(systemConsolePage.page);
+
+        const policy1Name = `LDAP Remove StartsWith ${await pw.random.id()}`;
+        await createAdvancedPolicy(systemConsolePage.page, {
+            name: policy1Name,
+            celExpression: 'user.attributes.Department.startsWith("Eng")',
+            autoSync: true, // Auto-add TRUE
+            channels: [channel1.display_name],
+        });
+
+        // Activate policy
+        await systemConsolePage.page.waitForTimeout(2000);
+        await waitForLatestSyncJob(systemConsolePage.page);
+        const searchInput = systemConsolePage.page.locator('input[placeholder*="Search" i]').first();
+        await searchInput.waitFor({state: 'visible', timeout: 5000});
+        await searchInput.fill(policy1Name.match(/([a-z0-9]+)$/i)?.[1] || policy1Name);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        const policyRow1 = systemConsolePage.page.locator('.policy-name').first();
+        const policyId1 = (await policyRow1.getAttribute('id'))?.replace('customDescription-', '');
+        if (policyId1) {
+            await activatePolicy(adminClient, policyId1);
+        }
+        await searchInput.clear();
+
+        // Run sync - user should be AUTO-ADDED (has Department=Engineering which starts with "Eng")
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        const user1InitialCheck = await verifyUserInChannel(adminClient, user1.id, channel1.id);
+        expect(user1InitialCheck).toBe(true);
+
+        // Simulate LDAP sync by changing Department to value that doesn't start with "Eng"
+        await updateUserAttributes(adminClient, user1.id, {Department: 'Sales'});
+
+        // Run ABAC sync job to remove user
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        // Verify user IS REMOVED from channel
+        const user1AfterSync = await verifyUserInChannel(adminClient, user1.id, channel1.id);
+        expect(user1AfterSync).toBe(false);
+
+        // Verify system message
+        const posts1 = await adminClient.getPosts(channel1.id, 0, 10);
+        const postList1 = posts1.order.map((postId: string) => posts1.posts[postId]);
+        const removeMessage1 = postList1.find((post: any) => {
+            return post.type === 'system_remove_from_channel' && post.props?.removedUserId === user1.id;
+        });
+        if (removeMessage1) {
+            // System message found
+        } else {
+            // System message not found (may be disabled in test env)
+        }
+
+        // ============================================================
+        // STEP 2: Two attributes using == operator
+        // ============================================================
+
+        // Create user with both qualifying attributes
+        const user2 = await createUserWithAttributes(adminClient, {Department: 'Engineering'});
+        await adminClient.addToTeam(team.id, user2.id);
+
+        // Create second channel
+        const channel2 = await createPrivateChannelForABAC(adminClient, team.id);
+
+        await navigateToABACPage(systemConsolePage.page);
+
+        // Create policy with TWO attributes: Department == "Engineering"
+        // Note: Using single attribute with == since we can't reliably set multiple different attribute types
+        const policy2Name = `LDAP Remove TwoAttr ${await pw.random.id()}`;
+        await createBasicPolicy(systemConsolePage.page, {
+            name: policy2Name,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: true, // Auto-add TRUE
+            channels: [channel2.display_name],
+        });
+
+        // Activate policy
+        await systemConsolePage.page.waitForTimeout(2000);
+        await waitForLatestSyncJob(systemConsolePage.page);
+        await searchInput.fill(policy2Name.match(/([a-z0-9]+)$/i)?.[1] || policy2Name);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        const policyRow2 = systemConsolePage.page.locator('.policy-name').first();
+        const policyId2 = (await policyRow2.getAttribute('id'))?.replace('customDescription-', '');
+        if (policyId2) {
+            await activatePolicy(adminClient, policyId2);
+        }
+        await searchInput.clear();
+
+        // Run initial sync - user should be AUTO-ADDED
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        const user2InitialCheck = await verifyUserInChannel(adminClient, user2.id, channel2.id);
+        expect(user2InitialCheck).toBe(true);
+
+        // Simulate LDAP sync by removing the Department attribute (changing to non-qualifying value)
+        await updateUserAttributes(adminClient, user2.id, {Department: 'Sales'});
+
+        // Run ABAC sync job
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        // Verify user IS REMOVED from channel
+        const user2AfterSync = await verifyUserInChannel(adminClient, user2.id, channel2.id);
+        expect(user2AfterSync).toBe(false);
+
+        // Verify system message
+        const posts2 = await adminClient.getPosts(channel2.id, 0, 10);
+        const postList2 = posts2.order.map((postId: string) => posts2.posts[postId]);
+        const removeMessage2 = postList2.find((post: any) => {
+            return post.type === 'system_remove_from_channel' && post.props?.removedUserId === user2.id;
+        });
+        if (removeMessage2) {
+            // System message found
+        } else {
+            // System message not found (may be disabled in test env)
+        }
+    });
+
+    /**
+     * MM-T5800: Policy enforcement after attribute change
+     * @objective Verify that policy enforcement updates when user attributes change
+     *
+     * This test is similar to MM-T5794 but focuses on the bidirectional nature:
+     * - User starts with non-qualifying attribute → NOT in channel
+     * - Attribute changed to qualifying value → User auto-added
+     * - Attribute changed back to non-qualifying → User auto-removed
+     */
+    test('MM-T5800 Policy enforcement after attribute change (bidirectional)', async ({pw}) => {
+        test.setTimeout(120000);
+
+        await pw.skipIfNoLicense();
+
+        // ============================================================
+        // SETUP
+        // ============================================================
+        const {adminUser, adminClient, team} = await pw.initSetup();
+        await ensureUserAttributes(adminClient);
+
+        // Create user with Sales department (non-qualifying)
+        const user = await createUserWithAttributes(adminClient, {Department: 'Sales'});
+        await adminClient.addToTeam(team.id, user.id);
+
+        const privateChannel = await createPrivateChannelForABAC(adminClient, team.id);
+
+        // ============================================================
+        // Create policy for Engineering with auto-add
+        // ============================================================
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        await navigateToABACPage(systemConsolePage.page);
+        await enableABAC(systemConsolePage.page);
+
+        const policyName = `Dynamic Policy ${await pw.random.id()}`;
+        await createBasicPolicy(systemConsolePage.page, {
+            name: policyName,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: true,
+            channels: [privateChannel.display_name],
+        });
+
+        // Activate policy
+        await waitForLatestSyncJob(systemConsolePage.page);
+        const searchInput = systemConsolePage.page.locator('input[placeholder*="Search" i]').first();
+        await searchInput.waitFor({state: 'visible', timeout: 5000});
+        const idMatch = policyName.match(/([a-z0-9]+)$/i);
+        const uniqueId = idMatch ? idMatch[1] : policyName;
+        await searchInput.fill(uniqueId);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        const policyRow = systemConsolePage.page.locator('.policy-name').first();
+        const policyId = (await policyRow.getAttribute('id'))?.replace('customDescription-', '');
+
+        if (policyId) {
+            await activatePolicy(adminClient, policyId);
+        }
+        await searchInput.clear();
+
+        // ============================================================
+        // PHASE 1: User should NOT be added (Department=Sales)
+        // ============================================================
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        const phase1InChannel = await verifyUserInChannel(adminClient, user.id, privateChannel.id);
+        expect(phase1InChannel).toBe(false);
+
+        // ============================================================
+        // PHASE 2: Change attribute to qualifying value → User auto-added
+        // ============================================================
+        await updateUserAttributes(adminClient, user.id, {Department: 'Engineering'});
+
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        const phase2InChannel = await verifyUserInChannel(adminClient, user.id, privateChannel.id);
+        expect(phase2InChannel).toBe(true);
+
+        // ============================================================
+        // PHASE 3: Change attribute back → User auto-removed
+        // ============================================================
+        await updateUserAttributes(adminClient, user.id, {Department: 'Marketing'});
+
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        const phase3InChannel = await verifyUserInChannel(adminClient, user.id, privateChannel.id);
+        expect(phase3InChannel).toBe(false);
+    });
+});

--- a/e2e-tests/playwright/specs/functional/system_console/abac/policies/advanced_policies.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/policies/advanced_policies.spec.ts
@@ -1,0 +1,704 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {
+    expect,
+    test,
+    enableABAC,
+    navigateToABACPage,
+    runSyncJob,
+    verifyUserInChannel,
+    createUserWithAttributes,
+} from '@mattermost/playwright-lib';
+
+import {
+    CustomProfileAttribute,
+    setupCustomProfileAttributeFields,
+} from '../../../channels/custom_profile_attributes/helpers';
+import {
+    ensureUserAttributes,
+    createUserForABAC,
+    testAccessRule,
+    createPrivateChannelForABAC,
+    createAdvancedPolicy,
+    activatePolicy,
+    waitForLatestSyncJob,
+    getJobDetailsFromRecentJobs,
+    enableUserManagedAttributes,
+} from '../support';
+
+/**
+ * ABAC Policies - Advanced Policies
+ * Tests for advanced policy configurations including multiple attributes, operators, and complex rules
+ */
+test.describe('ABAC Policies - Advanced Policies', () => {
+    /**
+     * MM-T5785: Attribute-based access policy that uses all the attribute types, including
+     * multi-select with multiple values, controls access as specified
+     * (multiple attributes, = is, with auto-add)
+     *
+     * @reference https://github.com/mattermost/mattermost-test-management/blob/main/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5785.md
+     *
+     * Test Steps:
+     * 1. As system admin, go to ABAC page, click Add policy, enter name, set Auto-add = TRUE
+     * 2-3. Select policy values using ALL attribute types: Text, Phone, URL, Select, MultiSelect
+     */
+    test('MM-T5785 Test policy with all attribute types and auto-add', async ({pw}) => {
+        test.setTimeout(180000); // 3 minutes for this complex test
+
+        // # Skip test if no license for ABAC
+        await pw.skipIfNoLicense();
+
+        // ============================================================
+        // SETUP: Use simplified attribute setup (same as working tests)
+        // ============================================================
+        const {adminUser, adminClient, team} = await pw.initSetup();
+
+        // Use ensureUserAttributes like other working tests
+        await ensureUserAttributes(adminClient);
+
+        // ============================================================
+        // Create 3 users with different attribute combinations
+        // ============================================================
+
+        // User 1: Satisfies policy (Department=Engineering), NOT in channel initially
+        const satisfyingUserNotInChannel = await createUserWithAttributes(adminClient, {
+            Department: 'Engineering',
+        });
+
+        // User 2: Satisfies policy (Department=Engineering), IN channel initially
+        const satisfyingUserInChannel = await createUserWithAttributes(adminClient, {
+            Department: 'Engineering',
+        });
+
+        // User 3: Does NOT satisfy policy (Department=Sales), IN channel initially
+        const partialSatisfyingUser = await createUserWithAttributes(adminClient, {
+            Department: 'Sales',
+        });
+
+        // Add all users to team
+        await adminClient.addToTeam(team.id, satisfyingUserNotInChannel.id);
+        await adminClient.addToTeam(team.id, satisfyingUserInChannel.id);
+        await adminClient.addToTeam(team.id, partialSatisfyingUser.id);
+
+        // Create private channel and add users 2 and 3 (but NOT user 1)
+        const privateChannel = await createPrivateChannelForABAC(adminClient, team.id);
+        await adminClient.addToChannel(satisfyingUserInChannel.id, privateChannel.id);
+        await adminClient.addToChannel(partialSatisfyingUser.id, privateChannel.id);
+
+        // Verify initial channel state
+        const initialUser1InChannel = await verifyUserInChannel(
+            adminClient,
+            satisfyingUserNotInChannel.id,
+            privateChannel.id,
+        );
+        const initialUser2InChannel = await verifyUserInChannel(
+            adminClient,
+            satisfyingUserInChannel.id,
+            privateChannel.id,
+        );
+        const initialUser3InChannel = await verifyUserInChannel(
+            adminClient,
+            partialSatisfyingUser.id,
+            privateChannel.id,
+        );
+        expect(initialUser1InChannel).toBe(false);
+        expect(initialUser2InChannel).toBe(true);
+        expect(initialUser3InChannel).toBe(true);
+
+        // ============================================================
+        // STEP 1-5: Login, navigate to ABAC, create policy
+        // ============================================================
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        await navigateToABACPage(systemConsolePage.page);
+        await enableABAC(systemConsolePage.page);
+
+        // Create policy with just Department (Text) first to verify users have attributes
+        const policyName = `Multi-Attr Policy ${await pw.random.id()}`;
+
+        // Start with just Text attribute to debug
+        // User 1 and 2 have Department=Engineering, User 3 has Department=Sales
+        const celExpression = 'user.attributes.Department == "Engineering"';
+
+        await createAdvancedPolicy(systemConsolePage.page, {
+            name: policyName,
+            celExpression: celExpression,
+            autoSync: true,
+            channels: [privateChannel.display_name],
+        });
+
+        // ============================================================
+        // STEP 4: Test Access Rule
+        // ============================================================
+
+        await systemConsolePage.page.waitForTimeout(1000);
+        const policyRowForTest = systemConsolePage.page.locator('.policy-name').filter({hasText: policyName}).first();
+        if (await policyRowForTest.isVisible({timeout: 3000})) {
+            await policyRowForTest.click();
+            await systemConsolePage.page.waitForLoadState('networkidle');
+
+            const testResult = await testAccessRule(systemConsolePage.page, {
+                expectedMatchingUsers: [satisfyingUserNotInChannel.username, satisfyingUserInChannel.username],
+                expectedNonMatchingUsers: [partialSatisfyingUser.username],
+            });
+
+            expect(testResult.expectedUsersMatch).toBe(true);
+            expect(testResult.unexpectedUsersMatch).toBe(false);
+
+            await navigateToABACPage(systemConsolePage.page);
+        }
+
+        // Get policy ID FIRST (before any sync jobs run)
+        const searchInput = systemConsolePage.page.locator('input[placeholder*="Search" i]').first();
+        await searchInput.waitFor({state: 'visible', timeout: 5000});
+
+        const idMatch = policyName.match(/([a-z0-9]+)$/i);
+        const uniqueId = idMatch ? idMatch[1] : policyName;
+        await searchInput.fill(uniqueId);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        const policyRow = systemConsolePage.page.locator('.policy-name').first();
+        const policyElementId = await policyRow.getAttribute('id');
+        const policyId = policyElementId?.replace('customDescription-', '');
+
+        if (!policyId) {
+            throw new Error('Could not get policy ID');
+        }
+        await searchInput.clear();
+
+        // Activate the policy BEFORE waiting for sync jobs
+        await activatePolicy(adminClient, policyId);
+
+        // Wait for the initial sync job (created when policy was saved)
+        await waitForLatestSyncJob(systemConsolePage.page, 10);
+
+        // Run ANOTHER sync job now that policy is active
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page, 10);
+
+        // ============================================================
+        // VERIFY VIA JOB DETAILS - Check the LATEST job (after activation)
+        // ============================================================
+
+        // Direct verification via API first to debug
+        await verifyUserInChannel(adminClient, satisfyingUserNotInChannel.id, privateChannel.id);
+        await verifyUserInChannel(adminClient, satisfyingUserInChannel.id, privateChannel.id);
+        await verifyUserInChannel(adminClient, partialSatisfyingUser.id, privateChannel.id);
+
+        // Try to get job details, but don't fail test if they're not as expected
+        // The direct API checks below are the authoritative verification
+        try {
+            const jobDetails = await getJobDetailsFromRecentJobs(systemConsolePage.page, privateChannel.display_name);
+
+            // Log expectations but don't fail on job details - use direct API checks instead
+            if (jobDetails.added >= 1) {
+                // Expected: user added
+            } else {
+                // No users added
+            }
+            if (jobDetails.removed >= 1) {
+                // Expected: user removed
+            } else {
+                // No users removed
+            }
+        } catch {
+            // Ignore errors
+        }
+
+        // ============================================================
+        // STEP 6-8: Verify channel membership via API
+        // ============================================================
+
+        // Step 6: User who satisfies policy but NOT in channel → AUTO-ADDED
+        let user1AfterSync = await verifyUserInChannel(adminClient, satisfyingUserNotInChannel.id, privateChannel.id);
+
+        // If user not added, try running sync one more time
+        if (!user1AfterSync) {
+            await runSyncJob(systemConsolePage.page);
+            await waitForLatestSyncJob(systemConsolePage.page, 10);
+            await systemConsolePage.page.waitForTimeout(2000);
+            user1AfterSync = await verifyUserInChannel(adminClient, satisfyingUserNotInChannel.id, privateChannel.id);
+        }
+        expect(user1AfterSync).toBe(true); // AUTO-ADDED
+
+        // Step 7: User who satisfies policy and IS in channel → stays in channel
+        const user2AfterSync = await verifyUserInChannel(adminClient, satisfyingUserInChannel.id, privateChannel.id);
+        expect(user2AfterSync).toBe(true); // Stays in channel
+
+        // Step 8: User who does NOT satisfy policy and IS in channel → AUTO-REMOVED
+        const user3AfterSync = await verifyUserInChannel(adminClient, partialSatisfyingUser.id, privateChannel.id);
+        expect(user3AfterSync).toBe(false); // AUTO-REMOVED
+    });
+
+    /**
+     * MM-T5786: Attribute-based access policy using operator variations in Simple mode
+     * controls access as specified (one attribute, various operators, with auto-add)
+     *
+     * @reference https://github.com/mattermost/mattermost-test-management/blob/main/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5786.md
+     *
+     * Tests operators: is not (!=), in, starts with, ends with, contains
+     */
+    test('MM-T5786 Test policy with various operators in Simple mode', async ({pw}) => {
+        // Increase timeout for this test since it tests multiple operators
+        test.setTimeout(300000); // 5 minutes for 5 operator steps
+        // # Skip test if no license for ABAC
+        await pw.skipIfNoLicense();
+
+        // # Setup
+        const {adminUser, adminClient, team} = await pw.initSetup();
+        await enableUserManagedAttributes(adminClient);
+
+        // Delete existing attributes and create fresh
+        try {
+            const existingFields = await adminClient.getCustomProfileAttributeFields();
+            for (const field of existingFields || []) {
+                await adminClient.deleteCustomProfileAttributeField(field.id).catch(() => {
+                    // Ignore deletion errors
+                });
+            }
+        } catch {
+            // Ignore errors
+        }
+
+        const attributeFields: CustomProfileAttribute[] = [{name: 'Department', type: 'text', value: ''}];
+        const attributeFieldsMap = await setupCustomProfileAttributeFields(adminClient, attributeFields);
+
+        // Create users with different Department values for testing various operators
+        // Engineering - for testing matches
+        // Sales - for testing non-matches
+        const engineerUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', type: 'text', value: 'Engineering'},
+        ]);
+        const salesUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', type: 'text', value: 'Sales'},
+        ]);
+
+        await adminClient.addToTeam(team.id, engineerUser.id);
+        await adminClient.addToTeam(team.id, salesUser.id);
+
+        // Login as admin
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        await navigateToABACPage(systemConsolePage.page);
+        await enableABAC(systemConsolePage.page);
+
+        // ============================================================
+        // STEP 1: Test "is not" (!=) operator
+        // Policy: Department != "Sales" → Engineering matches, Sales doesn't
+        // ============================================================
+
+        const channel1 = await createPrivateChannelForABAC(adminClient, team.id);
+        await adminClient.addToChannel(salesUser.id, channel1.id); // Sales user in channel initially
+
+        const policy1Name = `IsNot Policy ${await pw.random.id()}`;
+        await createAdvancedPolicy(systemConsolePage.page, {
+            name: policy1Name,
+            celExpression: 'user.attributes.Department != "Sales"',
+            autoSync: true,
+            channels: [channel1.display_name],
+        });
+
+        // Test Access Rule - navigate back to policy and verify
+        await systemConsolePage.page.waitForTimeout(1000);
+        const policyRowForTest1 = systemConsolePage.page.locator('.policy-name').filter({hasText: policy1Name}).first();
+        if (await policyRowForTest1.isVisible({timeout: 3000})) {
+            await policyRowForTest1.click();
+            await systemConsolePage.page.waitForLoadState('networkidle');
+
+            await testAccessRule(systemConsolePage.page, {
+                expectedMatchingUsers: [engineerUser.username],
+                expectedNonMatchingUsers: [salesUser.username],
+            });
+
+            await navigateToABACPage(systemConsolePage.page);
+        }
+
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        // Get policy ID and activate
+        const searchInput1 = systemConsolePage.page.locator('input[placeholder*="Search" i]').first();
+        await searchInput1.fill('IsNot');
+        await systemConsolePage.page.waitForTimeout(1000);
+        const policyRow1 = systemConsolePage.page.locator('.policy-name').first();
+        const policyId1 = (await policyRow1.getAttribute('id'))?.replace('customDescription-', '');
+        if (policyId1) {
+            await activatePolicy(adminClient, policyId1);
+            await runSyncJob(systemConsolePage.page);
+            await waitForLatestSyncJob(systemConsolePage.page);
+        }
+        await searchInput1.clear();
+
+        // Verify: Engineer should be added (satisfies != Sales), Sales should be removed
+        const eng1InChannel = await verifyUserInChannel(adminClient, engineerUser.id, channel1.id);
+        const sales1InChannel = await verifyUserInChannel(adminClient, salesUser.id, channel1.id);
+        expect(eng1InChannel).toBe(true);
+        expect(sales1InChannel).toBe(false);
+
+        // ============================================================
+        // STEP 2: Test "in" operator
+        // Policy: Department in ["Engineering", "DevOps"] → Engineering matches
+        // ============================================================
+
+        await navigateToABACPage(systemConsolePage.page);
+        const channel2 = await createPrivateChannelForABAC(adminClient, team.id);
+        await adminClient.addToChannel(salesUser.id, channel2.id); // Sales user in channel initially
+
+        const policy2Name = `In Policy ${await pw.random.id()}`;
+        await createAdvancedPolicy(systemConsolePage.page, {
+            name: policy2Name,
+            celExpression: 'user.attributes.Department in ["Engineering", "DevOps"]',
+            autoSync: true,
+            channels: [channel2.display_name],
+        });
+
+        // Test Access Rule - navigate back to policy and verify
+        await systemConsolePage.page.waitForTimeout(1000);
+        const policyRowForTest2 = systemConsolePage.page.locator('.policy-name').filter({hasText: policy2Name}).first();
+        if (await policyRowForTest2.isVisible({timeout: 3000})) {
+            await policyRowForTest2.click();
+            await systemConsolePage.page.waitForLoadState('networkidle');
+
+            await testAccessRule(systemConsolePage.page, {
+                expectedMatchingUsers: [engineerUser.username],
+                expectedNonMatchingUsers: [salesUser.username],
+            });
+
+            await navigateToABACPage(systemConsolePage.page);
+        }
+
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        const searchInput2 = systemConsolePage.page.locator('input[placeholder*="Search" i]').first();
+        await searchInput2.fill('In Policy');
+        await systemConsolePage.page.waitForTimeout(1000);
+        const policyRow2 = systemConsolePage.page.locator('.policy-name').first();
+        const policyId2 = (await policyRow2.getAttribute('id'))?.replace('customDescription-', '');
+        if (policyId2) {
+            await activatePolicy(adminClient, policyId2);
+            await runSyncJob(systemConsolePage.page);
+            await waitForLatestSyncJob(systemConsolePage.page);
+        }
+        await searchInput2.clear();
+
+        const eng2InChannel = await verifyUserInChannel(adminClient, engineerUser.id, channel2.id);
+        const sales2InChannel = await verifyUserInChannel(adminClient, salesUser.id, channel2.id);
+        expect(eng2InChannel).toBe(true);
+        expect(sales2InChannel).toBe(false);
+
+        // ============================================================
+        // STEP 3: Test "starts with" operator
+        // Policy: Department.startsWith("Eng") → Engineering matches
+        // ============================================================
+
+        await navigateToABACPage(systemConsolePage.page);
+        const channel3 = await createPrivateChannelForABAC(adminClient, team.id);
+        await adminClient.addToChannel(salesUser.id, channel3.id);
+
+        const policy3Name = `StartsWith Policy ${await pw.random.id()}`;
+        await createAdvancedPolicy(systemConsolePage.page, {
+            name: policy3Name,
+            celExpression: 'user.attributes.Department.startsWith("Eng")',
+            autoSync: true,
+            channels: [channel3.display_name],
+        });
+
+        // Test Access Rule - navigate back to policy and verify
+        await systemConsolePage.page.waitForTimeout(1000);
+        const policyRowForTest3 = systemConsolePage.page.locator('.policy-name').filter({hasText: policy3Name}).first();
+        if (await policyRowForTest3.isVisible({timeout: 3000})) {
+            await policyRowForTest3.click();
+            await systemConsolePage.page.waitForLoadState('networkidle');
+
+            await testAccessRule(systemConsolePage.page, {
+                expectedMatchingUsers: [engineerUser.username],
+                expectedNonMatchingUsers: [salesUser.username],
+            });
+
+            await navigateToABACPage(systemConsolePage.page);
+        }
+
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        const searchInput3 = systemConsolePage.page.locator('input[placeholder*="Search" i]').first();
+        await searchInput3.fill('StartsWith');
+        await systemConsolePage.page.waitForTimeout(1000);
+        const policyRow3 = systemConsolePage.page.locator('.policy-name').first();
+        const policyId3 = (await policyRow3.getAttribute('id'))?.replace('customDescription-', '');
+        if (policyId3) {
+            await activatePolicy(adminClient, policyId3);
+            await runSyncJob(systemConsolePage.page);
+            await waitForLatestSyncJob(systemConsolePage.page);
+        }
+        await searchInput3.clear();
+
+        const eng3InChannel = await verifyUserInChannel(adminClient, engineerUser.id, channel3.id);
+        const sales3InChannel = await verifyUserInChannel(adminClient, salesUser.id, channel3.id);
+        expect(eng3InChannel).toBe(true);
+        expect(sales3InChannel).toBe(false);
+
+        // ============================================================
+        // STEP 4: Test "ends with" operator
+        // Policy: Department.endsWith("ing") → Engineering matches
+        // ============================================================
+
+        await navigateToABACPage(systemConsolePage.page);
+        const channel4 = await createPrivateChannelForABAC(adminClient, team.id);
+        await adminClient.addToChannel(salesUser.id, channel4.id);
+
+        const policy4Name = `EndsWith Policy ${await pw.random.id()}`;
+        await createAdvancedPolicy(systemConsolePage.page, {
+            name: policy4Name,
+            celExpression: 'user.attributes.Department.endsWith("ing")',
+            autoSync: true,
+            channels: [channel4.display_name],
+        });
+
+        // Test Access Rule - navigate back to policy and verify
+        await systemConsolePage.page.waitForTimeout(1000);
+        const policyRowForTest4 = systemConsolePage.page.locator('.policy-name').filter({hasText: policy4Name}).first();
+        if (await policyRowForTest4.isVisible({timeout: 3000})) {
+            await policyRowForTest4.click();
+            await systemConsolePage.page.waitForLoadState('networkidle');
+
+            await testAccessRule(systemConsolePage.page, {
+                expectedMatchingUsers: [engineerUser.username],
+                expectedNonMatchingUsers: [salesUser.username],
+            });
+
+            await navigateToABACPage(systemConsolePage.page);
+        }
+
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        const searchInput4 = systemConsolePage.page.locator('input[placeholder*="Search" i]').first();
+        await searchInput4.fill('EndsWith');
+        await systemConsolePage.page.waitForTimeout(1000);
+        const policyRow4 = systemConsolePage.page.locator('.policy-name').first();
+        const policyId4 = (await policyRow4.getAttribute('id'))?.replace('customDescription-', '');
+        if (policyId4) {
+            await activatePolicy(adminClient, policyId4);
+            await runSyncJob(systemConsolePage.page);
+            await waitForLatestSyncJob(systemConsolePage.page);
+        }
+        await searchInput4.clear();
+
+        const eng4InChannel = await verifyUserInChannel(adminClient, engineerUser.id, channel4.id);
+        const sales4InChannel = await verifyUserInChannel(adminClient, salesUser.id, channel4.id);
+        expect(eng4InChannel).toBe(true);
+        expect(sales4InChannel).toBe(false);
+
+        // ============================================================
+        // STEP 5: Test "contains" operator
+        // Policy: Department.contains("gineer") → Engineering matches
+        // ============================================================
+
+        await navigateToABACPage(systemConsolePage.page);
+        const channel5 = await createPrivateChannelForABAC(adminClient, team.id);
+        await adminClient.addToChannel(salesUser.id, channel5.id);
+
+        const policy5Name = `Contains Policy ${await pw.random.id()}`;
+        await createAdvancedPolicy(systemConsolePage.page, {
+            name: policy5Name,
+            celExpression: 'user.attributes.Department.contains("gineer")',
+            autoSync: true,
+            channels: [channel5.display_name],
+        });
+
+        // Test Access Rule - navigate back to policy and verify
+        await systemConsolePage.page.waitForTimeout(1000);
+        const policyRowForTest5 = systemConsolePage.page.locator('.policy-name').filter({hasText: policy5Name}).first();
+        if (await policyRowForTest5.isVisible({timeout: 3000})) {
+            await policyRowForTest5.click();
+            await systemConsolePage.page.waitForLoadState('networkidle');
+
+            await testAccessRule(systemConsolePage.page, {
+                expectedMatchingUsers: [engineerUser.username],
+                expectedNonMatchingUsers: [salesUser.username],
+            });
+
+            await navigateToABACPage(systemConsolePage.page);
+        }
+
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        const searchInput5 = systemConsolePage.page.locator('input[placeholder*="Search" i]').first();
+        await searchInput5.fill('Contains');
+        await systemConsolePage.page.waitForTimeout(1000);
+        const policyRow5 = systemConsolePage.page.locator('.policy-name').first();
+        const policyId5 = (await policyRow5.getAttribute('id'))?.replace('customDescription-', '');
+        if (policyId5) {
+            await activatePolicy(adminClient, policyId5);
+            await runSyncJob(systemConsolePage.page);
+            await waitForLatestSyncJob(systemConsolePage.page);
+        }
+        await searchInput5.clear();
+
+        const eng5InChannel = await verifyUserInChannel(adminClient, engineerUser.id, channel5.id);
+        const sales5InChannel = await verifyUserInChannel(adminClient, salesUser.id, channel5.id);
+        expect(eng5InChannel).toBe(true);
+        expect(sales5InChannel).toBe(false);
+    });
+
+    /**
+     * MM-T5787: Attribute-based access policy created using Advanced Mode with complex rules
+     * @objective Verify complex CEL expressions with || (or) and () grouping work correctly
+     *
+     * Test Data:
+     * - Test || (or) with multiple conditions
+     * - Test using () to group conditions
+     *
+     * Expected:
+     * - User who satisfies the multi-rule policy is auto-added
+     * - User who does not satisfy all rules is auto-removed
+     */
+    test('MM-T5787 Test policy with complex rules in Advanced Mode', async ({pw}) => {
+        test.setTimeout(120000); // 2 minutes
+
+        // # Skip test if no license for ABAC
+        await pw.skipIfNoLicense();
+
+        // # Setup
+        const {adminUser, adminClient, team} = await pw.initSetup();
+
+        // # Enable user-managed attributes first
+        await enableUserManagedAttributes(adminClient);
+
+        // # Delete existing attributes and create fresh ones
+        // This ensures the Location attribute exists (same fix as MM-T5785)
+        try {
+            const existingFields = await (adminClient as any).doFetch(
+                `${adminClient.getBaseRoute()}/custom_profile_attributes/fields`,
+                {method: 'GET'},
+            );
+            for (const field of existingFields || []) {
+                try {
+                    await adminClient.deleteCustomProfileAttributeField(field.id);
+                } catch {
+                    // Ignore deletion errors
+                }
+            }
+        } catch {
+            // Ignore errors
+        }
+
+        // # Create attributes: Department and Location
+        const attributeFieldsMap = await setupCustomProfileAttributeFields(adminClient, [
+            {name: 'Department', type: 'text'},
+            {name: 'Location', type: 'text'},
+        ]);
+
+        // Verify attributes were created (unused but kept for debugging)
+        Object.keys(attributeFieldsMap);
+
+        // # Create test users with different attribute combinations
+        // User 1: Department=Engineering (satisfies first condition)
+        const engineerUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', value: 'Engineering', type: 'text'},
+            {name: 'Location', value: 'Office', type: 'text'},
+        ]);
+
+        // User 2: Department=Sales AND Location=Remote (satisfies second grouped condition)
+        const salesRemoteUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', value: 'Sales', type: 'text'},
+            {name: 'Location', value: 'Remote', type: 'text'},
+        ]);
+
+        // User 3: Department=Sales, Location=Office (meets SOME rules - Sales but not Remote)
+        // This user satisfies only PART of the grouped condition (Sales && Remote)
+        const salesOfficeUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', value: 'Sales', type: 'text'},
+            {name: 'Location', value: 'Office', type: 'text'},
+        ]);
+
+        // # Add all users to the team
+        await adminClient.addToTeam(team.id, engineerUser.id);
+        await adminClient.addToTeam(team.id, salesRemoteUser.id);
+        await adminClient.addToTeam(team.id, salesOfficeUser.id);
+
+        // # Create private channel with salesOfficeUser in it (will be removed - meets only SOME rules)
+        const channel = await createPrivateChannelForABAC(adminClient, team.id);
+        await adminClient.addToChannel(salesOfficeUser.id, channel.id);
+
+        // # Login and navigate
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        await navigateToABACPage(systemConsolePage.page);
+        await enableABAC(systemConsolePage.page);
+
+        // # Reload page to ensure UI sees the API-created attributes
+        await systemConsolePage.page.reload();
+        await systemConsolePage.page.waitForLoadState('networkidle');
+
+        // # Create policy with complex CEL expression using || and ()
+        // Expression: Department == "Engineering" OR (Department == "Sales" AND Location == "Remote")
+        const policyName = `Complex Policy ${await pw.random.id()}`;
+        const complexExpression =
+            'user.attributes.Department == "Engineering" || (user.attributes.Department == "Sales" && user.attributes.Location == "Remote")';
+
+        await createAdvancedPolicy(systemConsolePage.page, {
+            name: policyName,
+            celExpression: complexExpression,
+            autoSync: true,
+            channels: [channel.display_name],
+        });
+
+        // # Ensure we're on the ABAC page
+        await navigateToABACPage(systemConsolePage.page);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        // # Test Access Rule - click on policy to open it
+        const policyRow = systemConsolePage.page.locator('.policy-name').filter({hasText: policyName}).first();
+        if (await policyRow.isVisible({timeout: 5000})) {
+            await policyRow.click();
+            await systemConsolePage.page.waitForLoadState('networkidle');
+
+            await testAccessRule(systemConsolePage.page, {
+                expectedMatchingUsers: [engineerUser.username, salesRemoteUser.username],
+                expectedNonMatchingUsers: [salesOfficeUser.username],
+            });
+
+            // Go back to ABAC page
+            await navigateToABACPage(systemConsolePage.page);
+        } else {
+            // Policy row not visible
+        }
+
+        // # Wait for sync job (from Apply Policy)
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        // # Find and activate the policy - search by unique ID part
+        const searchInput = systemConsolePage.page.locator('input[placeholder*="Search" i]').first();
+        const policyIdMatch = policyName.match(/([a-z0-9]+)$/i);
+        const searchTerm = policyIdMatch ? policyIdMatch[1] : policyName;
+
+        await searchInput.fill(searchTerm);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        // Find the specific policy by name
+        const foundPolicy = systemConsolePage.page.locator('.policy-name').filter({hasText: policyName}).first();
+        if (await foundPolicy.isVisible({timeout: 5000})) {
+            const policyId = (await foundPolicy.getAttribute('id'))?.replace('customDescription-', '');
+            if (policyId) {
+                await activatePolicy(adminClient, policyId);
+                await runSyncJob(systemConsolePage.page);
+                await waitForLatestSyncJob(systemConsolePage.page);
+            }
+        } else {
+            // Try to list what policies ARE visible
+            await systemConsolePage.page.locator('.policy-name').allTextContents();
+        }
+        await searchInput.clear();
+
+        // # Verify results
+
+        // Step 6: Engineer should be auto-added (satisfies: Department == "Engineering")
+        const engineerInChannel = await verifyUserInChannel(adminClient, engineerUser.id, channel.id);
+        expect(engineerInChannel).toBe(true);
+
+        // Step 6: Sales+Remote user should be auto-added (satisfies: Department == "Sales" && Location == "Remote")
+        const salesRemoteInChannel = await verifyUserInChannel(adminClient, salesRemoteUser.id, channel.id);
+        expect(salesRemoteInChannel).toBe(true);
+
+        // Step 7: Sales-Office user should be removed (meets SOME rules but not ALL - Sales but not Remote)
+        const salesOfficeInChannel = await verifyUserInChannel(adminClient, salesOfficeUser.id, channel.id);
+        expect(salesOfficeInChannel).toBe(false);
+    });
+});

--- a/e2e-tests/playwright/specs/functional/system_console/abac/policies/channel_integration.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/policies/channel_integration.spec.ts
@@ -1,0 +1,408 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {
+    expect,
+    test,
+    enableABAC,
+    navigateToABACPage,
+    runSyncJob,
+    verifyUserInChannel,
+} from '@mattermost/playwright-lib';
+
+import {setupCustomProfileAttributeFields} from '../../../channels/custom_profile_attributes/helpers';
+import {
+    ensureUserAttributes,
+    createUserForABAC,
+    createPrivateChannelForABAC,
+    createBasicPolicy,
+    waitForLatestSyncJob,
+} from '../support';
+
+/**
+ * ABAC Policies - Channel Integration
+ * Tests for managing ABAC policies through Channel Configuration
+ */
+test.describe('ABAC Policies - Channel Integration', () => {
+    /**
+     * MM-T5788: Add attribute-based policy to a channel from Channel Configuration page
+     * @objective Verify that a policy can be added to a channel from the Channel Configuration page
+     *
+     * Steps:
+     * 1. As admin go to System Console > User Management > Channels
+     */
+    test('MM-T5788 Add policy to channel from Channel Configuration page', async ({pw}) => {
+        test.setTimeout(120000);
+
+        await pw.skipIfNoLicense();
+
+        // ============================================================
+        // SETUP: Create users, channel, and policy
+        // ============================================================
+        const {adminUser, adminClient, team} = await pw.initSetup();
+        await ensureUserAttributes(adminClient);
+
+        const attributeFieldsMap = await setupCustomProfileAttributeFields(adminClient, [
+            {name: 'Department', type: 'text'},
+        ]);
+
+        // Create satisfying user (Department=Engineering) - NOT in channel initially
+        const satisfyingUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', value: 'Engineering', type: 'text'},
+        ]);
+        await adminClient.addToTeam(team.id, satisfyingUser.id);
+
+        // Create non-satisfying user (Department=Sales) - will be IN channel initially
+        const nonSatisfyingUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', value: 'Sales', type: 'text'},
+        ]);
+        await adminClient.addToTeam(team.id, nonSatisfyingUser.id);
+
+        // Create private channel and add non-satisfying user
+        const channel = await createPrivateChannelForABAC(adminClient, team.id);
+        await adminClient.addToChannel(nonSatisfyingUser.id, channel.id);
+
+        // Login and setup ABAC
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        await navigateToABACPage(systemConsolePage.page);
+        await enableABAC(systemConsolePage.page);
+
+        // Create policy without channels (we'll link via Channel Config)
+        const policyName = `Channel Config Policy ${await pw.random.id()}`;
+        await createBasicPolicy(systemConsolePage.page, {
+            name: policyName,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+        });
+
+        // Get search term for policy
+        const policyIdMatch = policyName.match(/([a-z0-9]+)$/i);
+        const searchTerm = policyIdMatch ? policyIdMatch[1] : policyName;
+
+        // ============================================================
+        // STEP 1-2: Navigate to Channel Configuration
+        // ============================================================
+
+        await systemConsolePage.page.goto('/admin_console/user_management/channels');
+        await systemConsolePage.page.waitForLoadState('networkidle');
+
+        // Search and find our channel
+        const channelSearchInput = systemConsolePage.page.locator('input[placeholder*="Search" i]').first();
+        await channelSearchInput.fill(channel.display_name);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        // Verify channel shows "Manual Invites" management
+        const channelRow = systemConsolePage.page
+            .locator('.DataGrid_row')
+            .filter({hasText: channel.display_name})
+            .first();
+        // const managementText = await channelRow.textContent();
+
+        // Click Edit
+        await channelRow.getByText('Edit').click();
+        await systemConsolePage.page.waitForLoadState('networkidle');
+
+        // ============================================================
+        // STEP 3: Toggle on "Enable attribute based channel access"
+        // ============================================================
+
+        const abacToggle = systemConsolePage.page.locator('[data-testid="policy-enforce-toggle-button"]');
+        await abacToggle.waitFor({state: 'visible', timeout: 5000});
+
+        const isEnabled = await abacToggle.getAttribute('aria-pressed');
+        if (isEnabled !== 'true') {
+            await abacToggle.click();
+        }
+        await systemConsolePage.page.waitForTimeout(500);
+
+        // ============================================================
+        // STEP 4: Link to policy and Save
+        // ============================================================
+
+        // Click "Link to a policy"
+        const linkButton = systemConsolePage.page.locator('[data-testid="link-to-a-policy"]');
+        await linkButton.waitFor({state: 'visible', timeout: 5000});
+        await linkButton.click();
+        await systemConsolePage.page.waitForTimeout(500);
+
+        // Select policy in modal
+        const modal = systemConsolePage.page
+            .locator('[role="dialog"]')
+            .filter({hasText: 'Select an Access Control Policy'});
+        await modal.waitFor({state: 'visible', timeout: 5000});
+
+        const modalSearch = modal.locator('[data-testid="searchInput"]');
+        await modalSearch.fill(searchTerm);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        const policyOption = modal.locator('.DataGrid_row').filter({hasText: policyName}).first();
+        await policyOption.click();
+        await systemConsolePage.page.waitForTimeout(500);
+
+        // Save
+        await systemConsolePage.page.getByRole('button', {name: 'Save'}).click();
+        await systemConsolePage.page.waitForLoadState('networkidle');
+
+        // ============================================================
+        // Run sync to apply policy
+        // ============================================================
+        await systemConsolePage.page.waitForTimeout(2000);
+        await navigateToABACPage(systemConsolePage.page);
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        // ============================================================
+        // VERIFY: Channel membership
+        // ============================================================
+
+        // 1. Non-satisfying user should be REMOVED
+        const nonSatisfyingInChannel = await verifyUserInChannel(adminClient, nonSatisfyingUser.id, channel.id);
+        expect(nonSatisfyingInChannel).toBe(false);
+
+        // 2. Satisfying user should NOT be auto-added (per requirement)
+        const satisfyingInChannel = await verifyUserInChannel(adminClient, satisfyingUser.id, channel.id);
+        // Note: If implementation auto-adds, this will fail. Adjust if needed.
+        expect(satisfyingInChannel).toBe(false);
+
+        // 3. Satisfying user CAN be manually added
+        await adminClient.addToChannel(satisfyingUser.id, channel.id);
+        const afterManualAdd = await verifyUserInChannel(adminClient, satisfyingUser.id, channel.id);
+        expect(afterManualAdd).toBe(true);
+
+        // 4. Non-satisfying user CANNOT be added (blocked by policy)
+        let blocked = false;
+        try {
+            await adminClient.addToChannel(nonSatisfyingUser.id, channel.id);
+        } catch {
+            // Expected to fail - policy blocks non-qualifying users
+            blocked = true;
+        }
+        expect(blocked).toBe(true);
+    });
+
+    /**
+     * MM-T5789: Channel cannot use attribute-based policies if already constrained by LDAP group sync
+     *
+     * Preconditions:
+     * - At least one policy exists on the server
+     * - At least one channel configured to be constrained by LDAP group sync
+     *
+     * Step 1:
+     * 1. As admin go to System Console > User Management > Channels
+     * 2. Click a channel with Management = "Group Sync" (private channel)
+     * 3. Observe "Enable attribute based channel access" is NOT available
+     * 4. Toggle off "Sync Group Members", observe ABAC becomes available
+     *
+     * Step 2:
+     * 1. Go to System Console > User Management > Attribute-Based Access
+     * 2. Click a policy to edit it, click Add channels
+     * 3. Select a channel constrained by LDAP group sync
+     *
+     * Expected: ABAC not available for channels using LDAP group sync
+     *
+     * Test Data Note: Current UI behavior is uncertain - may allow save but channel
+     * not added, or may show error. This test observes and documents actual behavior.
+     *
+     * Implementation Note: We mock Group Sync by setting group_constrained=true via API.
+     * This works without LDAP - the server accepts it and UI shows "Group Sync".
+     */
+    test('MM-T5789 Channel with LDAP group sync cannot use ABAC', async ({pw}) => {
+        test.setTimeout(120000);
+
+        await pw.skipIfNoLicense();
+
+        const {adminUser, adminClient, team} = await pw.initSetup();
+        await ensureUserAttributes(adminClient);
+
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        const page = systemConsolePage.page;
+
+        // ===========================================
+        // PRECONDITION 1: Create a policy first
+        // ===========================================
+        await navigateToABACPage(page);
+        await enableABAC(page);
+
+        const policyName = `ABAC-GroupSync-Test-${await pw.random.id()}`;
+        await createBasicPolicy(page, {
+            name: policyName,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: false,
+        });
+
+        // ===========================================
+        // PRECONDITION 2: Create a Group Sync channel via API
+        // We mock Group Sync by setting group_constrained=true
+        // This works without LDAP configuration
+        // ===========================================
+
+        const groupSyncChannelName = `ABAC-GroupSync-${await pw.random.id()}`;
+        const groupSyncChannel = await adminClient.createChannel({
+            team_id: team.id,
+            name: groupSyncChannelName.toLowerCase().replace(/[^a-z0-9]/g, ''),
+            display_name: groupSyncChannelName,
+            type: 'P', // Private
+        });
+
+        // Set group_constrained=true via API to mock Group Sync
+        await adminClient.patchChannel(groupSyncChannel.id, {
+            group_constrained: true,
+        } as any);
+
+        // ===========================================
+        // STEP 1: Navigate to Group Sync channel config
+        // ===========================================
+        await page.goto('/admin_console/user_management/channels');
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(1000);
+
+        // Search for our channel
+        const searchInput = page.locator('input[placeholder*="Search" i]').first();
+        if (await searchInput.isVisible({timeout: 3000})) {
+            await searchInput.fill(groupSyncChannelName);
+            await page.waitForTimeout(1000);
+        }
+
+        // Verify channel shows as "Group Sync"
+        const channelRow = page.locator('.DataGrid_row').filter({hasText: groupSyncChannelName}).first();
+        await channelRow.waitFor({state: 'visible', timeout: 10000});
+
+        const rowText = await channelRow.textContent();
+        expect(rowText).toContain('Group Sync');
+
+        // Click Edit to open channel configuration
+        await channelRow.getByText('Edit').click();
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(1000);
+
+        // STEP 1.3: Verify ABAC toggle is NOT available when Group Sync is enabled
+        const abacToggle = page.locator('[data-testid="policy-enforce-toggle-button"]');
+        const abacVisibleWithGroupSync = await abacToggle.isVisible({timeout: 5000}).catch(() => false);
+
+        expect(abacVisibleWithGroupSync).toBe(false);
+
+        // STEP 1.4: Toggle off Group Sync and verify ABAC becomes available
+
+        // Disable Group Sync via API (more reliable than UI toggle)
+        await adminClient.patchChannel(groupSyncChannel.id, {
+            group_constrained: false,
+        } as any);
+
+        // Reload page to see updated UI
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(1000);
+
+        // Verify ABAC toggle is now available
+        const abacToggleAfter = page.locator('[data-testid="policy-enforce-toggle-button"]');
+        const abacVisibleAfterDisable = await abacToggleAfter.isVisible({timeout: 5000}).catch(() => false);
+
+        expect(abacVisibleAfterDisable).toBe(true);
+
+        // Re-enable Group Sync for Step 2
+        await adminClient.patchChannel(groupSyncChannel.id, {
+            group_constrained: true,
+        } as any);
+
+        // ===========================================
+        // STEP 2: Try to add Group Sync channel to existing policy
+        // ===========================================
+        await navigateToABACPage(page);
+        await page.waitForTimeout(1000);
+
+        // Step 2.2: Click the policy to edit it
+
+        // Search for the policy first
+        const policySearchInput = page.locator('input[placeholder*="Search" i]').first();
+        if (await policySearchInput.isVisible({timeout: 3000})) {
+            await policySearchInput.fill(policyName);
+            await page.waitForTimeout(1000);
+        }
+
+        // Click on the policy row (use text-based locator)
+        const policyRowLocator = page.locator('tr.clickable, .DataGrid_row').filter({hasText: policyName}).first();
+        await policyRowLocator.waitFor({state: 'visible', timeout: 10000});
+        await policyRowLocator.click();
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(1000);
+
+        // Click Add channels button
+        const addChannelsButton = page.getByRole('button', {name: /add channel/i});
+        await addChannelsButton.waitFor({state: 'visible', timeout: 10000});
+        await addChannelsButton.click();
+        await page.waitForTimeout(1000);
+
+        // Step 2.3: Try to select the Group Sync channel
+        const channelModal = page.locator('[role="dialog"]').filter({hasText: /channel/i});
+        await channelModal.waitFor({state: 'visible', timeout: 5000});
+
+        // Search for the Group Sync channel
+        const modalSearchInput = channelModal.locator('[data-testid="searchInput"], input[type="text"]').first();
+        if (await modalSearchInput.isVisible({timeout: 3000})) {
+            await modalSearchInput.fill(groupSyncChannelName);
+            await page.waitForTimeout(1000);
+        }
+
+        // Document actual behavior (requirement notes uncertainty)
+
+        const channelRows = channelModal.locator('.DataGrid_row, .more-modal__row');
+        const rowCount = await channelRows.count();
+
+        if (rowCount === 0) {
+            // Group Sync channel is filtered out - good behavior
+        } else {
+            // Channel is shown - try to select it
+            const channelRowToSelect = channelRows.first();
+            await channelRowToSelect.textContent();
+
+            // Try to click/select the channel
+            await channelRowToSelect.click({timeout: 5000}).catch(() => {
+                // Ignore click errors
+            });
+            await page.waitForTimeout(500);
+
+            // Try to click Add button
+            const addButton = channelModal.getByRole('button', {name: 'Add'});
+            if (await addButton.isVisible({timeout: 3000})) {
+                const addButtonDisabled = await addButton.isDisabled();
+                if (addButtonDisabled) {
+                    // Add button is disabled
+                } else {
+                    await addButton.click();
+                    await page.waitForTimeout(1000);
+                }
+            }
+
+            // Close modal
+            const closeButton = channelModal.getByRole('button', {name: /close|cancel|×/i});
+            if (await closeButton.isVisible({timeout: 2000})) {
+                await closeButton.click();
+                await page.waitForTimeout(500);
+            }
+
+            // Check if we're back on edit page - try to save
+            const saveButton = page.getByRole('button', {name: 'Save'});
+            if (await saveButton.isVisible({timeout: 3000})) {
+                const saveEnabled = await saveButton.isEnabled();
+
+                if (saveEnabled) {
+                    await saveButton.click();
+                    await page.waitForTimeout(2000);
+
+                    // Check for error message
+                    const errorMessage = page.locator('.error-message, [class*="error"], .alert-danger');
+                    const hasError = await errorMessage.isVisible({timeout: 3000}).catch(() => false);
+
+                    if (hasError) {
+                        await errorMessage.textContent();
+                    } else {
+                        // Check if channel was actually added
+                    }
+                }
+            }
+        }
+    });
+});

--- a/e2e-tests/playwright/specs/functional/system_console/abac/policies/create_policies.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/policies/create_policies.spec.ts
@@ -1,0 +1,368 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {
+    expect,
+    test,
+    enableABAC,
+    navigateToABACPage,
+    runSyncJob,
+    verifyUserInChannel,
+} from '@mattermost/playwright-lib';
+
+import {
+    CustomProfileAttribute,
+    setupCustomProfileAttributeFields,
+} from '../../../channels/custom_profile_attributes/helpers';
+import {
+    createUserForABAC,
+    testAccessRule,
+    createPrivateChannelForABAC,
+    createBasicPolicy,
+    activatePolicy,
+    waitForLatestSyncJob,
+    getJobDetailsFromRecentJobs,
+    enableUserManagedAttributes,
+} from '../support';
+
+/**
+ * ABAC Policies - Create Policies
+ * Tests for creating ABAC policies with different auto-add settings
+ */
+test.describe('ABAC Policies - Create Policies', () => {
+    test('MM-T5783 Create and test policy with auto-add disabled', async ({pw}) => {
+        // # Skip test if no license for ABAC
+        await pw.skipIfNoLicense();
+
+        // ============================================================
+        // SETUP: Create users and channel BEFORE creating policy
+        // ============================================================
+        const {adminUser, adminClient, team} = await pw.initSetup();
+
+        // Enable user-managed attributes
+        await enableUserManagedAttributes(adminClient);
+
+        // Define and create the Department attribute field
+        const departmentAttribute: CustomProfileAttribute[] = [{name: 'Department', type: 'text', value: ''}];
+        const attributeFieldsMap = await setupCustomProfileAttributeFields(adminClient, departmentAttribute);
+
+        // Create 3 users as per test case:
+        // 1. satisfyingUserNotInChannel - Department=Engineering, NOT in channel initially
+        // 2. satisfyingUserInChannel - Department=Engineering, IN channel initially
+        // 3. nonSatisfyingUserInChannel - Department=Sales, IN channel initially
+
+        const satisfyingUserNotInChannel = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', type: 'text', value: 'Engineering'},
+        ]);
+
+        const satisfyingUserInChannel = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', type: 'text', value: 'Engineering'},
+        ]);
+
+        const nonSatisfyingUserInChannel = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', type: 'text', value: 'Sales'},
+        ]);
+
+        // Add all users to the team
+        await adminClient.addToTeam(team.id, satisfyingUserNotInChannel.id);
+        await adminClient.addToTeam(team.id, satisfyingUserInChannel.id);
+        await adminClient.addToTeam(team.id, nonSatisfyingUserInChannel.id);
+
+        // Create private channel and add users 2 and 3 (but NOT user 1)
+        const privateChannel = await createPrivateChannelForABAC(adminClient, team.id);
+        await adminClient.addToChannel(satisfyingUserInChannel.id, privateChannel.id);
+        await adminClient.addToChannel(nonSatisfyingUserInChannel.id, privateChannel.id);
+
+        // Verify initial channel state
+        const initialUser1InChannel = await verifyUserInChannel(
+            adminClient,
+            satisfyingUserNotInChannel.id,
+            privateChannel.id,
+        );
+        const initialUser2InChannel = await verifyUserInChannel(
+            adminClient,
+            satisfyingUserInChannel.id,
+            privateChannel.id,
+        );
+        const initialUser3InChannel = await verifyUserInChannel(
+            adminClient,
+            nonSatisfyingUserInChannel.id,
+            privateChannel.id,
+        );
+        expect(initialUser1InChannel).toBe(false);
+        expect(initialUser2InChannel).toBe(true);
+        expect(initialUser3InChannel).toBe(true);
+
+        // ============================================================
+        // STEP 1-4: Login, navigate to ABAC, create policy with rule and channel
+        // ============================================================
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        await navigateToABACPage(systemConsolePage.page);
+        await enableABAC(systemConsolePage.page);
+
+        // Use the working createBasicPolicy helper (same as MM-T5784)
+        const policyName = `Engineering Policy ${await pw.random.id()}`;
+        await createBasicPolicy(systemConsolePage.page, {
+            name: policyName,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: false, // Auto-add DISABLED for this test
+            channels: [privateChannel.display_name],
+        });
+
+        // ============================================================
+        // STEP 3: Test Access Rule (navigate back to policy to test)
+        // ============================================================
+
+        // Navigate back to policy to test the access rule
+        await systemConsolePage.page.waitForTimeout(1000);
+        const policyRowForTest = systemConsolePage.page.locator('.policy-name').filter({hasText: policyName}).first();
+        if (await policyRowForTest.isVisible({timeout: 3000})) {
+            await policyRowForTest.click();
+            await systemConsolePage.page.waitForLoadState('networkidle');
+
+            const testResult = await testAccessRule(systemConsolePage.page, {
+                expectedMatchingUsers: [satisfyingUserNotInChannel.username, satisfyingUserInChannel.username],
+                expectedNonMatchingUsers: [nonSatisfyingUserInChannel.username],
+            });
+
+            expect(testResult.expectedUsersMatch).toBe(true);
+            expect(testResult.unexpectedUsersMatch).toBe(false);
+
+            // Navigate back to ABAC page
+            await navigateToABACPage(systemConsolePage.page);
+        }
+
+        // Wait for sync job to complete (triggered by createBasicPolicy)
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        // ============================================================
+        // STEP 5-7: Verify channel membership after sync
+        // ============================================================
+
+        // Step 5: User who satisfies policy but NOT in channel → should NOT be auto-added
+        const user1AfterSync = await verifyUserInChannel(adminClient, satisfyingUserNotInChannel.id, privateChannel.id);
+        expect(user1AfterSync).toBe(false); // NOT auto-added because auto-add is FALSE
+
+        // Step 6: User who satisfies policy and IS in channel → no change (stays in channel)
+        const user2AfterSync = await verifyUserInChannel(adminClient, satisfyingUserInChannel.id, privateChannel.id);
+        expect(user2AfterSync).toBe(true); // Stays in channel
+
+        // Step 7: User who does NOT satisfy policy and IS in channel → auto-removed
+        const user3AfterSync = await verifyUserInChannel(adminClient, nonSatisfyingUserInChannel.id, privateChannel.id);
+        expect(user3AfterSync).toBe(false); // AUTO-REMOVED
+
+        // ============================================================
+        // STEP 8: Admin can manually add the satisfying user to channel
+        // Validate: satisfying user CAN be added, non-satisfying user CANNOT
+        // ============================================================
+
+        // 8a. Add user who SATISFIES the policy - should succeed
+        await adminClient.addToChannel(satisfyingUserNotInChannel.id, privateChannel.id);
+        const user1AfterManualAdd = await verifyUserInChannel(
+            adminClient,
+            satisfyingUserNotInChannel.id,
+            privateChannel.id,
+        );
+        expect(user1AfterManualAdd).toBe(true); // Successfully added by admin
+
+        // 8b. Try to add user who does NOT satisfy the policy - should FAIL
+        try {
+            await adminClient.addToChannel(nonSatisfyingUserInChannel.id, privateChannel.id);
+        } catch {
+            // Expected to fail - policy prevents non-compliant users
+        }
+
+        // Verify the non-satisfying user is NOT in the channel
+        const user3AfterAttempt = await verifyUserInChannel(
+            adminClient,
+            nonSatisfyingUserInChannel.id,
+            privateChannel.id,
+        );
+        expect(user3AfterAttempt).toBe(false); // Policy prevents non-compliant users
+    });
+
+    /**
+     * MM-T5784: Attribute-based access policy created in System Console controls access as specified
+     * (one attribute, = is, with auto-add)
+     *
+     * @reference https://github.com/mattermost/mattermost-test-management/blob/main/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5784.md
+     *
+     * Test Steps:
+     * 1. As system admin, go to ABAC page, click Add policy, enter name, set Auto-add = TRUE
+     * 2. Select policy values: Attribute, Operator, and Value (just one)
+     * 3. Click Test Access Rule, observe users who satisfy the policy are listed
+     * 4. Click Add channels and select a channel, then save
+     * 5. User who satisfies policy but NOT in channel → should be AUTO-ADDED
+     * 6. User who satisfies policy and IS in channel → no change (stays in channel)
+     * 7. User who does NOT satisfy policy and IS in channel → auto-removed
+     *
+     * Expected:
+     * - User who satisfies the policy is auto-added
+     * - User who does not satisfy the policy is auto-removed
+     */
+    test('MM-T5784 Create and test policy with auto-add enabled', async ({pw}) => {
+        // Increase timeout for this complex test to prevent trace file race conditions
+        test.setTimeout(120000); // 2 minutes instead of default 1 minute
+
+        // # Skip test if no license for ABAC
+        await pw.skipIfNoLicense();
+
+        // ============================================================
+        // SETUP: Create users and channel BEFORE creating policy
+        // ============================================================
+        const {adminUser, adminClient, team} = await pw.initSetup();
+
+        // Enable user-managed attributes
+        await enableUserManagedAttributes(adminClient);
+
+        // Define and create the Department attribute field
+        const departmentAttribute: CustomProfileAttribute[] = [{name: 'Department', type: 'text', value: ''}];
+        const attributeFieldsMap = await setupCustomProfileAttributeFields(adminClient, departmentAttribute);
+
+        // Create 3 users as per test case:
+        // 1. satisfyingUserNotInChannel - Department=Engineering, NOT in channel initially
+        // 2. satisfyingUserInChannel - Department=Engineering, IN channel initially
+        // 3. nonSatisfyingUserInChannel - Department=Sales, IN channel initially
+
+        const satisfyingUserNotInChannel = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', type: 'text', value: 'Engineering'},
+        ]);
+
+        const satisfyingUserInChannel = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', type: 'text', value: 'Engineering'},
+        ]);
+
+        const nonSatisfyingUserInChannel = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', type: 'text', value: 'Sales'},
+        ]);
+
+        // Add all users to the team
+        await adminClient.addToTeam(team.id, satisfyingUserNotInChannel.id);
+        await adminClient.addToTeam(team.id, satisfyingUserInChannel.id);
+        await adminClient.addToTeam(team.id, nonSatisfyingUserInChannel.id);
+
+        // Wait for user attributes to be indexed before creating policy
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+
+        // Create private channel and add users 2 and 3 (but NOT user 1)
+        const privateChannel = await createPrivateChannelForABAC(adminClient, team.id);
+        await adminClient.addToChannel(satisfyingUserInChannel.id, privateChannel.id);
+        await adminClient.addToChannel(nonSatisfyingUserInChannel.id, privateChannel.id);
+
+        // Verify initial channel state
+        const initialUser1InChannel = await verifyUserInChannel(
+            adminClient,
+            satisfyingUserNotInChannel.id,
+            privateChannel.id,
+        );
+        const initialUser2InChannel = await verifyUserInChannel(
+            adminClient,
+            satisfyingUserInChannel.id,
+            privateChannel.id,
+        );
+        const initialUser3InChannel = await verifyUserInChannel(
+            adminClient,
+            nonSatisfyingUserInChannel.id,
+            privateChannel.id,
+        );
+        expect(initialUser1InChannel).toBe(false);
+        expect(initialUser2InChannel).toBe(true);
+        expect(initialUser3InChannel).toBe(true);
+
+        // ============================================================
+        // STEP 1-4: Login, navigate to ABAC, create policy with auto-add TRUE
+        // ============================================================
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        await navigateToABACPage(systemConsolePage.page);
+        await enableABAC(systemConsolePage.page);
+
+        // Use createBasicPolicy with autoSync: true
+        const policyName = `Auto-Add Policy ${await pw.random.id()}`;
+        await createBasicPolicy(systemConsolePage.page, {
+            name: policyName,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: true, // Auto-add ENABLED for this test
+            channels: [privateChannel.display_name],
+        });
+
+        // ============================================================
+        // STEP 3: Test Access Rule (navigate back to policy to test)
+        // ============================================================
+
+        await systemConsolePage.page.waitForTimeout(1000);
+        const policyRowForTest = systemConsolePage.page.locator('.policy-name').filter({hasText: policyName}).first();
+        if (await policyRowForTest.isVisible({timeout: 3000})) {
+            await policyRowForTest.click();
+            await systemConsolePage.page.waitForLoadState('networkidle');
+
+            const testResult = await testAccessRule(systemConsolePage.page, {
+                expectedMatchingUsers: [satisfyingUserNotInChannel.username, satisfyingUserInChannel.username],
+                expectedNonMatchingUsers: [nonSatisfyingUserInChannel.username],
+            });
+
+            expect(testResult.expectedUsersMatch).toBe(true);
+            expect(testResult.unexpectedUsersMatch).toBe(false);
+
+            await navigateToABACPage(systemConsolePage.page);
+        }
+
+        // Wait for initial sync job to complete
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        // Get policy ID and activate it for auto-add to work
+        const searchInput = systemConsolePage.page.locator('input[placeholder*="Search" i]').first();
+        await searchInput.waitFor({state: 'visible', timeout: 5000});
+
+        const idMatch = policyName.match(/([a-z0-9]+)$/i);
+        const uniqueId = idMatch ? idMatch[1] : policyName;
+        await searchInput.fill(uniqueId);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        const policyRow = systemConsolePage.page.locator('.policy-name').first();
+        const policyElementId = await policyRow.getAttribute('id');
+        const policyId = policyElementId?.replace('customDescription-', '');
+
+        if (!policyId) {
+            throw new Error('Could not get policy ID');
+        }
+        await searchInput.clear();
+
+        // Activate the policy so auto-add works
+        await activatePolicy(adminClient, policyId);
+
+        // Run sync job with active policy
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        // ============================================================
+        // VERIFY VIA JOB DETAILS: Check recent jobs for channel membership changes
+        // Note: Sometimes two jobs are created simultaneously, so we check both
+        // ============================================================
+        const jobDetails = await getJobDetailsFromRecentJobs(systemConsolePage.page, privateChannel.display_name);
+
+        // Expected: +1 added (satisfyingUserNotInChannel)
+        // Removed: 2 (nonSatisfyingUserInChannel + admin who created the channel without Department=Engineering)
+        expect(jobDetails.added).toBe(1); // satisfyingUserNotInChannel was auto-added
+        expect(jobDetails.removed).toBeGreaterThanOrEqual(1); // At least nonSatisfyingUserInChannel was removed (admin may also be removed)
+
+        // ============================================================
+        // STEP 5-7: Also verify via API for completeness
+        // ============================================================
+
+        // Step 5: User who satisfies policy but NOT in channel → should be AUTO-ADDED
+        const user1AfterSync = await verifyUserInChannel(adminClient, satisfyingUserNotInChannel.id, privateChannel.id);
+        expect(user1AfterSync).toBe(true); // AUTO-ADDED because auto-add is TRUE
+
+        // Step 6: User who satisfies policy and IS in channel → no change (stays in channel)
+        const user2AfterSync = await verifyUserInChannel(adminClient, satisfyingUserInChannel.id, privateChannel.id);
+        expect(user2AfterSync).toBe(true); // Stays in channel
+
+        // Step 7: User who does NOT satisfy policy and IS in channel → auto-removed
+        const user3AfterSync = await verifyUserInChannel(adminClient, nonSatisfyingUserInChannel.id, privateChannel.id);
+        expect(user3AfterSync).toBe(false); // AUTO-REMOVED
+    });
+});

--- a/e2e-tests/playwright/specs/functional/system_console/abac/policy_management/delete_policies.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/policy_management/delete_policies.spec.ts
@@ -1,0 +1,228 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test, enableABAC, navigateToABACPage} from '@mattermost/playwright-lib';
+
+import {
+    CustomProfileAttribute,
+    setupCustomProfileAttributeFields,
+} from '../../../channels/custom_profile_attributes/helpers';
+import {createPrivateChannelForABAC, createBasicPolicy, enableUserManagedAttributes} from '../support';
+
+/**
+ * ABAC Policy Management - Delete Policies
+ * Tests for deleting ABAC policies
+ */
+test.describe('ABAC Policy Management - Delete Policies', () => {
+    /**
+     * MM-T5793: Attribute-based access policy cannot be deleted if it is applied to any channels
+     *
+     * Step 1:
+     * 1. As system admin, go to ABAC page and click three-dot menu on a policy APPLIED to a channel
+     * 2. Observe Delete is DISABLED
+     * 3. Click three-dot menu on a policy NOT applied to any channels
+     * 4. Click Delete
+     *
+     * Expected:
+     * - Policy applied to a channel CANNOT be deleted (Delete is disabled)
+     * - Policy NOT applied to any channels CAN be deleted
+     */
+    test('MM-T5793 Policy with channels cannot be deleted, policy without channels can be deleted', async ({pw}) => {
+        test.setTimeout(120000);
+
+        await pw.skipIfNoLicense();
+
+        const {adminUser, adminClient} = await pw.initSetup();
+
+        // Enable user-managed attributes
+        await enableUserManagedAttributes(adminClient);
+
+        // Set up a basic attribute field
+        const attributeFields: CustomProfileAttribute[] = [{name: 'Department', type: 'text', value: ''}];
+        await setupCustomProfileAttributeFields(adminClient, attributeFields);
+
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        const page = systemConsolePage.page;
+
+        await navigateToABACPage(page);
+        await enableABAC(page);
+
+        // ===========================================
+        // Create two policies:
+        // 1. policyWithChannel - has a channel assigned
+        // 2. policyWithoutChannel - has NO channels assigned
+        // ===========================================
+        const uniqueId = await pw.random.id();
+        const policyWithChannelName = `ABAC-WithChannel-${uniqueId}`;
+        const policyWithoutChannelName = `ABAC-NoChannel-${uniqueId}`;
+
+        // Create a channel for the first policy
+        const team = (await adminClient.getMyTeams())[0];
+        const privateChannel = await createPrivateChannelForABAC(adminClient, team.id);
+
+        // Create policy WITH channel
+        await createBasicPolicy(page, {
+            name: policyWithChannelName,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: false,
+            channels: [privateChannel.display_name],
+        });
+
+        // Navigate back to ABAC page
+        await navigateToABACPage(page);
+        await page.waitForTimeout(1000);
+
+        // Create policy WITHOUT channel using UI (Advanced mode)
+        // We'll create the policy, save it without channels, then remove channels via UI
+
+        // Click Add policy
+        const addPolicyButton = page.getByRole('button', {name: 'Add policy'});
+        await addPolicyButton.click();
+        await page.waitForLoadState('networkidle');
+
+        // Fill policy name
+        const nameInput = page.locator('#admin\\.access_control\\.policy\\.edit_policy\\.policyName');
+        await nameInput.waitFor({state: 'visible', timeout: 10000});
+        await nameInput.fill(policyWithoutChannelName);
+
+        // Switch to Advanced mode to create minimal policy
+        const advancedModeButton = page.getByRole('button', {name: /advanced/i});
+        if (await advancedModeButton.isVisible({timeout: 2000})) {
+            await advancedModeButton.click();
+            await page.waitForTimeout(1000);
+        }
+
+        // Fill CEL expression in Monaco editor
+        const monacoContainer = page.locator('.monaco-editor').first();
+        await monacoContainer.waitFor({state: 'visible', timeout: 5000});
+
+        const editorLines = page.locator('.monaco-editor .view-lines').first();
+        await editorLines.click({force: true});
+        await page.waitForTimeout(300);
+
+        // Type a simple expression
+        const isMac = process.platform === 'darwin';
+        await page.keyboard.press(isMac ? 'Meta+a' : 'Control+a');
+        await page.waitForTimeout(100);
+        await page.keyboard.type('user.attributes.Department == "Sales"', {delay: 10});
+        await page.waitForTimeout(1000);
+
+        // Save policy WITHOUT assigning any channels
+        const saveButton = page.getByRole('button', {name: 'Save'});
+        await saveButton.click();
+
+        // The "Apply policy" modal should NOT appear since there are no channels
+        // The webapp will call handleSubmit() directly and navigate back automatically
+        // Wait for navigation to complete
+        await page.waitForURL('**/attribute_based_access_control', {timeout: 10000});
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(1500);
+
+        // ===========================================
+        // STEP 1-2: Verify Delete is DISABLED for policy WITH channel
+        // ===========================================
+
+        // Clear any existing search and verify both policies exist
+        const searchInput = page.locator('input[placeholder*="Search" i]').first();
+        await searchInput.waitFor({state: 'visible', timeout: 5000});
+        await searchInput.clear();
+        await page.waitForTimeout(500);
+
+        // Verify both policies are visible
+        await page.locator('.policy-name, tr.clickable').count();
+
+        // Now search for the policy with channel
+        await searchInput.fill(policyWithChannelName);
+        await page.waitForTimeout(1000);
+
+        // Find and click the three-dot menu for the policy with channel
+        const policyWithChannelRow = page
+            .locator('tr.clickable, .DataGrid_row')
+            .filter({hasText: policyWithChannelName})
+            .first();
+        await policyWithChannelRow.waitFor({state: 'visible', timeout: 10000});
+
+        const menuButtonWithChannel = policyWithChannelRow
+            .locator('button[id*="policy-menu"], button[aria-label*="menu" i], .menu-button, button:has(svg)')
+            .first();
+        await menuButtonWithChannel.click();
+        await page.waitForTimeout(500);
+
+        // Check if Delete is disabled
+        const deleteMenuItemWithChannel = page.getByRole('menuitem', {name: /delete/i});
+        const isDeleteDisabled = await deleteMenuItemWithChannel.isDisabled();
+
+        // Close the menu
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(300);
+
+        expect(isDeleteDisabled).toBe(true);
+
+        // ===========================================
+        // STEP 3-4: Verify Delete is ENABLED for policy WITHOUT channel and delete it
+        // ===========================================
+
+        // Clear search first to ensure we're seeing all policies
+        await searchInput.clear();
+        await page.waitForTimeout(500);
+
+        // Verify policy without channel exists in the list
+        const policyWithoutChannelExists = await page.locator('text=' + policyWithoutChannelName).count();
+
+        if (policyWithoutChannelExists === 0) {
+            // Try reloading if policy not visible
+            await page.reload();
+            await page.waitForLoadState('networkidle');
+            await page.waitForTimeout(1000);
+        }
+
+        // Now search for the policy without channel
+        await searchInput.fill(policyWithoutChannelName);
+        await page.waitForTimeout(1000);
+
+        // Find and click the three-dot menu for the policy without channel
+        const policyWithoutChannelRow = page
+            .locator('tr.clickable, .DataGrid_row')
+            .filter({hasText: policyWithoutChannelName})
+            .first();
+        await policyWithoutChannelRow.waitFor({state: 'visible', timeout: 10000});
+
+        const menuButtonWithoutChannel = policyWithoutChannelRow
+            .locator('button[id*="policy-menu"], button[aria-label*="menu" i], .menu-button, button:has(svg)')
+            .first();
+        await menuButtonWithoutChannel.click();
+        await page.waitForTimeout(500);
+
+        // Check if Delete is enabled
+        const deleteMenuItemWithoutChannel = page.getByRole('menuitem', {name: /delete/i});
+        const isDeleteEnabled = !(await deleteMenuItemWithoutChannel.isDisabled());
+
+        expect(isDeleteEnabled).toBe(true);
+
+        // Click Delete
+        await deleteMenuItemWithoutChannel.click();
+        await page.waitForTimeout(500);
+
+        // Handle confirmation modal if it appears
+        const confirmDeleteButton = page.getByRole('button', {name: /delete|confirm/i});
+        if (await confirmDeleteButton.isVisible({timeout: 2000})) {
+            await confirmDeleteButton.click();
+            await page.waitForTimeout(1000);
+        }
+
+        await page.waitForLoadState('networkidle');
+
+        // Verify the policy was deleted
+        await searchInput.clear();
+        await searchInput.fill(policyWithoutChannelName);
+        await page.waitForTimeout(1000);
+
+        const policyStillExists = await page
+            .locator('tr.clickable, .DataGrid_row')
+            .filter({hasText: policyWithoutChannelName})
+            .isVisible({timeout: 3000});
+        expect(policyStillExists).toBe(false);
+    });
+});

--- a/e2e-tests/playwright/specs/functional/system_console/abac/policy_management/edit_policies.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/policy_management/edit_policies.spec.ts
@@ -1,0 +1,797 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {
+    expect,
+    test,
+    enableABAC,
+    navigateToABACPage,
+    verifyUserInChannel,
+    verifyUserNotInChannel,
+    runSyncJob,
+} from '@mattermost/playwright-lib';
+
+import {
+    CustomProfileAttribute,
+    setupCustomProfileAttributeFields,
+} from '../../../channels/custom_profile_attributes/helpers';
+import {
+    createUserForABAC,
+    testAccessRule,
+    createPrivateChannelForABAC,
+    createBasicPolicy,
+    createAdvancedPolicy,
+    waitForLatestSyncJob,
+    enableUserManagedAttributes,
+} from '../support';
+
+/**
+ * ABAC Policy Management - Edit Policies
+ * Tests for editing existing ABAC policies
+ */
+test.describe('ABAC Policy Management - Edit Policies', () => {
+    /**
+     * MM-T5790: Editing value of existing attribute-based access policy applies access control as specified (without auto-add)
+     *
+     * Step 1:
+     * 1. Go to ABAC page, click a policy to edit. Ensure Auto-add is False
+     * 2. Edit an existing policy rule to a different value (same attribute and operator)
+     * 3. Click Test Access Rule, observe users who satisfy the policy
+     * 4. Save the changes
+     * 5. User who satisfies NEW policy but not in channel → NOT auto-added
+     */
+    test('MM-T5790 Editing policy value applies access control without auto-add', async ({pw}) => {
+        test.setTimeout(180000);
+
+        await pw.skipIfNoLicense();
+
+        const {adminUser, adminClient, team} = await pw.initSetup();
+
+        // Enable user-managed attributes FIRST (same order as MM-T5783)
+        await enableUserManagedAttributes(adminClient);
+
+        // Set up the Department attribute field
+        const attributeFields: CustomProfileAttribute[] = [{name: 'Department', type: 'text', value: ''}];
+        const attributeFieldsMap = await setupCustomProfileAttributeFields(adminClient, attributeFields);
+
+        // Create users with proper CPA attributes
+        // User A: Department=Engineering (will satisfy ORIGINAL policy)
+        // User B: Department=Sales (will satisfy EDITED policy)
+        const engineerUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', value: 'Engineering', type: 'text'},
+        ]);
+        const salesUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', value: 'Sales', type: 'text'},
+        ]);
+
+        await adminClient.addToTeam(team.id, engineerUser.id);
+        await adminClient.addToTeam(team.id, salesUser.id);
+
+        // Create channel - use direct API call for more control
+        const channelName = `abac-edit-test-${await pw.random.id()}`;
+
+        const privateChannel = await adminClient.createChannel({
+            team_id: team.id,
+            name: channelName.toLowerCase().replace(/[^a-z0-9-]/g, ''),
+            display_name: channelName,
+            type: 'P',
+        });
+
+        // Admin user is automatically added as channel creator, but let's add the test users
+        // Note: addToChannel(userId, channelId) - user first, then channel
+        await adminClient.addToChannel(engineerUser.id, privateChannel.id);
+
+        // Verify we can access the channel
+        // const channelCheck = await adminClient.getChannel(privateChannel.id);
+
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        const page = systemConsolePage.page;
+
+        await navigateToABACPage(page);
+        await enableABAC(page);
+
+        // Check membership BEFORE policy creation
+        // Using library helper verifyUserInChannel(client, userId, channelId)
+        await verifyUserInChannel(adminClient, engineerUser.id, privateChannel.id);
+
+        // Debug: Show user attributes BEFORE policy creation
+        try {
+            await (adminClient as any).doFetch(
+                `${adminClient.getBaseRoute()}/users/${engineerUser.id}/custom_profile_attributes`,
+                {method: 'GET'},
+            );
+        } catch {
+            // Ignore errors
+        }
+
+        // ===========================================
+        // SETUP: Create policy with ORIGINAL value (Engineering), Auto-add OFF
+        // ===========================================
+        const policyName = `ABAC-Edit-Test-${await pw.random.id()}`;
+
+        await createBasicPolicy(page, {
+            name: policyName,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: false, // Auto-add is OFF
+            channels: [privateChannel.display_name],
+        });
+
+        // Check membership AFTER policy creation (before explicit sync)
+        await verifyUserInChannel(adminClient, engineerUser.id, privateChannel.id);
+
+        // Wait for the automatic sync (triggered by createBasicPolicy's "Apply Policy") to complete
+        await page.waitForTimeout(3000); // Give time for sync job to run
+
+        // Check membership AFTER automatic sync
+        const engineerAfterSync = await verifyUserInChannel(adminClient, engineerUser.id, privateChannel.id);
+        const salesAfterSync = await verifyUserInChannel(adminClient, salesUser.id, privateChannel.id);
+
+        // Debug: Fetch user attributes to verify they're set
+        try {
+            await (adminClient as any).doFetch(
+                `${adminClient.getBaseRoute()}/users/${engineerUser.id}/custom_profile_attributes`,
+                {method: 'GET'},
+            );
+        } catch {
+            // Ignore errors
+        }
+
+        expect(engineerAfterSync).toBe(true);
+        expect(salesAfterSync).toBe(false);
+
+        // ===========================================
+        // STEP 1-2: Edit policy to different value (Sales instead of Engineering)
+        // ===========================================
+
+        // Navigate to ABAC page and find the policy
+        await navigateToABACPage(page);
+        await page.waitForTimeout(1000);
+
+        // Search for and click the policy
+        const policySearchInput = page.locator('input[placeholder*="Search" i]').first();
+        if (await policySearchInput.isVisible({timeout: 3000})) {
+            await policySearchInput.fill(policyName);
+            await page.waitForTimeout(1000);
+        }
+
+        const policyRowLocator = page.locator('tr.clickable, .DataGrid_row').filter({hasText: policyName}).first();
+        await policyRowLocator.waitFor({state: 'visible', timeout: 10000});
+        await policyRowLocator.click();
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(1000);
+
+        // Verify Auto-add is OFF (check the header checkbox)
+        const autoAddCheckbox = page.locator('#auto-add-header-checkbox');
+        if (await autoAddCheckbox.isVisible({timeout: 3000})) {
+            const isChecked = await autoAddCheckbox.isChecked();
+            if (isChecked) {
+                // Uncheck it
+                await autoAddCheckbox.click();
+                await page.waitForTimeout(500);
+            }
+        } else {
+            // Checkbox not visible
+        }
+
+        // Edit the value: Change from "Engineering" to "Sales"
+
+        // Strategy 1: Try simple input field (for text attributes)
+        const simpleValueInput = page.locator('.values-editor__simple-input').first();
+        if (await simpleValueInput.isVisible({timeout: 3000})) {
+            // Clear and fill the new value
+            await simpleValueInput.click();
+            await simpleValueInput.fill('');
+            await simpleValueInput.fill('Sales');
+            // Press Tab or click elsewhere to confirm
+            await page.keyboard.press('Tab');
+            await page.waitForTimeout(500);
+        } else {
+            // Strategy 2: Try value selector menu button
+            const valueButton = page.locator('[data-testid="valueSelectorMenuButton"]').first();
+            if (await valueButton.isVisible({timeout: 3000})) {
+                await valueButton.click();
+                await page.waitForTimeout(500);
+
+                // Look for input in the dropdown
+                const menuInput = page
+                    .locator('#value-selector-menu input[type="text"], .value-selector-menu input')
+                    .first();
+                if (await menuInput.isVisible({timeout: 2000})) {
+                    await menuInput.fill('Sales');
+                    await page.waitForTimeout(500);
+
+                    // Click on the option or press Enter
+                    const salesOption = page.locator('#value-selector-menu').getByText('Sales', {exact: true}).first();
+                    if (await salesOption.isVisible({timeout: 2000})) {
+                        await salesOption.click();
+                    } else {
+                        await page.keyboard.press('Enter');
+                    }
+                    await page.waitForTimeout(500);
+                }
+            } else {
+                // Strategy 3: Use Advanced mode to edit CEL expression directly
+                const advancedModeButton = page.getByRole('button', {name: /advanced|switch to advanced/i});
+                if (await advancedModeButton.isVisible({timeout: 3000})) {
+                    await advancedModeButton.click();
+                    await page.waitForTimeout(1000);
+
+                    // Find Monaco editor - use view-lines with force click to bypass overlay
+                    const monacoContainer = page.locator('.monaco-editor').first();
+                    if (await monacoContainer.isVisible({timeout: 3000})) {
+                        const editorLines = page.locator('.monaco-editor .view-lines').first();
+                        await editorLines.click({force: true});
+                        await page.waitForTimeout(300);
+
+                        // Platform-specific select all
+                        const isMac = process.platform === 'darwin';
+                        await page.keyboard.press(isMac ? 'Meta+a' : 'Control+a');
+                        await page.waitForTimeout(100);
+
+                        await page.keyboard.type('user.attributes.Department == "Sales"', {delay: 10});
+                        await page.waitForTimeout(500);
+                    }
+                }
+            }
+        }
+
+        // ===========================================
+        // STEP 3: Click Test Access Rule
+        // ===========================================
+        await testAccessRule(page);
+
+        // ===========================================
+        // STEP 4: Save the changes
+        // ===========================================
+        const saveButton = page.getByRole('button', {name: 'Save'});
+        await saveButton.waitFor({state: 'visible', timeout: 5000});
+        await saveButton.click();
+        await page.waitForTimeout(1000);
+
+        // Handle "Apply policy" confirmation if it appears
+        const applyPolicyButton = page.getByRole('button', {name: /apply policy/i});
+        if (await applyPolicyButton.isVisible({timeout: 3000})) {
+            await applyPolicyButton.click();
+            await page.waitForTimeout(1000);
+        }
+
+        // Wait for sync to complete
+        await navigateToABACPage(page);
+        await waitForLatestSyncJob(page, 5);
+
+        // ===========================================
+        // STEP 5 & 6: Verify channel membership after policy edit
+        // ===========================================
+
+        const salesInChannelAfterEdit = await verifyUserInChannel(adminClient, salesUser.id, privateChannel.id);
+        const engineerInChannelAfterEdit = await verifyUserInChannel(adminClient, engineerUser.id, privateChannel.id);
+
+        // Step 5: salesUser should NOT be in channel (auto-add is off)
+        expect(salesInChannelAfterEdit).toBe(false);
+
+        // Step 6: engineerUser should be REMOVED (no longer satisfies policy)
+        expect(engineerInChannelAfterEdit).toBe(false);
+
+        // ===========================================
+        // STEP 7: Admin can manually add satisfying user
+        // ===========================================
+        try {
+            // Note: addToChannel(userId, channelId) - user first, then channel
+            await adminClient.addToChannel(salesUser.id, privateChannel.id);
+
+            // Verify the user was actually added
+            const salesInChannelAfterManualAdd = await verifyUserInChannel(
+                adminClient,
+                salesUser.id,
+                privateChannel.id,
+            );
+            expect(salesInChannelAfterManualAdd).toBe(true);
+        } catch (error) {
+            throw new Error(`Step 7 FAILED: Admin should be able to manually add satisfying user. Error: ${error}`);
+        }
+    });
+
+    /**
+     * MM-T5791: Editing existing access policy to add another attribute applies access control as specified (with auto-add)
+     *
+     * Precondition: At least one policy in existence
+     *
+     * Step 1:
+     * 1. Go to ABAC page, click a policy to edit. Ensure Auto-add is TRUE
+     * 2. Edit an existing policy rule to add another attribute/value
+     * 3. Click Test Access Rule, observe users who satisfy the policy
+     * 4. Save the changes
+     * 5. User who satisfies NEWLY EDITED policy but not in channel → auto-ADDED
+     * 6. User who doesn't satisfy NEWLY EDITED policy and is in channel → auto-REMOVED
+     *
+     * Expected:
+     * - User satisfying new multi-attribute policy IS auto-added
+     * - User not satisfying new policy IS auto-removed
+     */
+    test('MM-T5791 Editing policy to add attribute with auto-add enabled', async ({pw}) => {
+        test.setTimeout(180000);
+
+        await pw.skipIfNoLicense();
+
+        const {adminUser, adminClient, team} = await pw.initSetup();
+
+        // Delete ALL existing custom attributes to start fresh
+        try {
+            const existingFields = await adminClient.getCustomProfileAttributeFields();
+            for (const field of existingFields) {
+                try {
+                    await adminClient.deleteCustomProfileAttributeField(field.id);
+                } catch {
+                    // Ignore deletion errors
+                }
+            }
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+        } catch {
+            // Ignore if no fields exist
+        }
+
+        // Enable user-managed attributes FIRST (same pattern as MM-T5783)
+        await enableUserManagedAttributes(adminClient);
+
+        // Set up TWO attribute fields: Department AND Office with admin-managed attrs
+        const attributeFields: CustomProfileAttribute[] = [
+            {name: 'Department', type: 'text', value: '', attrs: {managed: 'admin', visibility: 'when_set'} as any},
+            {name: 'Office', type: 'text', value: '', attrs: {managed: 'admin', visibility: 'when_set'} as any},
+        ];
+        const attributeFieldsMap = await setupCustomProfileAttributeFields(adminClient, attributeFields);
+
+        // Create users:
+        // 1. engineerRemoteUser: Dept=Engineering, Office=Remote → satisfies BOTH (after edit)
+        // 2. engineerOfficeUser: Dept=Engineering, Office=HQ → satisfies ORIGINAL only, NOT the edited policy
+        // 3. salesUser: Dept=Sales → doesn't satisfy any policy
+
+        const engineerRemoteUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', type: 'text', value: 'Engineering'},
+            {name: 'Office', type: 'text', value: 'Remote'},
+        ]);
+
+        const engineerOfficeUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', type: 'text', value: 'Engineering'},
+            {name: 'Office', type: 'text', value: 'HQ'},
+        ]);
+
+        const salesUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', type: 'text', value: 'Sales'},
+        ]);
+
+        // Add users to team
+        await adminClient.addToTeam(team.id, engineerRemoteUser.id);
+        await adminClient.addToTeam(team.id, engineerOfficeUser.id);
+        await adminClient.addToTeam(team.id, salesUser.id);
+
+        // Create channel and add engineerOfficeUser (satisfies original policy)
+        const privateChannel = await createPrivateChannelForABAC(adminClient, team.id);
+        await adminClient.addToChannel(engineerOfficeUser.id, privateChannel.id);
+
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        const page = systemConsolePage.page;
+
+        await navigateToABACPage(page);
+        await enableABAC(page);
+
+        // ===========================================
+        // PRECONDITION: Create ORIGINAL policy with ONE attribute (Department=Engineering)
+        // Auto-add ON so users are auto-added
+        // ===========================================
+        const policyName = `ABAC-AddAttr-Test-${await pw.random.id()}`;
+
+        await createBasicPolicy(page, {
+            name: policyName,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: true, // Auto-add is ON
+            channels: [privateChannel.display_name],
+        });
+
+        // Wait for automatic sync to complete
+        await page.waitForTimeout(3000);
+
+        // Verify initial state after original policy sync
+        await verifyUserInChannel(adminClient, engineerRemoteUser.id, privateChannel.id);
+        await verifyUserInChannel(adminClient, engineerOfficeUser.id, privateChannel.id);
+
+        // ===========================================
+        // STEP 1-2: Edit policy to ADD another attribute (Office=Remote)
+        // New expression: Department=Engineering AND Office=Remote
+        // ===========================================
+
+        // Navigate back to ABAC list page
+        await page.goto('/admin_console/system_attributes/attribute_based_access_control', {waitUntil: 'networkidle'});
+        await page.waitForTimeout(2000);
+
+        // Verify we're on the list page by checking for "Add policy" button
+        const addPolicyButton = page.getByRole('button', {name: 'Add policy'});
+        await addPolicyButton.waitFor({state: 'visible', timeout: 10000});
+
+        // Try to find the policy row first without search
+        const policyRowLocator = page.locator('tr.clickable, .DataGrid_row').filter({hasText: policyName}).first();
+        const isPolicyVisible = await policyRowLocator.isVisible({timeout: 3000}).catch(() => false);
+
+        // If not visible, use search
+        if (!isPolicyVisible) {
+            const policySearchInput = page
+                .locator('.DataGrid input[type="text"], input[placeholder*="Search policies" i]')
+                .first();
+            if (await policySearchInput.isVisible({timeout: 3000})) {
+                await policySearchInput.click();
+                await policySearchInput.fill(policyName);
+                await page.waitForTimeout(1500);
+            }
+        }
+
+        // Click policy to edit
+        await policyRowLocator.waitFor({state: 'visible', timeout: 15000});
+        await policyRowLocator.click();
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(1000);
+
+        // Check if "Add attribute" button is disabled (means attributes not loaded)
+        // If so, reload to fetch the Office attribute
+        const addAttributeButtonCheck = page.getByRole('button', {name: /add attribute/i});
+        if (await addAttributeButtonCheck.isVisible({timeout: 2000})) {
+            const isDisabled = await addAttributeButtonCheck.isDisabled();
+            if (isDisabled) {
+                await page.reload();
+                await page.waitForLoadState('networkidle');
+                await page.waitForTimeout(1000);
+            }
+        }
+
+        // Stay in Simple Mode and add a second attribute row
+        const addAttributeButton = page.getByRole('button', {name: /add attribute/i});
+        await addAttributeButton.waitFor({state: 'visible', timeout: 5000});
+        await addAttributeButton.click();
+        await page.waitForTimeout(1000);
+
+        // The attribute dropdown opens automatically after clicking "Add attribute"
+        // Wait for the menu to be visible and select "Office"
+        const attributeMenu = page.locator('[id^="attribute-selector-menu"]');
+        await attributeMenu.waitFor({state: 'visible', timeout: 5000});
+
+        const officeOption = attributeMenu.locator('li:has-text("Office")').first();
+        await officeOption.waitFor({state: 'visible', timeout: 5000});
+        await officeOption.click({force: true});
+        await page.waitForTimeout(500);
+
+        // Select operator "==" (is)
+        const operatorButton = page.locator('[data-testid="operatorSelectorMenuButton"]').last();
+        await operatorButton.waitFor({state: 'visible', timeout: 5000});
+        await operatorButton.click({force: true});
+        await page.waitForTimeout(500);
+
+        const operatorOption = page.locator('[id^="operator-selector-menu"] li:has-text("is")').first();
+        await operatorOption.click({force: true});
+        await page.waitForTimeout(500);
+
+        // Fill value "Remote"
+        const valueInput = page.locator('.values-editor__simple-input').last();
+        await valueInput.waitFor({state: 'visible', timeout: 5000});
+        await valueInput.fill('Remote');
+        await page.waitForTimeout(500);
+
+        // ===========================================
+        // STEP 3: Test Access Rule
+        // ===========================================
+        await testAccessRule(page);
+
+        // ===========================================
+        // STEP 4: Save the changes
+        // ===========================================
+        const saveButton = page.getByRole('button', {name: 'Save'});
+        await saveButton.waitFor({state: 'visible', timeout: 5000});
+        await saveButton.click();
+        await page.waitForTimeout(1000);
+
+        // Handle "Apply policy" confirmation if it appears
+        const applyPolicyButton = page.getByRole('button', {name: /apply policy/i});
+        if (await applyPolicyButton.isVisible({timeout: 3000})) {
+            await applyPolicyButton.click();
+            await page.waitForTimeout(1000);
+        }
+
+        // Navigate to ABAC page
+        await navigateToABACPage(page);
+        await page.waitForTimeout(1000);
+
+        // Manually trigger a sync job to apply the policy changes
+        await runSyncJob(page, false);
+        await waitForLatestSyncJob(page);
+
+        // Trigger a SECOND sync job - sometimes the first sync only processes additions
+        await runSyncJob(page, false);
+        await waitForLatestSyncJob(page);
+
+        // Additional wait for membership changes to propagate
+        await page.waitForTimeout(3000);
+
+        // ===========================================
+        // STEP 5 & 6: Verify channel membership after edit
+        // ===========================================
+
+        const engineerRemoteAfterEdit = await verifyUserInChannel(
+            adminClient,
+            engineerRemoteUser.id,
+            privateChannel.id,
+        );
+        const engineerOfficeAfterEdit = await verifyUserInChannel(
+            adminClient,
+            engineerOfficeUser.id,
+            privateChannel.id,
+        );
+        const salesAfterEdit = await verifyUserInChannel(adminClient, salesUser.id, privateChannel.id);
+
+        // Step 5: engineerRemoteUser should be in channel (satisfies BOTH attributes)
+        expect(engineerRemoteAfterEdit).toBe(true);
+
+        // Step 6: engineerOfficeUser should be REMOVED (only satisfies original, not new policy)
+        expect(engineerOfficeAfterEdit).toBe(false);
+
+        // salesUser should not be in channel (never satisfied any policy)
+        expect(salesAfterEdit).toBe(false);
+    });
+
+    /**
+     * MM-T5792: Editing existing access policy to remove one of the rules applies access control as specified (with auto-add)
+     *
+     * Precondition: At least one policy with MULTIPLE rules in existence
+     *
+     * Step 1:
+     * 1. Go to ABAC page, click a policy to edit. Ensure Auto-add is TRUE
+     * 2. Edit policy to REMOVE one of the rules (attribute/value)
+     * 3. Click Test Access Rule, observe users who satisfy the policy
+     * 4. Save the changes
+     * 5. User who satisfies newly edited (simpler) policy but not in channel → auto-ADDED
+     * 6. User who no longer satisfies newly edited policy and is in channel → auto-REMOVED
+     *
+     * Expected:
+     * - User satisfying new simpler policy IS auto-added
+     * - User not satisfying new policy IS auto-removed
+     *
+     * This is the OPPOSITE of MM-T5791:
+     * - MM-T5791: ADD rule → policy MORE restrictive
+     * - MM-T5792: REMOVE rule → policy LESS restrictive
+     */
+    test('MM-T5792 Editing policy to remove attribute rule with auto-add enabled', async ({pw}) => {
+        test.setTimeout(180000);
+
+        await pw.skipIfNoLicense();
+
+        const {adminUser, adminClient, team} = await pw.initSetup();
+
+        // Delete ALL existing custom attributes to start fresh
+        try {
+            const existingFields = await adminClient.getCustomProfileAttributeFields();
+            for (const field of existingFields) {
+                try {
+                    await adminClient.deleteCustomProfileAttributeField(field.id);
+                } catch {
+                    // Ignore deletion errors
+                }
+            }
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+        } catch {
+            // Ignore if no fields exist
+        }
+
+        // Enable user-managed attributes FIRST (same pattern as MM-T5783)
+        await enableUserManagedAttributes(adminClient);
+
+        // Set up TWO attribute fields: Department AND Office with admin-managed attrs
+        const attributeFields: CustomProfileAttribute[] = [
+            {name: 'Department', type: 'text', value: '', attrs: {managed: 'admin', visibility: 'when_set'} as any},
+            {name: 'Office', type: 'text', value: '', attrs: {managed: 'admin', visibility: 'when_set'} as any},
+        ];
+        const attributeFieldsMap = await setupCustomProfileAttributeFields(adminClient, attributeFields);
+
+        // Create users:
+        // 1. engineerRemoteUser: Dept=Engineering, Office=Remote → satisfies ORIGINAL (both rules)
+        // 2. engineerOfficeUser: Dept=Engineering, Office=HQ → satisfies EDITED policy (Dept only)
+        // 3. salesRemoteUser: Dept=Sales, Office=Remote → doesn't satisfy (wrong Dept)
+
+        const engineerRemoteUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', type: 'text', value: 'Engineering'},
+            {name: 'Office', type: 'text', value: 'Remote'},
+        ]);
+
+        const engineerOfficeUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', type: 'text', value: 'Engineering'},
+            {name: 'Office', type: 'text', value: 'HQ'},
+        ]);
+
+        const salesRemoteUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', type: 'text', value: 'Sales'},
+            {name: 'Office', type: 'text', value: 'Remote'},
+        ]);
+
+        // Add users to team
+        await adminClient.addToTeam(team.id, engineerRemoteUser.id);
+        await adminClient.addToTeam(team.id, engineerOfficeUser.id);
+        await adminClient.addToTeam(team.id, salesRemoteUser.id);
+
+        // Create channel and add salesRemoteUser (does NOT satisfy any policy)
+        // This user will be REMOVED after we edit policy (to verify removal behavior)
+        const privateChannel = await createPrivateChannelForABAC(adminClient, team.id);
+        await adminClient.addToChannel(salesRemoteUser.id, privateChannel.id);
+
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        const page = systemConsolePage.page;
+
+        await navigateToABACPage(page);
+        await enableABAC(page);
+
+        // ===========================================
+        // PRECONDITION: Create ORIGINAL policy with TWO attributes
+        // Department=Engineering AND Office=Remote
+        // Auto-add ON
+        // ===========================================
+        const policyName = `ABAC-RemoveRule-${await pw.random.id()}`;
+
+        // Use advanced mode for multi-attribute policy
+        await createAdvancedPolicy(page, {
+            name: policyName,
+            celExpression: 'user.attributes.Department == "Engineering" && user.attributes.Office == "Remote"',
+            autoSync: true, // Auto-add is ON
+            channels: [privateChannel.display_name],
+        });
+
+        // Wait for automatic sync to complete
+        await page.waitForTimeout(3000);
+
+        // Verify initial state after original policy sync
+        // Original policy: Department=Engineering AND Office=Remote
+        // - engineerRemoteUser: satisfies → should be auto-added
+        // - engineerOfficeUser: does NOT satisfy (HQ != Remote) → should NOT be in channel
+        // - salesRemoteUser: does NOT satisfy (Sales != Engineering) → should be auto-removed
+        await verifyUserInChannel(adminClient, engineerRemoteUser.id, privateChannel.id);
+        await verifyUserNotInChannel(adminClient, engineerOfficeUser.id, privateChannel.id);
+        await verifyUserNotInChannel(adminClient, salesRemoteUser.id, privateChannel.id);
+
+        // ===========================================
+        // STEP 1-2: Edit policy to REMOVE Location rule
+        // New expression: Department=Engineering (only)
+        // This makes policy LESS restrictive
+        // ===========================================
+
+        // Navigate back to ABAC list page
+        await page.goto('/admin_console/system_attributes/attribute_based_access_control', {waitUntil: 'networkidle'});
+        await page.waitForTimeout(2000);
+
+        // Verify we're on the list page by checking for "Add policy" button
+        const addPolicyButton = page.getByRole('button', {name: 'Add policy'});
+        await addPolicyButton.waitFor({state: 'visible', timeout: 10000});
+
+        // Try to find the policy row first without search
+        const policyRowLocator = page.locator('tr.clickable, .DataGrid_row').filter({hasText: policyName}).first();
+        const isPolicyVisible = await policyRowLocator.isVisible({timeout: 3000}).catch(() => false);
+
+        // If not visible, try with search
+        if (!isPolicyVisible) {
+            // Use a more specific selector for the search input in the policies table
+            const policySearchInput = page
+                .locator('.DataGrid input[type="text"], input[placeholder*="Search policies" i]')
+                .first();
+            if (await policySearchInput.isVisible({timeout: 3000})) {
+                await policySearchInput.click();
+                await policySearchInput.fill(policyName);
+                // DON'T press Enter - just wait for the search to filter
+                await page.waitForTimeout(1500);
+            }
+        }
+
+        // Wait for policy row to be visible
+        await policyRowLocator.waitFor({state: 'visible', timeout: 15000});
+        await policyRowLocator.click();
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(1000);
+
+        // Verify Auto-add is ON
+        const autoAddCheckbox = page.locator('#auto-add-header-checkbox');
+        if (await autoAddCheckbox.isVisible({timeout: 3000})) {
+            const isChecked = await autoAddCheckbox.isChecked();
+            if (!isChecked) {
+                await autoAddCheckbox.click();
+                await page.waitForTimeout(500);
+            }
+        }
+
+        // Check if Monaco editor is visible - if not, switch to Advanced mode
+        // Policy may open in Simple mode even if created in Advanced mode
+        let monacoContainer = page.locator('.monaco-editor').first();
+        const isMonacoVisible = await monacoContainer.isVisible({timeout: 2000}).catch(() => false);
+
+        if (!isMonacoVisible) {
+            const advancedModeButton = page.getByRole('button', {name: /advanced|switch to advanced/i});
+            if (await advancedModeButton.isVisible({timeout: 5000})) {
+                await advancedModeButton.click();
+                await page.waitForTimeout(2000); // Wait for Monaco to fully initialize
+            }
+        }
+
+        // Find Monaco editor and update expression to REMOVE Office rule
+        monacoContainer = page.locator('.monaco-editor').first();
+        await monacoContainer.waitFor({state: 'visible', timeout: 10000});
+
+        const editorLines = page.locator('.monaco-editor .view-lines').first();
+        await editorLines.waitFor({state: 'visible', timeout: 5000});
+        await page.waitForTimeout(500);
+
+        // Click to focus the editor
+        await editorLines.click({force: true});
+        await page.waitForTimeout(300);
+
+        // Use platform-specific select all (Meta+a on Mac, Control+a on others)
+        const isMac = process.platform === 'darwin';
+        await page.keyboard.press(isMac ? 'Meta+a' : 'Control+a');
+        await page.waitForTimeout(200);
+
+        // Type the new CEL expression (REMOVING Office rule)
+        const newExpression = 'user.attributes.Department == "Engineering"';
+        await page.keyboard.type(newExpression, {delay: 10});
+        await page.waitForTimeout(1000);
+
+        // Wait for the "Valid" indicator to confirm the expression is valid
+        const validIndicator = page.locator('text=Valid').first();
+        try {
+            await validIndicator.waitFor({state: 'visible', timeout: 10000});
+        } catch {
+            // Ignore if Valid indicator doesn't appear
+        }
+
+        // ===========================================
+        // STEP 3: Test Access Rule
+        // ===========================================
+        await testAccessRule(page);
+
+        // ===========================================
+        // STEP 4: Save the changes
+        // ===========================================
+        const saveButton = page.getByRole('button', {name: 'Save'});
+        await saveButton.waitFor({state: 'visible', timeout: 5000});
+        await saveButton.click();
+        await page.waitForTimeout(1000);
+
+        // Handle "Apply policy" confirmation if it appears
+        const applyPolicyButton = page.getByRole('button', {name: /apply policy/i});
+        if (await applyPolicyButton.isVisible({timeout: 3000})) {
+            await applyPolicyButton.click();
+            await page.waitForTimeout(1000);
+        }
+
+        // Navigate to ABAC page and wait for sync job to complete
+        await navigateToABACPage(page);
+        await waitForLatestSyncJob(page);
+
+        // ===========================================
+        // STEP 5 & 6: Verify channel membership after edit
+        // ===========================================
+
+        const engineerRemoteAfterEdit = await verifyUserInChannel(
+            adminClient,
+            engineerRemoteUser.id,
+            privateChannel.id,
+        );
+        const engineerOfficeAfterEdit = await verifyUserInChannel(
+            adminClient,
+            engineerOfficeUser.id,
+            privateChannel.id,
+        );
+        const salesRemoteAfterEdit = await verifyUserInChannel(adminClient, salesRemoteUser.id, privateChannel.id);
+
+        // Step 5: engineerOfficeUser should be AUTO-ADDED (now satisfies simpler Dept-only policy)
+        expect(engineerOfficeAfterEdit).toBe(true);
+
+        // engineerRemoteUser should still be in channel (continues to satisfy policy)
+        expect(engineerRemoteAfterEdit).toBe(true);
+
+        // Step 6: salesRemoteUser should NOT be in channel (never satisfied Dept requirement)
+        expect(salesRemoteAfterEdit).toBe(false);
+    });
+});

--- a/e2e-tests/playwright/specs/functional/system_console/abac/support.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/support.ts
@@ -1,0 +1,1077 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/**
+ * Shared ABAC test helper functions
+ * These functions are used across multiple ABAC test files to reduce duplication
+ */
+
+import type {Page} from '@playwright/test';
+import type {Client4} from '@mattermost/client';
+import type {UserProfile} from '@mattermost/types/users';
+import type {Channel} from '@mattermost/types/channels';
+import type {UserPropertyField} from '@mattermost/types/properties';
+
+import {
+    CustomProfileAttribute,
+    setupCustomProfileAttributeValuesForUser,
+} from '../../channels/custom_profile_attributes/helpers';
+
+/**
+ * Verify policy exists with better waiting and retry logic
+ */
+export async function verifyPolicyExists(page: Page, policyName: string): Promise<boolean> {
+    // Wait for the policy list to be stable
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(1000);
+
+    // Try multiple times with increasing waits (handle race conditions)
+    for (let attempt = 0; attempt < 3; attempt++) {
+        const policyElement = page.locator('.policy-name').filter({hasText: policyName});
+        const isVisible = await policyElement.isVisible({timeout: 3000});
+
+        if (isVisible) {
+            return true;
+        }
+
+        // Not found, wait a bit and try again
+        if (attempt < 2) {
+            await page.waitForTimeout(2000);
+            // Reload the page to force refresh
+            await page.reload();
+            await page.waitForLoadState('networkidle');
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Verify policy does NOT exist
+ */
+export async function verifyPolicyNotExists(page: Page, policyName: string): Promise<boolean> {
+    return !(await verifyPolicyExists(page, policyName));
+}
+
+/**
+ * Create user attribute field via API
+ */
+export async function createUserAttributeField(client: Client4, name: string, type: string = 'text'): Promise<any> {
+    const url = `${client.getBaseRoute()}/custom_profile_attributes/fields`;
+    const field = {
+        name: name,
+        type: type,
+        attrs: {
+            managed: 'admin', // Admin-managed attribute
+            visibility: 'when_set',
+        },
+    };
+
+    const response = await (client as any).doFetch(url, {
+        method: 'POST',
+        body: JSON.stringify(field),
+    });
+    return response;
+}
+
+/**
+ * Enable user-managed attributes config
+ */
+export async function enableUserManagedAttributes(client: Client4): Promise<void> {
+    try {
+        const config = await client.getConfig();
+        if (config.AccessControlSettings?.EnableUserManagedAttributes !== true) {
+            config.AccessControlSettings = config.AccessControlSettings || {};
+            config.AccessControlSettings.EnableUserManagedAttributes = true;
+            await client.updateConfig(config);
+        }
+    } catch {
+        // console.warn('Failed to enable EnableUserManagedAttributes:', _error.message || String(_error));
+    }
+}
+
+/**
+ * Ensure required user attributes exist via API
+ */
+export async function ensureUserAttributes(client: Client4, attributeNames?: string[]): Promise<void> {
+    const attributesToCreate = attributeNames || ['Department'];
+    await enableUserManagedAttributes(client);
+
+    let existingAttributes: any[] = [];
+    try {
+        existingAttributes = await (client as any).doFetch(
+            `${client.getBaseRoute()}/custom_profile_attributes/fields`,
+            {method: 'GET'},
+        );
+    } catch {
+        // console.warn(`Failed to fetch existing attributes:`, _error.message);
+    }
+
+    for (const attrName of attributesToCreate) {
+        const exists = existingAttributes.some((attr: any) => attr.name === attrName);
+
+        if (!exists) {
+            try {
+                await createUserAttributeField(client, attrName);
+            } catch {
+                throw new Error(`Cannot proceed: Attribute "${attrName}" does not exist and could not be created`);
+            }
+        }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+}
+
+/**
+ * Navigate to User Attributes page and create attributes via UI
+ */
+export async function setupUserAttributesViaUI(page: Page, attributes: string[]): Promise<void> {
+    // Navigate to System Attributes → User Attributes
+    await page.goto('/admin_console/system_attributes/user_attributes');
+    await page.waitForLoadState('networkidle');
+
+    for (const attrName of attributes) {
+        // Click "Add attribute" button
+        const addButton = page.getByRole('button', {name: /add.*attribute/i});
+        if (await addButton.isVisible({timeout: 2000})) {
+            await addButton.click();
+            await page.waitForTimeout(500);
+
+            // Fill attribute name
+            const nameInput = page.locator('input[placeholder*="name" i], input[name="name"]').last();
+            await nameInput.fill(attrName);
+
+            // Select type (default to Text)
+            // Save attribute
+            const saveButton = page.getByRole('button', {name: /save/i});
+            if (await saveButton.isVisible({timeout: 1000})) {
+                await saveButton.click();
+                await page.waitForTimeout(500);
+            }
+        }
+    }
+
+    // Save the page
+    const savePageButton = page.getByRole('button', {name: 'Save'}).first();
+    if (await savePageButton.isVisible({timeout: 2000})) {
+        await savePageButton.click();
+        await page.waitForLoadState('networkidle');
+    }
+}
+
+/**
+ * ABAC-specific helper to create user and set attributes using proper CPA helpers
+ */
+export async function createUserForABAC(
+    adminClient: Client4,
+    attributeFieldsMap: Record<string, UserPropertyField>,
+    attributes: CustomProfileAttribute[],
+): Promise<UserProfile> {
+    // Generate random ID and ensure username starts with letter
+    const randomId = Math.random().toString(36).substring(2, 9);
+    const username = `user${randomId}`.toLowerCase();
+
+    // Create the user
+    const user = await adminClient.createUser(
+        {
+            email: `${username}@example.com`,
+            username: username,
+            password: 'Password123!',
+        } as any,
+        '',
+        '',
+    );
+
+    await setupCustomProfileAttributeValuesForUser(adminClient, attributes, attributeFieldsMap, user.id);
+
+    return user;
+}
+
+/**
+ * Test Access Rule Result interface
+ */
+export interface TestAccessRuleResult {
+    totalMatches: number;
+    matchingUsernames: string[];
+    expectedUsersMatch: boolean;
+    unexpectedUsersMatch: boolean;
+}
+
+/**
+ * Test Access Rule Helper
+ * Clicks the "Test access rule" button and verifies which users match the policy
+ */
+export async function testAccessRule(
+    page: Page,
+    options: {
+        expectedMatchingUsers?: string[]; // usernames that SHOULD match
+        expectedNonMatchingUsers?: string[]; // usernames that should NOT match
+        searchForUser?: string; // optional: search for a specific user in the modal
+    } = {},
+): Promise<TestAccessRuleResult> {
+    const testButton = page.locator('button').filter({hasText: 'Test access rule'});
+    await testButton.waitFor({state: 'visible', timeout: 5000});
+    await testButton.click();
+
+    const modal = page.locator('[role="dialog"], .modal').filter({hasText: 'Access Rule Test Results'});
+    await modal.waitFor({state: 'visible', timeout: 5000});
+
+    await page.waitForTimeout(1000);
+    let totalMatches = 0;
+
+    const countText = await modal
+        .locator('text=/\\d+.*(?:members|total|match)/i')
+        .first()
+        .textContent({timeout: 5000})
+        .catch(() => null);
+
+    if (countText) {
+        const totalMatch = countText.match(/of\s*(\d+)\s*total/i);
+        if (totalMatch) {
+            totalMatches = parseInt(totalMatch[1]);
+        } else {
+            const matchesMatch = countText.match(/(\d+)\s*match/i);
+            if (matchesMatch) {
+                totalMatches = parseInt(matchesMatch[1]);
+            }
+        }
+    }
+
+    const matchingUsernames: string[] = [];
+    const userButtons = modal.locator('.more-modal__name button, [class*="more-modal__name"] button');
+    const count = await userButtons.count();
+
+    for (let i = 0; i < count; i++) {
+        const username = await userButtons.nth(i).textContent();
+        if (username) {
+            const cleanUsername = username.replace('@', '').trim();
+            matchingUsernames.push(cleanUsername);
+        }
+    }
+
+    if (options.searchForUser) {
+        const searchInput = modal.locator('input[placeholder*="Search" i]').first();
+        if (await searchInput.isVisible({timeout: 2000})) {
+            await searchInput.fill(options.searchForUser);
+            await page.waitForTimeout(500);
+        }
+    }
+
+    let expectedUsersMatch = true;
+    if (options.expectedMatchingUsers && options.expectedMatchingUsers.length > 0) {
+        for (const expectedUser of options.expectedMatchingUsers) {
+            const searchInput = modal.locator('input[placeholder*="Search" i]').first();
+            if (await searchInput.isVisible({timeout: 2000})) {
+                await searchInput.fill(expectedUser);
+                await page.waitForTimeout(1000);
+
+                const userInResults = modal.locator(`text=@${expectedUser}`).first();
+                const isVisible = await userInResults.isVisible({timeout: 5000});
+
+                if (!isVisible) {
+                    // console.error(`✗ Expected user "${expectedUser}" NOT found in matching results`);
+                    expectedUsersMatch = false;
+                }
+
+                await searchInput.fill('');
+                await page.waitForTimeout(500);
+            }
+        }
+    }
+
+    let unexpectedUsersMatch = false;
+    if (options.expectedNonMatchingUsers && options.expectedNonMatchingUsers.length > 0) {
+        for (const unexpectedUser of options.expectedNonMatchingUsers) {
+            const searchInput = modal.locator('input[placeholder*="Search" i]').first();
+            if (await searchInput.isVisible({timeout: 2000})) {
+                await searchInput.fill(unexpectedUser);
+                await page.waitForTimeout(500);
+
+                const userInResults = modal.locator(`text=@${unexpectedUser}`).first();
+                const isVisible = await userInResults.isVisible({timeout: 2000});
+
+                if (isVisible) {
+                    // console.error(`✗ Non-matching user "${unexpectedUser}" FOUND in results (should NOT be there)`);
+                    unexpectedUsersMatch = true;
+                }
+
+                await searchInput.fill('');
+                await page.waitForTimeout(300);
+            }
+        }
+    }
+
+    const closeButton = modal.locator('button[aria-label*="Close" i], button:has-text("×"), .close').first();
+    if (await closeButton.isVisible({timeout: 1000})) {
+        await closeButton.click();
+        await page.waitForTimeout(500);
+    } else {
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(500);
+    }
+
+    return {
+        totalMatches,
+        matchingUsernames,
+        expectedUsersMatch,
+        unexpectedUsersMatch,
+    };
+}
+
+/**
+ * Create private channel with unique ID for ABAC testing
+ */
+export async function createPrivateChannelForABAC(client: Client4, teamId: string): Promise<Channel> {
+    // Generate unique ID - lowercase alphanumeric only
+    const uniqueId = Date.now().toString(36) + Math.random().toString(36).substring(2, 7);
+    const channel = await client.createChannel({
+        team_id: teamId,
+        name: `abac${uniqueId}`,
+        display_name: `ABAC-${uniqueId}`,
+        type: 'P', // Private channel
+    });
+    return channel;
+}
+
+/**
+ * Create basic policy using Table Editor (Simple mode)
+ */
+export async function createBasicPolicy(
+    page: Page,
+    options: {
+        name: string;
+        attribute: string;
+        operator: string;
+        value: string;
+        autoSync?: boolean;
+        channels?: string[];
+    },
+): Promise<void> {
+    // Click Add policy button
+    const addPolicyButton = page.getByRole('button', {name: 'Add policy'});
+    await addPolicyButton.click();
+    await page.waitForLoadState('networkidle');
+
+    // Fill policy name
+    const nameInput = page.locator('#admin\\.access_control\\.policy\\.edit_policy\\.policyName');
+    await nameInput.waitFor({state: 'visible', timeout: 10000});
+    await nameInput.fill(options.name);
+
+    // Check if "Add attribute" button is disabled (means no attributes loaded)
+    // If so, reload the page to fetch the newly created attributes
+    const addAttributeButton = page.getByRole('button', {name: /add attribute/i});
+    if (await addAttributeButton.isVisible({timeout: 2000})) {
+        const isDisabled = await addAttributeButton.isDisabled();
+        if (isDisabled) {
+            await page.reload();
+            await page.waitForLoadState('networkidle');
+
+            // Re-fill the policy name after reload
+            const nameInputAfterReload = page.locator('#admin\\.access_control\\.policy\\.edit_policy\\.policyName');
+            await nameInputAfterReload.waitFor({state: 'visible', timeout: 10000});
+            await nameInputAfterReload.fill(options.name);
+        }
+    }
+
+    // Fill attribute, operator, value in table editor
+    if (await addAttributeButton.isVisible({timeout: 2000})) {
+        const isDisabled = await addAttributeButton.isDisabled();
+        if (!isDisabled) {
+            await addAttributeButton.click();
+            await page.waitForTimeout(1000);
+        }
+    }
+
+    // Select attribute
+    const attributeMenu = page.locator('[id^="attribute-selector-menu"]');
+    const menuIsOpen = await attributeMenu.isVisible({timeout: 2000});
+
+    if (!menuIsOpen) {
+        const attributeButton = page.locator('[data-testid="attributeSelectorMenuButton"]').first();
+        await attributeButton.click();
+        await page.waitForTimeout(500);
+    }
+
+    const attributeOption = page.locator(`[id^="attribute-selector-menu"] li:has-text("${options.attribute}")`).first();
+    await attributeOption.click({force: true});
+    await page.waitForTimeout(500);
+
+    // Select operator
+    const operatorButton = page.locator('[data-testid="operatorSelectorMenuButton"]').first();
+    await operatorButton.waitFor({state: 'visible', timeout: 5000});
+    await operatorButton.click({force: true});
+    await page.waitForTimeout(500);
+
+    const operatorMap: Record<string, string> = {
+        '==': 'is',
+        '!=': 'is not',
+        in: 'is one of',
+        contains: 'contains',
+        startsWith: 'starts with',
+        endsWith: 'ends with',
+    };
+    const operatorText = operatorMap[options.operator] || options.operator;
+    const operatorOption = page.locator(`[id^="operator-selector-menu"] li:has-text("${operatorText}")`).first();
+    await operatorOption.click({force: true});
+    await page.waitForTimeout(500);
+
+    // Fill value
+    if (options.operator === 'in') {
+        // Multi-value operator
+        const valueButton = page.locator('[data-testid="valueSelectorMenuButton"]').first();
+        await valueButton.waitFor({state: 'visible', timeout: 10000});
+        await valueButton.click({force: true});
+        await page.waitForTimeout(500);
+
+        const valueInput = page.locator('input[type="text"]').last();
+        await valueInput.fill(options.value);
+        await page.keyboard.press('Enter');
+        await page.waitForTimeout(300);
+    } else {
+        // Single-value operator
+        const valueInput = page.locator('.values-editor__simple-input, input[placeholder*="Add value" i]').first();
+        await valueInput.waitFor({state: 'visible', timeout: 10000});
+        await valueInput.fill(options.value);
+        await page.waitForTimeout(500);
+    }
+
+    // Assign channels if specified
+    if (options.channels && options.channels.length > 0) {
+        const addChannelsButton = page.getByRole('button', {name: /add channels/i});
+        await addChannelsButton.click();
+        await page.waitForTimeout(500);
+
+        for (const channelName of options.channels) {
+            const searchInput = page.locator('input[type="text"], input[placeholder*="search" i]').last();
+            await searchInput.fill(channelName);
+            await page.waitForTimeout(500);
+
+            const channelOption = page
+                .locator('.channel-selector-modal, [role="dialog"]')
+                .locator('text=' + channelName)
+                .first();
+            await channelOption.click({force: true});
+            await page.waitForTimeout(300);
+        }
+
+        const addButton = page.getByRole('button', {name: /^add$|^save$/i}).last();
+        await addButton.click();
+        await page.waitForTimeout(500);
+    }
+
+    // Set auto-add for all channels if autoSync is true
+    if (options.autoSync && options.channels && options.channels.length > 0) {
+        await page.waitForTimeout(1000); // Wait for channel list to update
+
+        // Click the header checkbox to enable auto-add for ALL channels
+        const headerCheckbox = page.locator('#auto-add-header-checkbox');
+
+        if (await headerCheckbox.isVisible({timeout: 3000})) {
+            const isChecked = await headerCheckbox.isChecked();
+
+            // Only click if we need to enable it
+            if (!isChecked) {
+                await headerCheckbox.click({force: true});
+                await page.waitForTimeout(500);
+            }
+        }
+    }
+
+    // Save policy and confirm
+    const saveButton = page.getByRole('button', {name: 'Save'});
+    await saveButton.click();
+    await page.waitForTimeout(1000);
+
+    // Click "Apply policy" button in confirmation modal (only appears if channels are assigned)
+    const applyPolicyButton = page.getByRole('button', {name: /apply policy/i});
+    const applyVisible = await applyPolicyButton.isVisible({timeout: 3000}).catch(() => false);
+    if (applyVisible) {
+        await applyPolicyButton.click();
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(2000);
+    } else {
+        // No channels assigned, just wait for save to complete
+        await page.waitForLoadState('networkidle');
+    }
+}
+
+/**
+ * Create policy with multiple attribute rules (Table Editor mode)
+ */
+export async function createMultiAttributePolicy(
+    page: Page,
+    options: {
+        name: string;
+        rules: Array<{attribute: string; operator: string; value: string}>;
+        autoSync?: boolean;
+        channels?: string[];
+    },
+): Promise<void> {
+    // Click Add policy button
+    const addPolicyButton = page.getByRole('button', {name: 'Add policy'});
+    await addPolicyButton.click();
+    await page.waitForLoadState('networkidle');
+
+    // Fill policy name
+    const nameInput = page.locator('#admin\\.access_control\\.policy\\.edit_policy\\.policyName');
+    await nameInput.waitFor({state: 'visible', timeout: 10000});
+    await nameInput.fill(options.name);
+
+    // Check if "Add attribute" button is disabled (means no attributes loaded)
+    const addAttributeButton = page.getByRole('button', {name: /add attribute/i});
+    if (await addAttributeButton.isVisible({timeout: 2000})) {
+        const isDisabled = await addAttributeButton.isDisabled();
+        if (isDisabled) {
+            await page.reload();
+            await page.waitForLoadState('networkidle');
+
+            const nameInputAfterReload = page.locator('#admin\\.access_control\\.policy\\.edit_policy\\.policyName');
+            await nameInputAfterReload.waitFor({state: 'visible', timeout: 10000});
+            await nameInputAfterReload.fill(options.name);
+        }
+    }
+
+    // Add each rule
+    for (let i = 0; i < options.rules.length; i++) {
+        const rule = options.rules[i];
+
+        // Click "Add attribute" to add a new row (for EVERY rule - there's no default row)
+        const addAttrBtn = page.getByRole('button', {name: /add attribute/i});
+        if ((await addAttrBtn.isVisible({timeout: 2000})) && !(await addAttrBtn.isDisabled())) {
+            await addAttrBtn.click();
+            await page.waitForTimeout(500);
+        }
+
+        // Select attribute - click the attribute selector for this row
+        const attributeButtons = page.locator('[data-testid="attributeSelectorMenuButton"]');
+        const attributeButton = attributeButtons.nth(i);
+        await attributeButton.waitFor({state: 'visible', timeout: 5000});
+        await attributeButton.click({force: true});
+        await page.waitForTimeout(500);
+
+        // Select the attribute from the menu
+        const attributeOption = page
+            .locator(`[id^="attribute-selector-menu"] li:has-text("${rule.attribute}")`)
+            .first();
+        await attributeOption.click({force: true});
+        await page.waitForTimeout(500);
+
+        // Select operator
+        const operatorButtons = page.locator('[data-testid="operatorSelectorMenuButton"]');
+        const operatorButton = operatorButtons.nth(i);
+        await operatorButton.waitFor({state: 'visible', timeout: 5000});
+        await operatorButton.click({force: true});
+        await page.waitForTimeout(500);
+
+        // Map operator to display text
+        const operatorMap: Record<string, string> = {
+            '==': 'is',
+            '!=': 'is not',
+            in: 'in',
+            contains: 'contains',
+            startsWith: 'starts with',
+            endsWith: 'ends with',
+        };
+        const operatorText = operatorMap[rule.operator] || 'is';
+        const operatorOption = page.locator(`[id^="operator-selector-menu"] li:has-text("${operatorText}")`).first();
+        await operatorOption.click({force: true});
+        await page.waitForTimeout(500);
+
+        // Enter value - check if it's a text input or select menu
+        const valueInput = page.locator('.values-editor__simple-input').nth(i);
+        if (await valueInput.isVisible({timeout: 2000})) {
+            await valueInput.fill(rule.value);
+            await page.waitForTimeout(300);
+        } else {
+            // It might be a select/multiselect - click the value selector
+            const valueButtons = page.locator('[data-testid="valueSelectorMenuButton"]');
+            const valueButton = valueButtons.nth(i);
+            if (await valueButton.isVisible({timeout: 2000})) {
+                await valueButton.click({force: true});
+                await page.waitForTimeout(500);
+
+                const valueOption = page.locator(`[id^="value-selector-menu"] li:has-text("${rule.value}")`).first();
+                await valueOption.click({force: true});
+                await page.waitForTimeout(300);
+            }
+        }
+    }
+
+    // Assign channels if specified
+    if (options.channels && options.channels.length > 0) {
+        const addChannelsButton = page.getByRole('button', {name: /add channels/i});
+        await addChannelsButton.click();
+        await page.waitForTimeout(500);
+
+        for (const channelName of options.channels) {
+            const searchInput = page
+                .locator('[role="dialog"], .modal')
+                .filter({hasText: /channel/i})
+                .locator('input[placeholder*="Search" i]')
+                .first();
+            await searchInput.waitFor({state: 'visible', timeout: 5000});
+            await searchInput.fill(channelName);
+            await page.waitForTimeout(500);
+
+            const channelOption = page
+                .locator('.channel-selector-modal, [role="dialog"]')
+                .locator('text=' + channelName)
+                .first();
+            await channelOption.click({force: true});
+            await page.waitForTimeout(300);
+        }
+
+        const addButton = page.getByRole('button', {name: /^add$|^save$/i}).last();
+        await addButton.click();
+        await page.waitForTimeout(500);
+    }
+
+    // Set auto-add for all channels if autoSync is true
+    if (options.autoSync && options.channels && options.channels.length > 0) {
+        await page.waitForTimeout(1000);
+
+        const headerCheckbox = page.locator('#auto-add-header-checkbox');
+
+        if (await headerCheckbox.isVisible({timeout: 3000})) {
+            const isChecked = await headerCheckbox.isChecked();
+            if (!isChecked) {
+                await headerCheckbox.click({force: true});
+                await page.waitForTimeout(500);
+            }
+        }
+    }
+
+    // Save policy and confirm
+    const saveButton = page.getByRole('button', {name: 'Save'});
+    await saveButton.click();
+    await page.waitForTimeout(1000);
+
+    // Click "Apply policy" button in confirmation modal
+    const applyPolicyButton = page.getByRole('button', {name: /apply policy/i});
+    await applyPolicyButton.waitFor({state: 'visible', timeout: 5000});
+    await applyPolicyButton.click();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+}
+
+/**
+ * Create advanced policy using CEL Editor (Advanced mode)
+ */
+export async function createAdvancedPolicy(
+    page: Page,
+    options: {
+        name: string;
+        celExpression: string;
+        autoSync?: boolean;
+        channels?: string[];
+    },
+): Promise<void> {
+    // Click Add policy button
+    const addPolicyButton = page.getByRole('button', {name: 'Add policy'});
+    await addPolicyButton.click();
+    await page.waitForLoadState('networkidle');
+
+    // Fill policy name
+    const nameInput = page.locator('#admin\\.access_control\\.policy\\.edit_policy\\.policyName');
+    await nameInput.waitFor({state: 'visible', timeout: 10000});
+    await nameInput.fill(options.name);
+
+    // Switch to Advanced mode
+    const advancedModeButton = page.getByRole('button', {name: /advanced/i});
+    if (await advancedModeButton.isVisible({timeout: 2000})) {
+        await advancedModeButton.click();
+        await page.waitForTimeout(1000);
+    }
+
+    // Fill CEL expression in the Monaco editor
+    // Monaco editor has a visual layer that intercepts clicks, so we need to:
+    // 1. Click on the editor container to focus it
+    // 2. Use keyboard to clear and type the expression
+    const monacoContainer = page.locator('.monaco-editor').first();
+    await monacoContainer.waitFor({state: 'visible', timeout: 5000});
+
+    // Click on the visible lines area to focus the editor
+    const editorLines = page.locator('.monaco-editor .view-lines').first();
+    await editorLines.click({force: true});
+    await page.waitForTimeout(300);
+
+    // Select all existing content and replace with our expression
+    // Use Cmd+A on Mac, Ctrl+A on others
+    const isMac = process.platform === 'darwin';
+    await page.keyboard.press(isMac ? 'Meta+a' : 'Control+a');
+    await page.waitForTimeout(100);
+
+    // Type the CEL expression
+    await page.keyboard.type(options.celExpression, {delay: 10});
+    await page.waitForTimeout(1000);
+
+    // Wait for the "Valid" indicator to appear
+    const validIndicator = page.locator('text=Valid').first();
+    await validIndicator.isVisible({timeout: 5000}).catch(() => false);
+
+    // Assign channels if specified
+    if (options.channels && options.channels.length > 0) {
+        const addChannelsButton = page.getByRole('button', {name: /add channels/i});
+        await addChannelsButton.click();
+        await page.waitForTimeout(1000);
+
+        // Wait for the modal to appear
+        const channelModal = page.locator('[role="dialog"]').filter({hasText: /channel/i});
+        await channelModal.waitFor({state: 'visible', timeout: 5000});
+
+        for (const channelName of options.channels) {
+            // Find search input within the modal
+            const searchInput = channelModal.locator('input').first();
+            await searchInput.waitFor({state: 'visible', timeout: 5000});
+            await searchInput.fill(channelName);
+            await page.waitForTimeout(1000);
+
+            // Click the "Select channel" button (the + button) to add it
+            const selectChannelButton = channelModal.getByRole('button', {name: /select channel/i}).first();
+            if (await selectChannelButton.isVisible({timeout: 5000})) {
+                await selectChannelButton.click();
+            }
+            await page.waitForTimeout(300);
+        }
+
+        // Click Add button inside the modal to confirm
+        const modalAddButton = channelModal.getByRole('button', {name: 'Add'});
+        await modalAddButton.click();
+
+        // Wait for modal to close
+        await page.waitForTimeout(1000);
+        const modalStillOpen = await channelModal.isVisible().catch(() => false);
+        if (modalStillOpen) {
+            // Try pressing Escape to close
+            await page.keyboard.press('Escape');
+            await page.waitForTimeout(500);
+        }
+    }
+
+    // Verify channels were added before saving
+    if (options.channels && options.channels.length > 0) {
+        const channelsTable = page
+            .locator('.policy-channels-table, [class*="channel"]')
+            .filter({hasText: options.channels[0]});
+        await channelsTable.isVisible({timeout: 3000}).catch(() => false);
+    }
+
+    // Set auto-add for all channels if autoSync is true
+    if (options.autoSync && options.channels && options.channels.length > 0) {
+        await page.waitForTimeout(1000); // Wait for channel list to update
+
+        // Click the header checkbox to enable auto-add for ALL channels
+        const headerCheckbox = page.locator('#auto-add-header-checkbox');
+
+        if (await headerCheckbox.isVisible({timeout: 3000})) {
+            const isChecked = await headerCheckbox.isChecked();
+
+            // Only click if we need to enable it
+            if (!isChecked) {
+                await headerCheckbox.click({force: true});
+                await page.waitForTimeout(500);
+            }
+        }
+    }
+
+    // Save policy and confirm
+    const saveButton = page.getByRole('button', {name: 'Save'});
+
+    // Make sure Save button is enabled
+    const saveEnabled = await saveButton.isEnabled({timeout: 5000}).catch(() => false);
+    if (!saveEnabled) {
+        // console.error(`❌ Save button is disabled - cannot save policy`);
+        throw new Error(`Save button is disabled`);
+    }
+
+    await saveButton.click();
+    await page.waitForTimeout(2000);
+
+    // Check for error message
+    const errorMessage = page.locator('text=/Unable to save|errors in the form/i').first();
+    if (await errorMessage.isVisible({timeout: 2000}).catch(() => false)) {
+        const errorText = await errorMessage.textContent();
+        // console.error(`❌ Save failed: ${errorText}`);
+        throw new Error(`Failed to save policy: ${errorText}`);
+    }
+
+    // Click "Apply policy" button in confirmation modal
+    const applyPolicyButton = page.getByRole('button', {name: /apply policy/i});
+    const applyVisible = await applyPolicyButton.isVisible({timeout: 10000}).catch(() => false);
+
+    if (applyVisible) {
+        await applyPolicyButton.click();
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(2000);
+    } else {
+        // console.error(`❌ Apply Policy button not found`);
+        throw new Error(`Apply Policy button not visible after Save`);
+    }
+}
+
+/**
+ * Activate a policy (set active: true)
+ */
+export async function activatePolicy(client: Client4, policyId: string): Promise<void> {
+    const url = `${client.getBaseRoute()}/access_control_policies/${policyId}/activate?active=true`;
+    await (client as any).doFetch(url, {method: 'GET'});
+}
+
+/**
+ * Wait for sync job to complete and get the latest job row
+ */
+export async function waitForLatestSyncJob(page: Page, maxRetries: number = 5): Promise<any> {
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        // Wait a bit for the job to process
+        await page.waitForTimeout(2000);
+
+        // Reload the page to get fresh data
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(1000);
+
+        // Get the first (latest) job row
+        const latestJobRow = page.locator('tr.clickable').first();
+
+        if (await latestJobRow.isVisible({timeout: 3000})) {
+            // Check the status
+            const statusCell = latestJobRow.locator('td').first();
+            const status = await statusCell.textContent();
+
+            if (status?.trim() === 'Success') {
+                return latestJobRow;
+            } else if (status?.trim() === 'Error' || status?.trim() === 'Failed') {
+                throw new Error(`Sync job failed with status: ${status?.trim()}`);
+            }
+        }
+    }
+
+    throw new Error(`Sync job did not complete after ${maxRetries} retries`);
+}
+
+/**
+ * Open job details modal, search for a channel, get channel membership changes
+ */
+export async function getJobDetailsForChannel(
+    page: Page,
+    jobRow: any,
+    channelName: string,
+): Promise<{added: number; removed: number}> {
+    // Click on the job row to open details modal
+    await jobRow.click();
+    await page.waitForTimeout(1000);
+
+    // Wait for the Job Details modal to appear
+    const jobDetailsModal = page.locator('[role="dialog"], .modal').filter({hasText: 'Job Details'});
+    await jobDetailsModal.waitFor({state: 'visible', timeout: 5000});
+
+    // Find the search input in the modal
+    const searchInput = jobDetailsModal.locator('input[placeholder*="Search" i]').first();
+    await searchInput.waitFor({state: 'visible', timeout: 3000});
+
+    // Search for the channel
+    await searchInput.fill(channelName);
+    await page.waitForTimeout(1000);
+
+    // Find and click the channel row to open Channel Membership Changes modal
+    const channelRow = jobDetailsModal.locator(`text=${channelName}`).first();
+
+    let added = 0;
+    let removed = 0;
+
+    if (await channelRow.isVisible({timeout: 3000})) {
+        await channelRow.click();
+        await page.waitForTimeout(1000);
+
+        // Wait for the Channel Membership Changes modal
+        const membershipModal = page.locator('[role="dialog"], .modal').filter({hasText: 'Channel Membership Changes'});
+
+        if (await membershipModal.isVisible({timeout: 3000})) {
+            // Parse Added count from the tab: "Added (X)"
+            const addedTab = membershipModal.locator('text=/Added \\(\\d+\\)/i').first();
+            if (await addedTab.isVisible({timeout: 2000})) {
+                const addedText = await addedTab.textContent();
+                const addedMatch = addedText?.match(/Added\s*\((\d+)\)/i);
+                added = addedMatch ? parseInt(addedMatch[1]) : 0;
+            }
+
+            // Parse Removed count from the tab: "Removed (X)"
+            const removedTab = membershipModal.locator('text=/Removed \\(\\d+\\)/i').first();
+            if (await removedTab.isVisible({timeout: 2000})) {
+                const removedText = await removedTab.textContent();
+                const removedMatch = removedText?.match(/Removed\s*\((\d+)\)/i);
+                removed = removedMatch ? parseInt(removedMatch[1]) : 0;
+            }
+
+            // Close the Channel Membership Changes modal
+            const closeButton = membershipModal
+                .locator('button[aria-label*="Close" i], .close, button:has-text("×")')
+                .first();
+            if (await closeButton.isVisible({timeout: 1000})) {
+                await closeButton.click();
+                await page.waitForTimeout(500);
+            } else {
+                await page.keyboard.press('Escape');
+                await page.waitForTimeout(500);
+            }
+        } else {
+            // Fallback: parse from the row text
+            const channelRowParent = channelRow.locator('..').locator('..');
+            const countsText = await channelRowParent.textContent();
+
+            const addedMatch = countsText?.match(/\+(\d+)/);
+            const removedMatch = countsText?.match(/-(\d+)/);
+
+            added = addedMatch ? parseInt(addedMatch[1]) : 0;
+            removed = removedMatch ? parseInt(removedMatch[1]) : 0;
+        }
+    }
+
+    // Close the Job Details modal
+    const closeJobDetailsButton = jobDetailsModal
+        .locator('button[aria-label*="Close" i], .close, button:has-text("×")')
+        .first();
+    if (await closeJobDetailsButton.isVisible({timeout: 1000})) {
+        await closeJobDetailsButton.click();
+        await page.waitForTimeout(500);
+    } else {
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(500);
+    }
+
+    return {added, removed};
+}
+
+/**
+ * Check both recent jobs if they have similar timestamps
+ * This handles the case where two jobs are created almost simultaneously
+ */
+export async function getJobDetailsFromRecentJobs(
+    page: Page,
+    channelName: string,
+): Promise<{added: number; removed: number}> {
+    // Get all job rows
+    const jobRows = page.locator('tr.clickable');
+    const jobCount = await jobRows.count();
+
+    if (jobCount === 0) {
+        return {added: 0, removed: 0};
+    }
+
+    // Get timestamps of first two jobs to check if they're close
+    const job1Row = jobRows.nth(0);
+    const job2Row = jobCount > 1 ? jobRows.nth(1) : null;
+
+    // Get finish times from the rows
+    const job1TimeCell = job1Row.locator('td').nth(1); // Second column is Finish Time
+    const job1TimeText = await job1TimeCell.textContent();
+
+    let checkBothJobs = false;
+    if (job2Row) {
+        const job2TimeCell = job2Row.locator('td').nth(1);
+        const job2TimeText = await job2TimeCell.textContent();
+
+        // Check if timestamps are within 2 minutes of each other
+        // Parse times like "Jan 22, 2026 - 10:11 AM"
+        if (job1TimeText && job2TimeText) {
+            try {
+                const time1 = new Date(job1TimeText.replace(' - ', ' ')).getTime();
+                const time2 = new Date(job2TimeText.replace(' - ', ' ')).getTime();
+                const diffMs = Math.abs(time1 - time2);
+                const diffMinutes = diffMs / (1000 * 60);
+
+                if (diffMinutes <= 2) {
+                    checkBothJobs = true;
+                }
+            } catch {
+                checkBothJobs = true;
+            }
+        }
+    }
+
+    let totalAdded = 0;
+    let totalRemoved = 0;
+
+    // Check first job
+    const job1Details = await getJobDetailsForChannel(page, job1Row, channelName);
+    totalAdded = Math.max(totalAdded, job1Details.added);
+    totalRemoved = Math.max(totalRemoved, job1Details.removed);
+
+    // Check second job if timestamps are close
+    if (checkBothJobs && job2Row) {
+        // Need to wait for page to stabilize after closing previous modal
+        await page.waitForTimeout(500);
+        const job2Details = await getJobDetailsForChannel(page, job2Row, channelName);
+        totalAdded = Math.max(totalAdded, job2Details.added);
+        totalRemoved = Math.max(totalRemoved, job2Details.removed);
+    }
+
+    return {added: totalAdded, removed: totalRemoved};
+}
+
+/**
+ * Get policy ID by name using search API (with retry)
+ */
+export async function getPolicyIdByName(
+    client: Client4,
+    policyName: string,
+    retries: number = 3,
+): Promise<string | null> {
+    const searchUrl = `${client.getBaseRoute()}/access_control/policies/search`;
+
+    // Extract the base name without the random ID suffix for search
+    // e.g., "Auto-Add Policy 48b0141" -> "Auto-Add Policy"
+    const baseNameMatch = policyName.match(/^(.+?)\s+[a-z0-9]+$/i);
+    const searchTerm = baseNameMatch ? baseNameMatch[1] : policyName;
+
+    for (let attempt = 1; attempt <= retries; attempt++) {
+        try {
+            // Use the search API
+            const result = await (client as any).doFetch(searchUrl, {
+                method: 'POST',
+                body: JSON.stringify({
+                    term: searchTerm,
+                }),
+            });
+
+            const policies = result?.policies || [];
+
+            if (policies.length > 0) {
+                // Try exact match first
+                let policy = policies.find((p: any) => p.name === policyName);
+
+                // If no exact match, try partial match
+                if (!policy) {
+                    policy = policies.find((p: any) => p.name.includes(searchTerm));
+                }
+
+                // If still no match, just take the first result
+                if (!policy && policies.length > 0) {
+                    policy = policies[0];
+                }
+
+                if (policy) {
+                    return policy.id;
+                } else {
+                    // Wait before retrying
+                    if (attempt < retries) {
+                        await new Promise((resolve) => setTimeout(resolve, 2000));
+                    }
+                }
+            } else {
+                // Wait before retrying
+                if (attempt < retries) {
+                    await new Promise((resolve) => setTimeout(resolve, 2000));
+                }
+            }
+        } catch {
+            // console.error(`Failed to search policies (attempt ${attempt}):`, _error.message || String(_error));
+
+            if (attempt < retries) {
+                await new Promise((resolve) => setTimeout(resolve, 2000));
+            }
+        }
+    }
+
+    return null;
+}

--- a/e2e-tests/playwright/specs/functional/system_console/abac/user_attributes/attribute_changes.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/user_attributes/attribute_changes.spec.ts
@@ -1,0 +1,436 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {
+    expect,
+    test,
+    enableABAC,
+    navigateToABACPage,
+    runSyncJob,
+    verifyUserInChannel,
+    updateUserAttributes,
+    createUserWithAttributes,
+} from '@mattermost/playwright-lib';
+
+import {
+    CustomProfileAttribute,
+    setupCustomProfileAttributeFields,
+} from '../../../channels/custom_profile_attributes/helpers';
+import {
+    ensureUserAttributes,
+    createUserForABAC,
+    createPrivateChannelForABAC,
+    createBasicPolicy,
+    activatePolicy,
+    waitForLatestSyncJob,
+    enableUserManagedAttributes,
+} from '../support';
+
+/**
+ * ABAC User Attributes - Attribute Changes
+ * Tests for user attribute changes affecting ABAC policies
+ */
+test.describe('ABAC User Attributes - Attribute Changes', () => {
+    /**
+     * MM-T5794: User is auto-added to channel when a qualifying attribute is added to their profile (auto-add true)
+     *
+     * Step 1:
+     * With at least one access policy in existence on the server, set to auto-add, and applied to a channel:
+     * 1. As system admin make a note of the attribute needed for a user to be auto-added to a channel
+     * 2. As a user not in the channel and not having the required attribute
+     * 3. Click user's own profile picture top right and select Profile
+     * 4. Scroll down to the required custom attribute, click Edit, and add the required value
+     */
+    test('MM-T5794 User auto-added when qualifying attribute is added to profile', async ({pw}) => {
+        test.setTimeout(120000);
+
+        await pw.skipIfNoLicense();
+
+        // ============================================================
+        // SETUP: Create attribute, policy, and channel
+        // ============================================================
+        const {adminUser, adminClient, team} = await pw.initSetup();
+
+        // Setup attributes (using ensureUserAttributes like MM-T5800 does)
+        await ensureUserAttributes(adminClient);
+
+        // Create test user with NON-qualifying Department attribute (same pattern as MM-T5800)
+        // MM-T5800 creates user with Department=Sales, then changes to Engineering
+        // We do the same: Start with Sales (non-qualifying), then change to Engineering (qualifying)
+        const testUser = await createUserWithAttributes(adminClient, {Department: 'Sales'});
+        await adminClient.addToTeam(team.id, testUser.id);
+
+        // Create private channel
+        const privateChannel = await createPrivateChannelForABAC(adminClient, team.id);
+
+        // ============================================================
+        // STEP 1: Create ABAC policy with auto-add enabled
+        // Policy requirement: Department == "Engineering"
+        // ============================================================
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        await navigateToABACPage(systemConsolePage.page);
+        await enableABAC(systemConsolePage.page);
+
+        const policyName = `Engineering Access ${await pw.random.id()}`;
+        await createBasicPolicy(systemConsolePage.page, {
+            name: policyName,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: true, // ✅ Auto-add enabled
+            channels: [privateChannel.display_name],
+        });
+
+        // Activate policy (EXACT same pattern as MM-T5800)
+        await waitForLatestSyncJob(systemConsolePage.page);
+        const searchInput = systemConsolePage.page.locator('input[placeholder*="Search" i]').first();
+        await searchInput.waitFor({state: 'visible', timeout: 5000});
+        const idMatch = policyName.match(/([a-z0-9]+)$/i);
+        const uniqueId = idMatch ? idMatch[1] : policyName;
+        await searchInput.fill(uniqueId);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        const policyRow = systemConsolePage.page.locator('.policy-name').first();
+        const policyId = (await policyRow.getAttribute('id'))?.replace('customDescription-', '');
+
+        if (policyId) {
+            await activatePolicy(adminClient, policyId);
+        }
+        await searchInput.clear();
+
+        // ============================================================
+        // STEP 2: Verify user is NOT in channel initially
+        // ============================================================
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        const initialInChannel = await verifyUserInChannel(adminClient, testUser.id, privateChannel.id);
+        expect(initialInChannel).toBe(false);
+
+        // ============================================================
+        // STEPS 3-5: Add qualifying attribute to user's profile
+        // Note: Using API for attribute update. UI testing for profile editing
+        // is covered in separate user profile test suite.
+        // ============================================================
+        await updateUserAttributes(adminClient, testUser.id, {Department: 'Engineering'});
+
+        // ============================================================
+        // STEP 6: Run sync job to trigger auto-add
+        // ============================================================
+
+        // DEBUG: Verify attribute was updated before sync
+        await adminClient.getUserCustomProfileAttributesValues(testUser.id);
+
+        // Get the Department field to check its value
+        await adminClient.getCustomProfileAttributeFields();
+
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        // ============================================================
+        // VERIFICATION: User should now be auto-added to channel
+        // ============================================================
+
+        // DEBUG: Check all channel members
+        await adminClient.getChannelMembers(privateChannel.id);
+
+        const finalInChannel = await verifyUserInChannel(adminClient, testUser.id, privateChannel.id);
+
+        if (!finalInChannel) {
+            // console.error('\n[ERROR] User NOT in channel after sync!');
+            // console.error('[ERROR] This means the ABAC sync did not add the user.');
+            // console.error('[ERROR] Possible causes:');
+            // console.error('[ERROR] 1. Policy not active');
+            // console.error('[ERROR] 2. Attribute value not matching policy');
+            // console.error('[ERROR] 3. Sync job failed silently');
+        }
+
+        expect(finalInChannel).toBe(true);
+
+        // ============================================================
+        // VERIFICATION: Check for "User added" system message
+        // ============================================================
+
+        // Get recent posts from the channel
+        const posts = await adminClient.getPosts(privateChannel.id, 0, 10);
+        const postList = posts.order.map((postId: string) => posts.posts[postId]);
+
+        // Find system message for user being added
+        const userAddedMessage = postList.find((post: any) => {
+            return (
+                post.type === 'system_add_to_channel' &&
+                post.props?.addedUserId === testUser.id &&
+                post.user_id === 'system'
+            );
+        });
+
+        if (userAddedMessage) {
+            // System message found
+        } else {
+            // System message not found (may be disabled in test env)
+        }
+
+        // System messages might be disabled in test env, so we don't fail the test
+        // The important verification is that the user was added
+        expect(finalInChannel).toBe(true);
+    });
+
+    /**
+     * MM-T5795: User can be added to channel by system admin after a qualifying attribute is added to their profile (auto-add false)
+     *
+     * Preconditions:
+     * - Access policy with auto-add set to FALSE
+     *
+     * Steps:
+     * 1. As system admin, note the required attribute for channel access
+     * 2. As a user not in the channel and lacking the required attribute:
+     *    - Add the required attribute value to user profile
+     * 3. As system admin, go to the channel and add the user
+     *
+     * Expected:
+     * - User who now meets the policy CAN be added to the channel by the admin
+     * - "User added" message is posted in the channel by System
+     */
+    test('MM-T5795 User can be added by admin after attribute added (auto-add false)', async ({pw}) => {
+        test.setTimeout(120000);
+
+        await pw.skipIfNoLicense();
+
+        // ============================================================
+        // SETUP: Create attribute, policy with auto-add FALSE, and channel
+        // ============================================================
+        const {adminUser, adminClient, team} = await pw.initSetup();
+
+        await enableUserManagedAttributes(adminClient);
+
+        const attributeFields: CustomProfileAttribute[] = [{name: 'Department', type: 'text', value: ''}];
+        const attributeFieldsMap = await setupCustomProfileAttributeFields(adminClient, attributeFields);
+
+        // Create test user WITHOUT the qualifying attribute
+        const testUser = await createUserForABAC(adminClient, attributeFieldsMap, []);
+        await adminClient.addToTeam(team.id, testUser.id);
+
+        const privateChannel = await createPrivateChannelForABAC(adminClient, team.id);
+
+        // ============================================================
+        // STEP 1: Create policy with auto-add DISABLED
+        // ============================================================
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        await navigateToABACPage(systemConsolePage.page);
+        await enableABAC(systemConsolePage.page);
+
+        const policyName = `Engineering Manual Add ${await pw.random.id()}`;
+        await createBasicPolicy(systemConsolePage.page, {
+            name: policyName,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: false, // ✅ Auto-add DISABLED
+            channels: [privateChannel.display_name],
+        });
+
+        // ============================================================
+        // STEP 2: Add qualifying attribute to user
+        // ============================================================
+        await updateUserAttributes(adminClient, testUser.id, {Department: 'Engineering'});
+
+        // ============================================================
+        // STEP 3: Admin manually adds user to channel
+        // ============================================================
+
+        // Verify user can be added (policy allows it since user has qualifying attribute)
+        await adminClient.addToChannel(testUser.id, privateChannel.id);
+
+        // Verify user is now in channel
+        const userInChannel = await verifyUserInChannel(adminClient, testUser.id, privateChannel.id);
+        expect(userInChannel).toBe(true);
+
+        // ============================================================
+        // VERIFICATION: Check for "User added" system message
+        // ============================================================
+
+        const posts = await adminClient.getPosts(privateChannel.id, 0, 10);
+        const postList = posts.order.map((postId: string) => posts.posts[postId]);
+
+        const userAddedMessage = postList.find((post: any) => {
+            return post.type === 'system_add_to_channel' && post.props?.addedUserId === testUser.id;
+        });
+
+        if (userAddedMessage) {
+            // System message found
+        } else {
+            // System message not found (may be disabled in test env)
+        }
+    });
+
+    /**
+     * MM-T5796: User is auto-removed from channel when required attribute is removed
+     *
+     * Test Scenario 1 & 2 (Auto-add: False & True):
+     * Steps:
+     * 1. As system admin, identify the required attribute for channel access
+     * 2. Log in as a user currently in the channel with the required attribute
+     * 3. Edit user's profile
+     * 4. Remove or change the required attribute value
+     * 5. Save changes
+     *
+     * Expected:
+     * - User is automatically removed from the channel
+     * - System posts a "User removed" message in the channel
+     */
+    test('MM-T5796 User auto-removed when required attribute is removed', async ({pw}) => {
+        test.setTimeout(180000);
+
+        await pw.skipIfNoLicense();
+
+        // ============================================================
+        // SETUP
+        // ============================================================
+        const {adminUser, adminClient, team} = await pw.initSetup();
+
+        await enableUserManagedAttributes(adminClient);
+
+        const attributeFields: CustomProfileAttribute[] = [{name: 'Department', type: 'text', value: ''}];
+        const attributeFieldsMap = await setupCustomProfileAttributeFields(adminClient, attributeFields);
+
+        // Create test user WITH the qualifying attribute (starts with Department=Engineering)
+        const testUser = await createUserForABAC(adminClient, attributeFieldsMap, [
+            {name: 'Department', type: 'text', value: 'Engineering'},
+        ]);
+        await adminClient.addToTeam(team.id, testUser.id);
+
+        const privateChannel = await createPrivateChannelForABAC(adminClient, team.id);
+
+        // ============================================================
+        // TEST SCENARIO 1: Auto-add FALSE
+        // ============================================================
+
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        await navigateToABACPage(systemConsolePage.page);
+        await enableABAC(systemConsolePage.page);
+
+        const policy1Name = `Engineering Access NoAutoAdd ${await pw.random.id()}`;
+        await createBasicPolicy(systemConsolePage.page, {
+            name: policy1Name,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: false, // Auto-add FALSE
+            channels: [privateChannel.display_name],
+        });
+
+        // Manually add user to channel
+        await adminClient.addToChannel(testUser.id, privateChannel.id);
+        const initialInChannel = await verifyUserInChannel(adminClient, testUser.id, privateChannel.id);
+        expect(initialInChannel).toBe(true);
+
+        // Get policy ID and activate
+        await waitForLatestSyncJob(systemConsolePage.page);
+        const searchInput = systemConsolePage.page.locator('input[placeholder*="Search" i]').first();
+        await searchInput.waitFor({state: 'visible', timeout: 5000});
+        const idMatch = policy1Name.match(/([a-z0-9]+)$/i);
+        const uniqueId = idMatch ? idMatch[1] : policy1Name;
+        await searchInput.fill(uniqueId);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        const policyRow = systemConsolePage.page.locator('.policy-name').first();
+        const policyElementId = await policyRow.getAttribute('id');
+        const policyId = policyElementId?.replace('customDescription-', '');
+
+        if (policyId) {
+            await activatePolicy(adminClient, policyId);
+        }
+        await searchInput.clear();
+
+        // Remove the qualifying attribute
+        await updateUserAttributes(adminClient, testUser.id, {Department: 'Sales'});
+
+        // Wait for attribute change to propagate
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        // Run sync job
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        // Wait for membership updates to apply
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        // Verify user is removed
+        const userInChannelAfterRemoval = await verifyUserInChannel(adminClient, testUser.id, privateChannel.id);
+        expect(userInChannelAfterRemoval).toBe(false);
+
+        // Check for removal system message
+        const posts = await adminClient.getPosts(privateChannel.id, 0, 10);
+        const postList = posts.order.map((postId: string) => posts.posts[postId]);
+
+        const userRemovedMessage = postList.find((post: any) => {
+            return (
+                (post.type === 'system_remove_from_channel' || post.type === 'system_leave_channel') &&
+                (post.props?.removedUserId === testUser.id || post.user_id === testUser.id)
+            );
+        });
+
+        if (userRemovedMessage) {
+            // System message found
+        } else {
+            // System message not found (may be disabled in test env)
+        }
+
+        // ============================================================
+        // TEST SCENARIO 2: Auto-add TRUE
+        // ============================================================
+
+        // Restore user attribute and create new policy with auto-add=true
+        await updateUserAttributes(adminClient, testUser.id, {Department: 'Engineering'});
+
+        const channel2 = await createPrivateChannelForABAC(adminClient, team.id);
+
+        await navigateToABACPage(systemConsolePage.page);
+
+        const policy2Name = `Engineering Access WithAutoAdd ${await pw.random.id()}`;
+        await createBasicPolicy(systemConsolePage.page, {
+            name: policy2Name,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: true, // Auto-add TRUE
+            channels: [channel2.display_name],
+        });
+
+        // Activate and run sync to auto-add user
+        await waitForLatestSyncJob(systemConsolePage.page);
+        await searchInput.fill(policy2Name.match(/([a-z0-9]+)$/i)?.[1] || policy2Name);
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        const policyRow2 = systemConsolePage.page.locator('.policy-name').first();
+        const policyId2 = (await policyRow2.getAttribute('id'))?.replace('customDescription-', '');
+
+        if (policyId2) {
+            await activatePolicy(adminClient, policyId2);
+        }
+        await searchInput.clear();
+
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        const userAutoAdded = await verifyUserInChannel(adminClient, testUser.id, channel2.id);
+        expect(userAutoAdded).toBe(true);
+
+        // Remove attribute again
+        await updateUserAttributes(adminClient, testUser.id, {Department: 'Marketing'});
+
+        // Wait for attribute change to propagate
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        // Run sync
+        await runSyncJob(systemConsolePage.page);
+        await waitForLatestSyncJob(systemConsolePage.page);
+
+        // Small delay for channel membership update
+        await systemConsolePage.page.waitForTimeout(1000);
+
+        // Verify user is removed
+        const userRemovedFromChannel2 = await verifyUserInChannel(adminClient, testUser.id, channel2.id);
+        expect(userRemovedFromChannel2).toBe(false);
+    });
+});

--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -864,9 +864,9 @@ func (a *App) buildFullPushNotificationMessage(rctx request.CTX, contentsConfig 
 	}
 
 	postMessage := post.Message
-	stripped, err := utils.StripMarkdown(postMessage)
+	stripped, err := utils.StripMarkdownAndDecode(postMessage)
 	if err != nil {
-		rctx.Logger().Warn("Failed parse to markdown", mlog.String("post_id", post.Id), mlog.Err(err))
+		rctx.Logger().Warn("Failed to strip markdown from post", mlog.String("post_id", post.Id), mlog.Err(err))
 	} else {
 		postMessage = stripped
 	}

--- a/server/channels/utils/markdown.go
+++ b/server/channels/utils/markdown.go
@@ -16,7 +16,7 @@ import (
 	"github.com/yuin/goldmark/util"
 )
 
-// StripMarkdown remove some markdown syntax
+// StripMarkdown removes markdown syntax from text and returns plain text.
 func StripMarkdown(markdown string) (string, error) {
 	md := goldmark.New(
 		goldmark.WithExtensions(extension.Strikethrough),
@@ -33,6 +33,21 @@ func StripMarkdown(markdown string) (string, error) {
 	}
 
 	return strings.TrimSpace(buf.String()), nil
+}
+
+// StripMarkdownAndDecode removes markdown syntax and decodes HTML entities
+// (both named like &lt; and numeric like &#60;) to their character equivalents.
+// This is useful for plain text contexts like mobile push notifications where
+// HTML will not be rendered.
+//
+// SECURITY NOTE: The output is intended for plain text contexts only.
+// Do NOT use in contexts where HTML could be rendered without proper escaping.
+func StripMarkdownAndDecode(markdown string) (string, error) {
+	stripped, err := StripMarkdown(markdown)
+	if err != nil {
+		return "", err
+	}
+	return html.UnescapeString(stripped), nil
 }
 
 var relLinkReg = regexp.MustCompile(`\[(.*)]\((/.*)\)`)

--- a/webapp/channels/src/components/admin_console/access_control/editors/cel_editor/editor.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/editors/cel_editor/editor.tsx
@@ -3,7 +3,7 @@
 
 import * as monaco from 'monaco-editor';
 import React, {useCallback, useEffect, useRef, useState, useMemo} from 'react';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 
 import type {AccessControlTestResult} from '@mattermost/types/access_control';
 
@@ -93,6 +93,7 @@ function CELEditor({
     disabled = false,
     userAttributes,
 }: CELEditorProps): JSX.Element {
+    const intl = useIntl();
     const [editorState, setEditorState] = useState({
         expression: value,
         isValidating: false,
@@ -376,7 +377,15 @@ function CELEditor({
                 <div className='help-text-container'>
                     <div>
                         <HelpText
-                            message={'Write rules like `user.<attribute> == <value>`. Use `&&` / `||` (and/or) for multiple conditions. Group conditions with `()`.'}
+                            message={intl.formatMessage({
+                                id: 'admin.access_control.cel.help_text',
+                                defaultMessage: 'Write rules like `user.attributes.{lessThan}attribute{greaterThan} == {lessSign}value{greaterSign}`. Use `&&` / `||` (and/or) for multiple conditions. Group conditions with `()`.',
+                            }, {
+                                lessThan: '<',
+                                greaterThan: '>',
+                                lessSign: '<',
+                                greaterSign: '>',
+                            })}
                             onLearnMoreClick={() => setShowHelpModal(true)}
                         />
                     </div>

--- a/webapp/channels/src/components/suggestion/switch_channel_provider.test.tsx
+++ b/webapp/channels/src/components/suggestion/switch_channel_provider.test.tsx
@@ -587,7 +587,12 @@ describe('components/SwitchChannelProvider', () => {
         ];
 
         expect(resultsCallback).toHaveBeenCalledWith(expect.objectContaining({
-            terms: expectedOrder,
+            groups: expect.arrayContaining([
+                expect.objectContaining({
+                    key: 'channels',
+                    terms: expectedOrder,
+                }),
+            ]),
         }));
     });
 
@@ -670,7 +675,12 @@ describe('components/SwitchChannelProvider', () => {
         ];
 
         expect(resultsCallback).toHaveBeenCalledWith(expect.objectContaining({
-            terms: expectedOrder,
+            groups: expect.arrayContaining([
+                expect.objectContaining({
+                    key: 'channels',
+                    terms: expectedOrder,
+                }),
+            ]),
         }));
     });
 
@@ -757,7 +767,12 @@ describe('components/SwitchChannelProvider', () => {
             'channel_other_user1',
         ];
         expect(resultsCallback).toHaveBeenCalledWith(expect.objectContaining({
-            terms: expectedOrder,
+            groups: expect.arrayContaining([
+                expect.objectContaining({
+                    key: 'channels',
+                    terms: expectedOrder,
+                }),
+            ]),
         }));
     });
 
@@ -906,7 +921,12 @@ describe('components/SwitchChannelProvider', () => {
         ];
 
         expect(resultsCallback).toHaveBeenCalledWith(expect.objectContaining({
-            terms: channelsFromActiveTeams,
+            groups: expect.arrayContaining([
+                expect.objectContaining({
+                    key: 'channels',
+                    terms: channelsFromActiveTeams,
+                }),
+            ]),
         }));
     });
 
@@ -992,7 +1012,12 @@ describe('components/SwitchChannelProvider', () => {
         ];
 
         expect(resultsCallback).toHaveBeenCalledWith(expect.objectContaining({
-            terms: expectedOrder,
+            groups: expect.arrayContaining([
+                expect.objectContaining({
+                    key: 'channels',
+                    terms: expectedOrder,
+                }),
+            ]),
         }));
     });
 

--- a/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
+++ b/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
@@ -655,9 +655,13 @@ export default class SwitchChannelProvider extends Provider {
 
         resultsCallback({
             matchedPretext: channelPrefix,
-            items: combinedItems,
-            terms: combinedTerms,
-            component: ConnectedSwitchChannelSuggestion,
+            groups: [{
+                key: 'channels',
+                label: defineMessage({id: 'suggestion.channels', defaultMessage: 'Channels'}),
+                items: combinedItems,
+                terms: combinedTerms,
+                component: ConnectedSwitchChannelSuggestion,
+            }],
         });
     }
 

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -261,6 +261,7 @@
   "admin.access_control.cel_help_modal.important_notes_title": "Important Notes",
   "admin.access_control.cel_help_modal.subheader": "With CEL you can define conditions to filter user attributes and control resource access.",
   "admin.access_control.cel_help_modal.title": "Common Expression Language (CEL)",
+  "admin.access_control.cel.help_text": "Write rules like `user.attributes.{lessThan}attribute{greaterThan} == {lessSign}value{greaterSign}`. Use `&&` / `||` (and/or) for multiple conditions. Group conditions with `()`.",
   "admin.access_control.cel.incomplete_expression": "Incomplete expression, awaiting input...",
   "admin.access_control.cel.line_and_column_number": "L{lineNumber}:{columnNumber}",
   "admin.access_control.cel.type_expression": "Type an expression...",

--- a/webapp/channels/src/utils/markdown/link_only_renderer.tsx
+++ b/webapp/channels/src/utils/markdown/link_only_renderer.tsx
@@ -23,4 +23,10 @@ export default class LinkOnlyRenderer extends RemoveMarkdown {
 
         return output;
     }
+
+    // Override text() to NOT decode HTML entities since this renderer outputs HTML.
+    // Decoding entities in an HTML context could allow HTML injection attacks.
+    public text(text: string) {
+        return text.replace('\n', ' ');
+    }
 }

--- a/webapp/channels/src/utils/markdown/remove_markdown.ts
+++ b/webapp/channels/src/utils/markdown/remove_markdown.ts
@@ -5,6 +5,54 @@ import marked from 'marked';
 
 import * as TextFormatting from 'utils/text_formatting';
 
+// Map of HTML entities to their decoded characters.
+// This should match the entities handled by Go's html.UnescapeString on the server.
+const HTML_ENTITY_DECODE_MAP: Record<string, string> = {
+
+    // Numeric entities (decimal)
+    '&#33;': '!', // Exclamation Mark
+    '&#34;': '"', // Double Quote
+    '&#35;': '#', // Hash
+    '&#38;': '&', // Ampersand
+    '&#39;': "'", // Single Quote/Apostrophe
+    '&#40;': '(', // Left Parenthesis
+    '&#41;': ')', // Right Parenthesis
+    '&#42;': '*', // Asterisk
+    '&#43;': '+', // Plus Sign
+    '&#45;': '-', // Dash
+    '&#46;': '.', // Period
+    '&#47;': '/', // Forward Slash
+    '&#58;': ':', // Colon
+    '&#59;': ';', // Semicolon
+    '&#60;': '<', // Less Than
+    '&#61;': '=', // Equals Sign
+    '&#62;': '>', // Greater Than
+    '&#63;': '?', // Question Mark
+    '&#64;': '@', // At Sign
+    '&#91;': '[', // Left Square Bracket
+    '&#92;': '\\', // Backslash
+    '&#93;': ']', // Right Square Bracket
+    '&#94;': '^', // Caret
+    '&#95;': '_', // Underscore
+    '&#96;': '`', // Backtick
+    '&#123;': '{', // Left Curly Brace
+    '&#124;': '|', // Vertical Bar
+    '&#125;': '}', // Right Curly Brace
+    '&#126;': '~', // Tilde
+
+    // Named entities (common ones handled by Go's html.UnescapeString)
+    '&amp;': '&', // Ampersand
+    '&lt;': '<', // Less Than
+    '&gt;': '>', // Greater Than
+    '&quot;': '"', // Double Quote
+    '&apos;': "'", // Single Quote/Apostrophe
+};
+
+const HTML_ENTITY_PATTERN = new RegExp(
+    Object.keys(HTML_ENTITY_DECODE_MAP).map((key) => TextFormatting.escapeRegex(key)).join('|'),
+    'g',
+);
+
 export default class RemoveMarkdown extends marked.Renderer {
     public code(text: string) {
         // We need to escape the input here because our version of marked does this in the renderer. Every other node
@@ -77,6 +125,8 @@ export default class RemoveMarkdown extends marked.Renderer {
     }
 
     public text(text: string) {
-        return text.replace('\n', ' ');
+        return text.
+            replace('\n', ' ').
+            replace(HTML_ENTITY_PATTERN, (match) => HTML_ENTITY_DECODE_MAP[match]);
     }
 }


### PR DESCRIPTION
## Summary
2026-02-19 날짜의 upstream(mattermost/mattermost) 커밋 9개를 정밀 분석해 반영.

### cherry-pick (6)
- `31ebadd0` MM-66410 - standardize abac suggestions (#34446)
- `5f9ecb7e` MM-67091 Fixing notification titles rendering encoded values as-is (#35001)
- `4e81e504` Fix E2E-only PRs and duplicate E2E test runs after PR merges (#35368)
- `c45ba961` [MM-67565] Prevent setting protected=true on fields without source_plugin_id (#35265)
- `8309cb6a` Fix: Channels header disappears in Find Channels dialog during search (#35202)
- `7590aff7` MM-64490 - Add ABAC system console E2E tests (#35066)

### exclude (3) — `.github/workflows/docs-impact-review.yml` 후속 수정
okrbest에 이 워크플로 자체가 없음(부모 커밋 `45f54a0e`가 이미 exclude 처리됨: Mattermost 공식 docs 저장소 전용, adapt 대상 없음).
- `0fa5e235` Fix Permission Request for Docs Agent (#35373)
- `7ccafd79` Fix PR Checkout (#35375)
- `202334aa` Allow GH Bash Invocations (#35376)

## i18n 후속 필요
`31ebadd0`이 `en.json`에 신규 키 `admin.access_control.cel.help_text`를 추가했으나 `ko.json` 번역은 이번 세션에서 반영하지 않음 — 별도 작업 필요.

## Test plan
- [x] server: `go test ./channels/utils/... ./channels/app/...` (markdown, notification_push, property_access) 통과
- [x] webapp: `npx jest src/components/admin_console/access_control src/utils/markdown src/components/suggestion/switch_channel_provider.test.tsx` 통과
- [x] e2e-tests/playwright: 신규 ABAC spec 타입체크·lint 통과 (실제 브라우저 실행은 미수행)
- [x] server `make check-style`: 세션 커밋과 무관한 기존 결함(`enterprise/message_export/shared` vet 에러, `storetest.Store`에 `NotificationHistory` 메서드 누락) 1건 확인 — 이번 세션 변경과 무관해 별도 이슈로 분리
- [x] webapp `npm run check`: 세션이 건드린 8개 파일은 lint 클린, 나머지 303개 에러는 세션과 무관한 기존 파일들

🤖 Generated with [Claude Code](https://claude.com/claude-code)