### PR TITLE
upstream sync 2026-08-06 (picked 5)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,19 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-06 15:58
+- 갱신일: 2026-08-06 16:44
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1015개
+- 남은 커밋: 1010개
 
-**마지막 반영 커밋:** `7590aff7` | [MM-64490 - Add ABAC system console E2E tests (#35066)](https://github.com/mattermost/mattermost/commit/7590aff7abf5f34d26c154ad203b52adc03da929) | 2026-02-19
+**마지막 반영 커밋:** `033867a3` | [MM-67522 Add tests for syncing user statuses (#35269)](https://github.com/mattermost/mattermost/commit/033867a3448875d84653c81026d31bddf3ce4c40) | 2026-02-20
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| e80dec22 | [GetAllForObject, use Master instead of replica (#35356)](https://github.com/mattermost/mattermost/commit/e80dec22600820bfbdb32178e313b6cd2388dcd9) | 2026-02-20 |
-| 392253a1 | [MM-67539 Fix 'Last login' column in System Console Users table never being populated (#35239)](https://github.com/mattermost/mattermost/commit/392253a168942d09603a908e75cdddf5e39cff88) | 2026-02-20 |
-| 100cde3a | [\[MM-67587\] Exclude system messages from autotranslation queue (#35267)](https://github.com/mattermost/mattermost/commit/100cde3a1aeee2faf5a537d1cb1a280b4c24f594) | 2026-02-20 |
-| 334c1bcb | [update default worker count for autotranslations (#35355)](https://github.com/mattermost/mattermost/commit/334c1bcbb768855991f52c83b0df3c2cae08e7a2) | 2026-02-20 |
-| 033867a3 | [MM-67522 Add tests for syncing user statuses (#35269)](https://github.com/mattermost/mattermost/commit/033867a3448875d84653c81026d31bddf3ce4c40) | 2026-02-20 |
 | b96f7c1a | [Content flagging actions implementation tests (#35035)](https://github.com/mattermost/mattermost/commit/b96f7c1a8da95e7caff2d948055c8dd02161f54a) | 2026-02-23 |
 | 8d511d77 | [Handled null column for scheduled post type in database (#35193)](https://github.com/mattermost/mattermost/commit/8d511d77a83878e0ab821c6717e7e93bef9d5fb6) | 2026-02-23 |
 | ec0ad9d1 | [Translations update from Mattermost Weblate (#35404)](https://github.com/mattermost/mattermost/commit/ec0ad9d1b14f900fd99edbbed2d327be3491f0df) | 2026-02-23 |
@@ -1065,3 +1060,4 @@
 | d87527b3 | [\[MM-67488\] Set autotranslation feature flag default to true (#35288)](https://github.com/mattermost/mattermost/commit/d87527b374636ace6e5ef7bff2fcb8238a9d3385) | AutoTranslation 실제 구현(번역 엔진 호출 로직)이 github.com/mattermost/enterprise/autotranslation 비공개 저장소에만 있음 - 자체 모듈(LibreTranslate 등) 개발 전까지 feature flag 비활성 유지 |
 | a8dc8baa | [\[MM-67235\] Add support for autotranslations on GM and DM (#35255)](https://github.com/mattermost/mattermost/commit/a8dc8baa905630d28c9d6966aca67c3ee01df16c) | GM/DM 자동번역 프론트엔드 배선(selector·UI). 실제 번역 로직은 github.com/mattermost/enterprise/autotranslation(비공개)에 있어 okrbest에서 작동 불가 — exclude 처리(위 부록 참조). 자체 모듈 개발 시 UI 참고 가능. |
 | 932086e2 | [separate websocket event for translations metrics (#35296)](https://github.com/mattermost/mattermost/commit/932086e29cf3e2574d69417ddd9140be76784d7a) | AutoTranslation 관련 websocket 이벤트(post_translation_updated) 전용 Prometheus 카운터 등록만 추가. 실제 번역 로직은 github.com/mattermost/enterprise/autotranslation(비공개 저장소)에 있어 okrbest에선 이 이벤트가 발생하지 않아 카운터는 항상 0으로 남는 비활성(inert) 계측. 향후 자체 autotranslation 기능 구현 시 재사용 가능. |
+| 100cde3a | [\[MM-67587\] Exclude system messages from autotranslation queue (#35267)](https://github.com/mattermost/mattermost/commit/100cde3a1aeee2faf5a537d1cb1a280b4c24f594) | 제목이 표방하는 '자동번역 큐에서 시스템 메시지 제외' 실제 로직은 github.com/mattermost/enterprise/autotranslation(비공개, //go:build enterprise 태그) 안에만 있음. 우리 저장소에는 RegisterAutoTranslationInterface()를 호출해 구현체를 등록하는 코드가 없고 go.mod/go.sum에도 참조 없음 — cherry-pick한 건 이 로직을 호출하는 post.go의 if/else→switch 스타일 리팩터뿐, 시스템 메시지 제외 기능 자체는 우리 쪽에서 비활성 상태. |

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -429,12 +429,13 @@ func (a *App) CreatePost(rctx request.CTX, post *model.Post, channel *model.Chan
 			_, translateErr := a.AutoTranslation().Translate(rctx.Context(), model.TranslationObjectTypePost, rpost.Id, rpost.ChannelId, rpost.UserId, rpost)
 			if translateErr != nil {
 				var notAvailErr *model.ErrAutoTranslationNotAvailable
-				if errors.As(translateErr, &notAvailErr) {
+				switch {
+				case errors.As(translateErr, &notAvailErr):
 					// Feature not available - log at debug level and continue
 					rctx.Logger().Debug("Auto-translation feature not available", mlog.String("post_id", rpost.Id), mlog.Err(translateErr))
-				} else if translateErr.Id == "ent.autotranslation.no_translatable_content" {
+				case translateErr.Id == "ent.autotranslation.no_translatable_content":
 					// No translatable content (only URLs/mentions) - this is expected, don't log
-				} else {
+				default:
 					// Unexpected error - log at warn level but don't fail post creation
 					rctx.Logger().Warn("Failed to translate post", mlog.String("post_id", rpost.Id), mlog.Err(translateErr))
 				}
@@ -942,12 +943,13 @@ func (a *App) UpdatePost(rctx request.CTX, receivedUpdatedPost *model.Post, upda
 			_, translateErr := a.AutoTranslation().Translate(rctx.Context(), model.TranslationObjectTypePost, rpost.Id, rpost.ChannelId, rpost.UserId, rpost)
 			if translateErr != nil {
 				var notAvailErr *model.ErrAutoTranslationNotAvailable
-				if errors.As(translateErr, &notAvailErr) {
+				switch {
+				case errors.As(translateErr, &notAvailErr):
 					// Feature not available - log at debug level and continue
 					rctx.Logger().Debug("Auto-translation feature not available for edited post", mlog.String("post_id", rpost.Id), mlog.Err(translateErr))
-				} else if translateErr.Id == "ent.autotranslation.no_translatable_content" {
+				case translateErr.Id == "ent.autotranslation.no_translatable_content":
 					// No translatable content (only URLs/mentions) - this is expected, don't log
-				} else {
+				default:
 					// Unexpected error - log at warn level but don't fail post update
 					rctx.Logger().Warn("Failed to translate edited post", mlog.String("post_id", rpost.Id), mlog.Err(translateErr))
 				}

--- a/server/channels/store/sqlstore/autotranslation_store.go
+++ b/server/channels/store/sqlstore/autotranslation_store.go
@@ -233,7 +233,8 @@ func (s *SqlAutoTranslationStore) GetAllForObject(objectType, objectID string) (
 		Where(sq.Eq{"ObjectType": objectType, "ObjectId": objectID})
 
 	var translations []Translation
-	if err := s.GetReplica().SelectBuilder(&translations, query); err != nil {
+	// Use GetMaster to avoid replica lag issues when workers fetch queued items
+	if err := s.GetMaster().SelectBuilder(&translations, query); err != nil {
 		return nil, errors.Wrapf(err, "failed to get all translations for object_id=%s", objectID)
 	}
 

--- a/server/platform/services/sharedchannel/sync_recv_test.go
+++ b/server/platform/services/sharedchannel/sync_recv_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package sharedchannel
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost/server/v8/channels/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+	"github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
+)
+
+func TestUpsertSyncUserStatus(t *testing.T) {
+	setup := func(remoteID string, user *model.User) (*Service, *MockAppIface, *model.Status, *model.RemoteCluster) {
+		var userID string
+		if user == nil {
+			userID = model.NewId()
+		} else {
+			userID = user.Id
+		}
+
+		status := &model.Status{
+			UserId: userID,
+			Status: model.StatusDnd,
+		}
+		remoteCluster := &model.RemoteCluster{
+			RemoteId: remoteID,
+			Name:     "test-remote",
+		}
+
+		mockUserStore := &mocks.UserStore{}
+		if user == nil {
+			mockUserStore.On("Get", mockTypeContext, mock.Anything).Return(nil, store.NewErrNotFound("User", userID))
+		} else {
+			mockUserStore.On("Get", mockTypeContext, user.Id).Return(user, nil)
+		}
+
+		mockStore := &mocks.Store{}
+		mockStore.On("User").Return(mockUserStore)
+
+		logger := mlog.CreateConsoleTestLogger(t)
+
+		mockServer := &MockServerIface{}
+		mockServer.On("GetStore").Return(mockStore)
+		mockServer.On("Log").Return(logger)
+
+		mockApp := &MockAppIface{}
+		mockApp.On("SaveAndBroadcastStatus", status).Return()
+
+		scs := &Service{
+			server: mockServer,
+			app:    mockApp,
+		}
+
+		return scs, mockApp, status, remoteCluster
+	}
+
+	t.Run("should broadcast changes to a remote user's status", func(t *testing.T) {
+		remoteID := model.NewId()
+		user := &model.User{
+			Id:       model.NewId(),
+			RemoteId: model.NewPointer(remoteID),
+		}
+
+		scs, mockApp, status, remoteCluster := setup(remoteID, user)
+
+		err := scs.upsertSyncUserStatus(request.TestContext(t), status, remoteCluster)
+
+		require.NoError(t, err)
+		mockApp.AssertCalled(t, "SaveAndBroadcastStatus", status)
+	})
+
+	t.Run("should return an error when the user doesn't exist locally", func(t *testing.T) {
+		remoteID := model.NewId()
+		var user *model.User
+
+		scs, mockApp, status, remoteCluster := setup(remoteID, user)
+
+		rctx := request.TestContext(t)
+		err := scs.upsertSyncUserStatus(rctx, status, remoteCluster)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error getting user when syncing status")
+		mockApp.AssertNotCalled(t, "SaveAndBroadcastStatus")
+	})
+
+	t.Run("should return an error when attempting to sync a local user", func(t *testing.T) {
+		remoteID := model.NewId()
+		user := &model.User{
+			Id:       model.NewId(),
+			RemoteId: nil,
+		}
+
+		scs, mockApp, status, remoteCluster := setup(remoteID, user)
+
+		rctx := request.TestContext(t)
+		err := scs.upsertSyncUserStatus(rctx, status, remoteCluster)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrRemoteIDMismatch)
+		assert.Contains(t, err.Error(), "error updating user status")
+		mockApp.AssertNotCalled(t, "SaveAndBroadcastStatus")
+	})
+
+	t.Run("should return an error when attempting to sync a user from a different remote", func(t *testing.T) {
+		remoteID := model.NewId()
+		anotherRemoteID := model.NewId()
+		user := &model.User{
+			Id:       model.NewId(),
+			RemoteId: model.NewPointer(anotherRemoteID),
+		}
+
+		scs, mockApp, status, remoteCluster := setup(remoteID, user)
+
+		rctx := request.TestContext(t)
+		err := scs.upsertSyncUserStatus(rctx, status, remoteCluster)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrRemoteIDMismatch)
+		assert.Contains(t, err.Error(), "error updating user status")
+		mockApp.AssertNotCalled(t, "SaveAndBroadcastStatus")
+	})
+}

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -204,6 +204,8 @@ const (
 	AnnouncementSettingsDefaultNoticesJsonURL               = "https://notices.mattermost.com/"
 	AnnouncementSettingsDefaultNoticesFetchFrequencySeconds = 3600
 
+	AutoTranslationDefaultWorkers = 6
+
 	TeamSettingsDefaultTeamText = "default"
 
 	ElasticsearchSettingsDefaultConnectionURL               = "http://localhost:9200"
@@ -2836,7 +2838,7 @@ func (s *AutoTranslationSettings) SetDefaults() {
 	}
 
 	if s.Workers == nil {
-		s.Workers = NewPointer(4)
+		s.Workers = NewPointer(AutoTranslationDefaultWorkers)
 	}
 
 	if s.TimeoutMs == nil {

--- a/webapp/channels/src/components/admin_console/system_users/system_users.tsx
+++ b/webapp/channels/src/components/admin_console/system_users/system_users.tsx
@@ -319,7 +319,7 @@ function SystemUsers(props: Props) {
             },
             {
                 id: ColumnNames.lastLoginAt,
-                accessorKey: 'last_login_at',
+                accessorKey: 'last_login',
                 header: formatMessage({
                     id: 'admin.system_users.list.lastLoginAt',
                     defaultMessage: 'Last login',

--- a/webapp/platform/types/src/reports.ts
+++ b/webapp/platform/types/src/reports.ts
@@ -76,7 +76,7 @@ export type UserReportOptions = UserReportFilter & {
 };
 
 export type UserReport = UserProfile & {
-    last_login_at: number;
+    last_login: number;
     last_status_at?: number;
     last_post_date?: number;
     days_active?: number;


### PR DESCRIPTION
## Summary
2026-02-20 날짜의 upstream(mattermost/mattermost) 커밋 5개를 정밀 분석해 전부 cherry-pick 반영.

- `e80dec22` GetAllForObject, use Master instead of replica (#35356) — 자동번역 replica lag 레이스 버그 수정
- `392253a1` MM-67539 Fix 'Last login' column in System Console Users table never being populated (#35239) — 필드명 불일치 버그 수정
- `100cde3a` [MM-67587] Exclude system messages from autotranslation queue (#35267) — post.go 에러 처리 리팩터(스타일 변경). 실제 "시스템 메시지 제외" 로직은 비공개 모듈(github.com/mattermost/enterprise/autotranslation)에만 있어 우리 쪽은 비활성 — ledger에 private-module 태그로 기록
- `334c1bcb` update default worker count for autotranslations (#35355) — 기본 워커 수 4→6
- `033867a3` MM-67522 Add tests for syncing user statuses (#35269) — Shared Channels 상태 동기화에 RemoteID 검증 추가(스푸핑 방지 보안 수정) + 테스트

## Test plan
- [x] server: `go test ./channels/store/sqlstore/... ./public/model/... ./platform/services/sharedchannel/...` (autotranslation, config defaults, status sync) 통과
- [x] webapp: `npx jest src/components/admin_console/system_users` 통과
- [x] server `make check-style`: 세션 커밋과 무관한 기존 결함(`enterprise/message_export/shared` vet 에러, `storetest.Store`에 `NotificationHistory` 메서드 누락) 1건 재확인 — master에 이미 존재, 이번 세션과 diff 0
- [x] webapp `npm run check-types`: 세션이 건드린 2개 파일(`system_users.tsx`, `reports.ts`)은 에러 목록에 없음 — 나머지 에러는 전부 세션과 무관한 기존 파일들

🤖 Generated with [Claude Code](https://claude.com/claude-code)