### PR TITLE
upstream sync 2026-03-03 (picked 5)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,19 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-07 13:23
+- 갱신일: 2026-08-07 13:44
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 996개
+- 남은 커밋: 991개
 
-**마지막 반영 커밋:** `59240826` | [MM-67754 - Fix ABAC E2E tests flakiness in Enterprise CI environment (#35452)](https://github.com/mattermost/mattermost/commit/592408261e4324254efb214b47cbe4be824cb36c) | 2026-03-02
+**마지막 반영 커밋:** `3726e87e` | [\[MM-67749\] Fix enter key issue for AI rewrite (#35449)](https://github.com/mattermost/mattermost/commit/3726e87ef236e4613de8c88c1274d3918fc4c965) | 2026-03-03
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 8dbfb878 | [MM-29974 Adds e2e tests to the plugin list command (#34866)](https://github.com/mattermost/mattermost/commit/8dbfb87877307df75d6aa4efc717ee723aff5aae) | 2026-03-03 |
-| 27d054c4 | [Prepackage Playbooks FIPS v2.7.0 (#35450) (#35456)](https://github.com/mattermost/mattermost/commit/27d054c4d39cafeef2f3e67df683197c4f180ea1) | 2026-03-03 |
-| c4627201 | [\[MM-65822\] Add directory conflict checks for plugin and import uploads (#34681)](https://github.com/mattermost/mattermost/commit/c4627201869d6d3a75b260b9812069a6bb8b046a) | 2026-03-03 |
-| a7930cc7 | [fix: flaky flag-messages.spec (#35453)](https://github.com/mattermost/mattermost/commit/a7930cc782520120e84b4b310c64cfc8e488aeb4) | 2026-03-04 |
-| 3726e87e | [\[MM-67749\] Fix enter key issue for AI rewrite (#35449)](https://github.com/mattermost/mattermost/commit/3726e87ef236e4613de8c88c1274d3918fc4c965) | 2026-03-03 |
 | 72460bff | [fix: datetime and edit specs (#35455)](https://github.com/mattermost/mattermost/commit/72460bff617b4c408a453b70da3546142ef003e8) | 2026-03-04 |
 | a9a3d3f8 | [\[MM-65587\] Remove unused audit log file rotation settings (#35170)](https://github.com/mattermost/mattermost/commit/a9a3d3f889af805d52f534f2228feb02df2be55f) | 2026-03-04 |
 | 014fee59 | [fix: webhook server connection error in cypress (#35471)](https://github.com/mattermost/mattermost/commit/014fee5950c0b10fa39677ad5bf01cd25fba4f48) | 2026-03-04 |

--- a/e2e-tests/playwright/lib/src/ui/components/channels/center_view.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/center_view.ts
@@ -25,8 +25,6 @@ export default class ChannelsCenterView {
     readonly editedPostIcon;
     readonly channelBanner;
     readonly flagPostConfirmationDialog;
-    readonly messageDeleted;
-    readonly postText;
 
     constructor(container: Locator, page: Page) {
         this.container = container;
@@ -43,9 +41,6 @@ export default class ChannelsCenterView {
             page.locator('#FlagPostModal div.modal-content'),
             page,
         );
-        this.messageDeleted = (postId: string) =>
-            this.container.locator(`#${postId}_message >> text=(message deleted)`);
-        this.postText = (postID: string) => this.container.locator(`#postMessageText_${postID}`);
     }
 
     async toBeVisible() {
@@ -175,14 +170,5 @@ export default class ChannelsCenterView {
 
         const actualText = await strikethroughText.textContent();
         expect(actualText).toBe(text);
-    }
-
-    async messageDeletedVisible(isVisible: boolean = false, postId: string, message: string) {
-        await expect(this.messageDeleted(postId)).toBeVisible({visible: isVisible});
-        if (!isVisible) {
-            const postMessageText = this.postText(postId);
-            const postMessageTextContent = await postMessageText.textContent();
-            expect(postMessageTextContent).toBe(message);
-        }
     }
 }

--- a/e2e-tests/playwright/specs/functional/channels/content_flagging/flagging/flag-messages.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/content_flagging/flagging/flag-messages.spec.ts
@@ -89,7 +89,8 @@ test('Verify flagged message is hidden by default', async ({pw}) => {
     await flagPostFlow(post, channelsPage, message, FLAG_REASON_INAPPROPRIATE_ALT);
 
     // Verify the message is flagged
-    await channelsPage.centerView.messageDeletedVisible(true, postId, message);
+    const flaggedPost = await channelsPage.centerView.getPostById(postId);
+    await flaggedPost.toContainText('(message deleted)');
     const systemMessage = await channelsPage.getLastPost();
     await expect(systemMessage.body).toContainText(SYSTEM_MESSAGE(user.username));
 });

--- a/server/Makefile
+++ b/server/Makefile
@@ -174,7 +174,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # download the package from to work. This will no longer be needed when we unify
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
-	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.6.2%2Bb8f2bd9-fips
+	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.7.0%2B1031c5e-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v1.7.2%2B866e2dd-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.2%2B4282c63-fips
 endif

--- a/server/channels/utils/fileutils/fileutils.go
+++ b/server/channels/utils/fileutils/fileutils.go
@@ -4,8 +4,10 @@
 package fileutils
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/mattermost/mattermost/server/v8"
 )
@@ -114,4 +116,40 @@ func FindDirRelBinary(dir string) (string, bool) {
 		return "./", false
 	}
 	return found, true
+}
+
+// CheckDirectoryConflict checks if either directory is a subdirectory of the other.
+// Returns true if there is a conflict (one is a subdirectory of the other or they are the same).
+// Returns an error if the directory paths cannot be resolved.
+// If a directory does not exist, the absolute path is used without symlink resolution.
+func CheckDirectoryConflict(dir1, dir2 string) (bool, error) {
+	absDir1, err := filepath.Abs(dir1)
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve absolute path for %q: %w", dir1, err)
+	}
+	absDir2, err := filepath.Abs(dir2)
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve absolute path for %q: %w", dir2, err)
+	}
+
+	if resolved, err := filepath.EvalSymlinks(absDir1); err == nil {
+		absDir1 = resolved
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("failed to evaluate symlinks for %q: %w", dir1, err)
+	}
+
+	if resolved, err := filepath.EvalSymlinks(absDir2); err == nil {
+		absDir2 = resolved
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("failed to evaluate symlinks for %q: %w", dir2, err)
+	}
+
+	if !strings.HasSuffix(absDir1, string(filepath.Separator)) {
+		absDir1 += string(filepath.Separator)
+	}
+	if !strings.HasSuffix(absDir2, string(filepath.Separator)) {
+		absDir2 += string(filepath.Separator)
+	}
+
+	return strings.HasPrefix(absDir1, absDir2) || strings.HasPrefix(absDir2, absDir1), nil
 }

--- a/server/channels/utils/fileutils/fileutils_test.go
+++ b/server/channels/utils/fileutils/fileutils_test.go
@@ -129,3 +129,179 @@ func TestFindFile(t *testing.T) {
 		}
 	})
 }
+
+func TestCheckDirectoryConflict(t *testing.T) {
+	t.Run("separate directories", func(t *testing.T) {
+		tmpDir1, err := os.MkdirTemp("", "dir1")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir1)
+
+		tmpDir2, err := os.MkdirTemp("", "dir2")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir2)
+
+		conflict, err := CheckDirectoryConflict(tmpDir1, tmpDir2)
+		require.NoError(t, err)
+		assert.False(t, conflict)
+	})
+
+	t.Run("same directory", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "samedir")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		conflict, err := CheckDirectoryConflict(tmpDir, tmpDir)
+		require.NoError(t, err)
+		assert.True(t, conflict)
+	})
+
+	t.Run("first is subdirectory of second", func(t *testing.T) {
+		tmpDir1, err := os.MkdirTemp("", "parent")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir1)
+
+		tmpDir2 := filepath.Join(tmpDir1, "child")
+		err = os.MkdirAll(tmpDir2, 0700)
+		require.NoError(t, err)
+
+		conflict, err := CheckDirectoryConflict(tmpDir2, tmpDir1)
+		require.NoError(t, err)
+		assert.True(t, conflict)
+	})
+
+	t.Run("second is subdirectory of first", func(t *testing.T) {
+		tmpDir1, err := os.MkdirTemp("", "parent")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir1)
+
+		tmpDir2 := filepath.Join(tmpDir1, "child")
+		err = os.MkdirAll(tmpDir2, 0700)
+		require.NoError(t, err)
+
+		conflict, err := CheckDirectoryConflict(tmpDir1, tmpDir2)
+		require.NoError(t, err)
+		assert.True(t, conflict)
+	})
+
+	t.Run("deeply nested subdirectory", func(t *testing.T) {
+		tmpDir1, err := os.MkdirTemp("", "parent")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir1)
+
+		tmpDir2 := filepath.Join(tmpDir1, "a", "b", "c")
+		err = os.MkdirAll(tmpDir2, 0700)
+		require.NoError(t, err)
+
+		conflict, err := CheckDirectoryConflict(tmpDir1, tmpDir2)
+		require.NoError(t, err)
+		assert.True(t, conflict)
+
+		conflict, err = CheckDirectoryConflict(tmpDir2, tmpDir1)
+		require.NoError(t, err)
+		assert.True(t, conflict)
+	})
+
+	t.Run("symlinked directory", func(t *testing.T) {
+		tmpDir1, err := os.MkdirTemp("", "real")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir1)
+
+		tmpDir2, err := os.MkdirTemp("", "symlinks")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir2)
+
+		symlink := filepath.Join(tmpDir2, "link")
+		err = os.Symlink(tmpDir1, symlink)
+		require.NoError(t, err)
+
+		conflict, err := CheckDirectoryConflict(tmpDir1, symlink)
+		require.NoError(t, err)
+		assert.True(t, conflict)
+	})
+
+	t.Run("relative paths", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "parent")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		subDir := filepath.Join(tmpDir, "subdir")
+		err = os.MkdirAll(subDir, 0700)
+		require.NoError(t, err)
+
+		err = os.Chdir(tmpDir)
+		require.NoError(t, err)
+
+		conflict, err := CheckDirectoryConflict(".", ".")
+		require.NoError(t, err)
+		assert.True(t, conflict)
+
+		conflict, err = CheckDirectoryConflict(".", "./subdir")
+		require.NoError(t, err)
+		assert.True(t, conflict)
+
+		conflict, err = CheckDirectoryConflict("./subdir", ".")
+		require.NoError(t, err)
+		assert.True(t, conflict)
+	})
+
+	t.Run("similar prefix but not subdirectory", func(t *testing.T) {
+		tmpDir1, err := os.MkdirTemp("", "dir")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir1)
+
+		tmpDir2, err := os.MkdirTemp("", "dir")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir2)
+
+		conflict, err := CheckDirectoryConflict(tmpDir1, tmpDir2)
+		require.NoError(t, err)
+		assert.False(t, conflict)
+	})
+
+	t.Run("non-existent directories are handled", func(t *testing.T) {
+		// Both directories non-existent but separate - no error, no conflict
+		conflict, err := CheckDirectoryConflict("/nonexistent/path1", "/nonexistent/path2")
+		require.NoError(t, err)
+		assert.False(t, conflict)
+
+		// Both directories non-existent, one nested in the other
+		conflict, err = CheckDirectoryConflict("/nonexistent/parent", "/nonexistent/parent/child")
+		require.NoError(t, err)
+		assert.True(t, conflict)
+
+		// Same non-existent directory
+		conflict, err = CheckDirectoryConflict("/nonexistent/same", "/nonexistent/same")
+		require.NoError(t, err)
+		assert.True(t, conflict)
+	})
+
+	t.Run("root directory", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "dir")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		// Root directory handled as a conflict with a subdirectory of the root
+		conflict, err := CheckDirectoryConflict("/", tmpDir)
+		require.NoError(t, err)
+		assert.True(t, conflict)
+	})
+
+	t.Run("overlap but not path prefix", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "dir")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		subDir1 := filepath.Join(tmpDir, "prefix")
+		subDir2 := filepath.Join(tmpDir, "prefix-but-different-folder")
+
+		err = os.Mkdir(subDir1, 0700)
+		require.NoError(t, err)
+		err = os.Mkdir(subDir2, 0700)
+		require.NoError(t, err)
+
+		// Two paths, one a string prefix but not an actual path prefix
+		conflict, err := CheckDirectoryConflict(subDir1, subDir2)
+		require.NoError(t, err)
+		assert.False(t, conflict)
+	})
+}

