### PR TITLE
upstream sync 2026-02-24 (picked 3)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,17 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-07 09:26
+- 갱신일: 2026-08-07 09:58
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 1010개
+- 남은 커밋: 1008개
 
-**마지막 반영 커밋:** `ec0ad9d1` | [Translations update from Mattermost Weblate (#35404)](https://github.com/mattermost/mattermost/commit/ec0ad9d1b14f900fd99edbbed2d327be3491f0df) | 2026-02-23
+**마지막 반영 커밋:** `b831c18f` | [Increase minimum version of Node to 24 and NPM to 11 (#35413)](https://github.com/mattermost/mattermost/commit/b831c18f674a5a82d0df3f44d4c47ccea077ccdf) | 2026-02-24
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 8fd7aea6 | [update intune doc link (#35166)](https://github.com/mattermost/mattermost/commit/8fd7aea63c52f2c1c0016d4a60255d5ff77c4983) | 2026-02-24 |
-| 4b8ff4e6 | [fix: flaky MM-T5521-8 (#35385)](https://github.com/mattermost/mattermost/commit/4b8ff4e6a3fd82364709d07bade18afbcbb79d87) | 2026-02-24 |
-| b831c18f | [Increase minimum version of Node to 24 and NPM to 11 (#35413)](https://github.com/mattermost/mattermost/commit/b831c18f674a5a82d0df3f44d4c47ccea077ccdf) | 2026-02-24 |
 | 7b5c3433 | [E2E/Test: Migrate flaky MM-T388 to playwright (#35369)](https://github.com/mattermost/mattermost/commit/7b5c34339d710231361f8c68453b25da5392cc15) | 2026-02-25 |
 | 60fbce7d | [\[MM-67671\] Add CJK Post search support for PostgreSQL (#35260)](https://github.com/mattermost/mattermost/commit/60fbce7d03f2bbe00238c4c988b9d86b3360a0bd) | 2026-02-25 |
 | 24d3fed7 | [Update filippo.io/edwards25519 (#35422)](https://github.com/mattermost/mattermost/commit/24d3fed77757dcc621deef5a92d2ec932fad4c4d) | 2026-02-25 |
@@ -1021,6 +1018,7 @@
 | eed994d1 | [\[MM-70114\] Fix flaky channel guard broadcast test (#37847)](https://github.com/mattermost/mattermost/commit/eed994d1062da9305ec950ba10ddb5faf0d6396f) | 2026-08-06 |
 | 318fd812 | [Fix flaky TestComplianceStore/postgres/MessageExport_UntilUpdateAt (#37856)](https://github.com/mattermost/mattermost/commit/318fd81259c9c1b8859a3f6e357b26e9603d3e4a) | 2026-08-06 |
 | dce666b0 | [MM-69980 Fix edited posts being slightly taller than unedited ones (#37693)](https://github.com/mattermost/mattermost/commit/dce666b02d8ec1864ed7b368157cc6d8ab96e5b4) | 2026-08-06 |
+| fbf8402d | [\[MM-65680\] Add new configuration 'AttributeRefreshIntervalSeconds' to Access Control (#37854)](https://github.com/mattermost/mattermost/commit/fbf8402d4bce027823d7788c8f48401d839f8b31) | 2026-08-06 |
 
 ## 제외된 커밋
 

--- a/e2e-tests/playwright/lib/src/ui/components/system_console/sections/user_management/users/menus.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/system_console/sections/user_management/users/menus.ts
@@ -50,6 +50,9 @@ export class ColumnToggleMenu {
     }
 }
 
+type RoleFilter = 'Any' | 'System Admin' | 'Member' | 'Guest';
+type StatusFilter = 'Any' | 'Activated users' | 'Deactivated users';
+
 /**
  * Filter popover that appears when clicking the Filters button
  */
@@ -93,6 +96,22 @@ export class FilterPopover {
     }
 
     /**
+     * Select a team from the dropdown. For "All teams" and "No teams", opens the
+     * dropdown directly. For specific team names, searches first then selects.
+     */
+    async filterByTeam(team: 'All teams' | 'No teams' | (string & {})) {
+        if (team === 'All teams' || team === 'No teams') {
+            await expect(this.teamMenuInput).toBeVisible();
+            await this.teamMenuInput.click();
+        } else {
+            await this.searchInTeamMenu(team);
+        }
+        const option = this.container.getByRole('option', {name: team});
+        await option.waitFor();
+        await option.click();
+    }
+
+    /**
      * Open the role filter menu
      */
     async openRoleMenu() {
@@ -101,11 +120,31 @@ export class FilterPopover {
     }
 
     /**
+     * Open the role filter menu and select a role option
+     */
+    async filterByRole(role: RoleFilter) {
+        await this.openRoleMenu();
+        const option = this.container.getByRole('option', {name: role});
+        await option.waitFor();
+        await option.click();
+    }
+
+    /**
      * Open the status filter menu
      */
     async openStatusMenu() {
         await expect(this.statusMenuButton).toBeVisible();
         await this.statusMenuButton.click();
+    }
+
+    /**
+     * Open the status filter menu and select a status option
+     */
+    async filterByStatus(status: StatusFilter) {
+        await this.openStatusMenu();
+        const option = this.container.getByRole('option', {name: status});
+        await option.waitFor();
+        await option.click();
     }
 
     /**

--- a/e2e-tests/playwright/specs/functional/system_console/system_users/filter_popover.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/system_users/filter_popover.spec.ts
@@ -35,8 +35,7 @@ test('MM-T5521-7 Should be able to filter users with team filter', async ({pw}) 
     const filterPopover = await systemConsolePage.users.openFilterPopover();
 
     // # Enter the team name of the first user and select it
-    await filterPopover.searchInTeamMenu(team1.display_name);
-    await filterPopover.teamMenuInput.press('Enter');
+    await filterPopover.filterByTeam(team1.display_name);
 
     // # Save the filter and close the popover
     await filterPopover.save();
@@ -79,11 +78,7 @@ test('MM-T5521-8 Should be able to filter users with role filter', async ({pw}) 
     const filterPopover = await systemConsolePage.users.openFilterPopover();
 
     // # Open the role filter in the popover and select Guest
-    await filterPopover.openRoleMenu();
-    // Wait for dropdown options and click on Guest
-    const guestOption = systemConsolePage.page.getByText('Guest', {exact: true});
-    await guestOption.waitFor();
-    await guestOption.click();
+    await filterPopover.filterByRole('Guest');
 
     // # Save the filter and close the popover
     await filterPopover.save();
@@ -132,11 +127,7 @@ test('MM-T5521-9 Should be able to filter users with status filter', async ({pw}
     const filterPopover = await systemConsolePage.users.openFilterPopover();
 
     // # Open the status filter in the popover and select Deactivated users
-    await filterPopover.openStatusMenu();
-    // Wait for dropdown options and click on Deactivated users
-    const deactivatedOption = systemConsolePage.page.getByText('Deactivated users', {exact: true});
-    await deactivatedOption.waitFor();
-    await deactivatedOption.click();
+    await filterPopover.filterByStatus('Deactivated users');
 
     // # Save the filter and close the popover
     await filterPopover.save();

--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -2212,7 +2212,7 @@ const AdminDefinition: AdminDefinitionType = {
                                     featureName: 'intune_mam',
                                     title: defineMessage({id: 'admin.intune_feature_discovery.title', defaultMessage: 'Protect mobile data with Microsoft Intune App Protection Policies (MAM) and Entra ID authentication'}),
                                     description: defineMessage({id: 'admin.intune_feature_discovery.description', defaultMessage: 'With Mattermost Enterprise Advanced, you can enable Microsoft Intune Mobile Application Management (MAM) to enforce App Protection Policies (APP) on Mattermost Mobile. Users sign in with Microsoft Entra ID (Azure AD), and Intune MAM applies data protection, selective wipe, and compliance policies on supported iOS devices.'}),
-                                    learnMoreURL: 'https://docs.mattermost.com/deployment/intune-mam.html',
+                                    learnMoreURL: 'https://docs.mattermost.com/deployment-guide/mobile/configure-microsoft-intune-mam.html',
                                     svgImage: IntuneMAMSvg,
                                 },
                             },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -2,8 +2,8 @@
   "name": "@mattermost/webapp",
   "private": true,
   "engines": {
-    "node": "^20 || ^22 || ^24",
-    "npm": "^10 || ^11"
+    "node": "^24",
+    "npm": "^11"
   },
   "scripts": {
     "postinstall": "patch-package && npm run build --workspace platform/types --workspace platform/client --workspace platform/components --workspace platform/shared",


### PR DESCRIPTION
## Summary
- cherry-pick: update intune doc link (#35166)
- cherry-pick: fix: flaky MM-T5521-8 (#35385) — E2E filter popover flakiness fix
- cherry-pick: Increase minimum version of Node to 24 and NPM to 11 (#35413)

## Test plan
- [x] webapp: eslint on touched file (`admin_definition.tsx`) — clean aside from known CRLF noise and one pre-existing unrelated issue
- [x] webapp/package.json: JSON valid, local Node v24 / npm v11 already satisfy the tightened `engines` constraint
- [x] e2e-tests: manual review — all referenced page-object members (`teamMenuInput`, `roleMenuButton`, `statusMenuButton`, etc.) confirmed present; local `node_modules` not installed for this workspace so `tsc`/lint deferred to CI