--- a/server/cmd/mmctl/commands/plugin_e2e_test.go
+++ b/server/cmd/mmctl/commands/plugin_e2e_test.go
@@ -379,3 +379,86 @@ func (s *MmctlE2ETestSuite) TestPluginDeleteCmd() {
 		s.Require().Len(plugins.Inactive, 1)
 	})
 }
+
+func (s *MmctlE2ETestSuite) TestPluginListCmdF() {
+	s.SetupTestHelper().InitBasic(s.T())
+
+	s.Run("Error when appropriate permissions are not available", func() {
+		printer.Clean()
+
+		enablePlugin := *s.th.App.Config().PluginSettings.Enable
+		s.th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = true
+		})
+		defer s.th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = enablePlugin
+		})
+
+		cmd := &cobra.Command{}
+
+		err := pluginListCmdF(s.th.Client, cmd, []string{})
+		s.Require().Error(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.Equal("Unable to list plugins. Error: You do not have the appropriate permissions.", err.Error())
+	})
+
+	s.RunForSystemAdminAndLocal("Error when plugins are disabled", func(c client.Client) {
+		printer.Clean()
+
+		enablePlugin := *s.th.App.Config().PluginSettings.Enable
+		s.th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = false
+		})
+		defer s.th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = enablePlugin
+		})
+
+		cmd := &cobra.Command{}
+
+		err := pluginListCmdF(c, cmd, []string{})
+		s.Require().Error(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.Equal("Unable to list plugins. Error: Plugins have been disabled. Please check your logs for details.", err.Error())
+	})
+
+	s.RunForSystemAdminAndLocal("Success when appropriate permissions are available", func(c client.Client) {
+		printer.Clean()
+
+		enablePlugin := *s.th.App.Config().PluginSettings.Enable
+		s.th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = true
+		})
+		defer s.th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = enablePlugin
+		})
+
+		cmd := &cobra.Command{}
+
+		err := pluginListCmdF(c, cmd, []string{})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 3)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.RunForSystemAdminAndLocal("Success when appropriate permissions are available but prints json plugins", func(c client.Client) {
+		printer.Clean()
+
+		enablePlugin := *s.th.App.Config().PluginSettings.Enable
+		s.th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = true
+		})
+		defer s.th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = enablePlugin
+		})
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("format", "json", "")
+
+		err := pluginListCmdF(c, cmd, []string{})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -2693,6 +2693,14 @@
     "translation": "An error occurred while parsing the payload."
   },
   {
+    "id": "api.plugin.install.check_directory.app_error",
+    "translation": "An error occurred while checking the plugin directory configuration."
+  },
+  {
+    "id": "api.plugin.install.directory_conflict.app_error",
+    "translation": "Cannot install plugin: PluginSettings.Directory conflicts with ImportSettings.Directory."
+  },
+  {
     "id": "api.plugin.install.download_failed.app_error",
     "translation": "An error occurred while downloading the plugin."
   },
@@ -4169,6 +4177,14 @@
   {
     "id": "api.upgrade_to_enterprise_status.signature.app_error",
     "translation": "Mattermost was unable to upgrade to Enterprise Edition. The digital signature of the downloaded binary file could not be verified."
+  },
+  {
+    "id": "api.upload.create.check_directory.app_error",
+    "translation": "An error occurred while checking the import directory configuration."
+  },
+  {
+    "id": "api.upload.create.directory_conflict.app_error",
+    "translation": "Cannot create import upload: ImportSettings.Directory conflicts with PluginSettings.Directory."
   },
   {
     "id": "api.upload.create.upload_channel_not_shared_with_remote.app_error",

--- a/webapp/channels/src/components/advanced_text_editor/use_rewrite.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_rewrite.test.tsx
@@ -208,6 +208,7 @@ describe('useRewrite', () => {
             props = MockedRewriteMenu.mock.calls[MockedRewriteMenu.mock.calls.length - 1][0];
             const mockEvent = {
                 key: 'Enter',
+                nativeEvent: {isComposing: false},
                 stopPropagation: jest.fn(),
             } as unknown as React.KeyboardEvent<HTMLInputElement>;
 
@@ -393,6 +394,7 @@ describe('useRewrite', () => {
             props = MockedRewriteMenu.mock.calls[MockedRewriteMenu.mock.calls.length - 1][0];
             const mockEvent = {
                 key: 'Enter',
+                nativeEvent: {isComposing: false},
                 stopPropagation: jest.fn(),
             } as unknown as React.KeyboardEvent<HTMLInputElement>;
 
@@ -482,6 +484,7 @@ describe('useRewrite', () => {
             props = MockedRewriteMenu.mock.calls[MockedRewriteMenu.mock.calls.length - 1][0];
             const mockEvent = {
                 key: 'Enter',
+                nativeEvent: {isComposing: false},
                 stopPropagation: jest.fn(),
             } as unknown as React.KeyboardEvent<HTMLInputElement>;
 
@@ -497,6 +500,27 @@ describe('useRewrite', () => {
                     '',
                 );
             });
+        });
+
+        it('should not trigger rewrite on Enter key during IME composition', () => {
+            const {result, rerender} = renderHookWithProps();
+            render(result.current.additionalControl);
+            let props = MockedRewriteMenu.mock.calls[MockedRewriteMenu.mock.calls.length - 1][0];
+            props.setPrompt('Custom prompt');
+
+            rerender();
+            render(result.current.additionalControl);
+            props = MockedRewriteMenu.mock.calls[MockedRewriteMenu.mock.calls.length - 1][0];
+            const mockEvent = {
+                key: 'Enter',
+                nativeEvent: {isComposing: true},
+                stopPropagation: jest.fn(),
+            } as unknown as React.KeyboardEvent<HTMLInputElement>;
+
+            props.onCustomPromptKeyDown(mockEvent);
+
+            expect(mockEvent.stopPropagation).not.toHaveBeenCalled();
+            expect(Client4.getAIRewrittenMessage).not.toHaveBeenCalled();
         });
     });
 

--- a/webapp/channels/src/components/advanced_text_editor/use_rewrite.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_rewrite.tsx
@@ -124,6 +124,9 @@ const useRewrite = (
             return;
         }
         if (e.key === 'Enter') {
+            if (e.nativeEvent.isComposing) {
+                return;
+            }
             e.stopPropagation();
             handleRewrite(RewriteAction.CUSTOM, prompt);
         }


### PR DESCRIPTION
- MM-29974 Adds e2e tests to the plugin list command (#34866)
- Prepackage Playbooks FIPS v2.7.0 (#35450) (#35456)
- [MM-65822] Add directory conflict checks for plugin and import uploads (#34681)
- fix: flaky flag-messages.spec (#35453)
- [MM-67749] Fix enter key issue for AI rewrite (#35449)
- docs: upstream sync 진행 (picked 5)