### PR TITLE
upstream sync 2026-03-18 (picked 9, adapted 1)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,24 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-12 13:46
+- 갱신일: 2026-08-12 14:55
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 935개
+- 남은 커밋: 925개
 
-**마지막 반영 커밋:** `37028a79` | [\[MM-677967\] Send updated title template for popouts when state changes (#35635)](https://github.com/mattermost/mattermost/commit/37028a794d579c119713536879963167b258488d) | 2026-03-17
+**마지막 반영 커밋:** `0085d149` | [MM-67518 Increase amount that the post list is considered to be at the bottom (#35680)](https://github.com/mattermost/mattermost/commit/0085d14979ae7241e3c9459d6e457b3222c938ff) | 2026-03-18
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| b1034649 | [\[MM-67886\] Remove height cap on Feature Flags table in System Console (#35556)](https://github.com/mattermost/mattermost/commit/b10346496b4eb40ea06781ee2641c67ef7de198d) | 2026-03-18 |
-| 9dacec36 | [\[MM-29973\] Adds E2E tests for `mmctl plugin disable` (#35464)](https://github.com/mattermost/mattermost/commit/9dacec36723b2d88a5700274c191df4775f5cdcd) | 2026-03-18 |
-| 08f09274 | [mmctl: Add support for listing user roles through mmctl (#34064)](https://github.com/mattermost/mattermost/commit/08f09274e8d4d26caf09dc917e69268a6857a54b) | 2026-03-18 |
-| 0a21b88f | [MM-55536 Support Inline image when image proxy is enabled (#31020)](https://github.com/mattermost/mattermost/commit/0a21b88f948e2701680e8c394775883a9fcbb762) | 2026-03-18 |
-| 04baff8c | [Hyphenation (#30373)](https://github.com/mattermost/mattermost/commit/04baff8c8de8422285f5724f3d9b2a9b6297f273) | 2026-03-18 |
-| 314ed375 | [Fix import failures for Japanese filenames with dakuten on macOS (#35204)](https://github.com/mattermost/mattermost/commit/314ed3756aa04be0e985bd5bd3d36f8fe95bfbc1) | 2026-03-18 |
-| da62a280 | [Run i18n-extract (#35675)](https://github.com/mattermost/mattermost/commit/da62a280093e12004bd44eda4596cf2b9717ce32) | 2026-03-18 |
-| 1dea4b13 | [Add unit tests for ScheduledPost model (#35565)](https://github.com/mattermost/mattermost/commit/1dea4b13781e54e02509f5e600ea84309d93f423) | 2026-03-18 |
-| e9ae890a | [oauth check (#35553)](https://github.com/mattermost/mattermost/commit/e9ae890a013bb57989fcbdb548d8b7b86b240237) | 2026-03-18 |
-| 0085d149 | [MM-67518 Increase amount that the post list is considered to be at the bottom (#35680)](https://github.com/mattermost/mattermost/commit/0085d14979ae7241e3c9459d6e457b3222c938ff) | 2026-03-18 |
 | fee649d0 | [Run docs-impact-review as regular CI instead of slash command (#35620)](https://github.com/mattermost/mattermost/commit/fee649d06353948763d4fb09c6664fa942a82428) | 2026-03-19 |
 | aea8cbdc | [Fix typos in webapp: receivedStatus and separately (#35254)](https://github.com/mattermost/mattermost/commit/aea8cbdc7a970a3c5e647682b05d4cbd7925e77a) | 2026-03-19 |
 | b9aeb629 | [\[MM-67905\] Allow full Markdown rendering in message attachment footer (#35570)](https://github.com/mattermost/mattermost/commit/b9aeb629be642c2ba82d7992c7bfd769fa53700a) | 2026-03-19 |

--- a/server/channels/app/import.go
+++ b/server/channels/app/import.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/app/imports"
+	"github.com/mattermost/mattermost/server/v8/channels/utils"
 )
 
 type ReactionImportData = imports.ReactionImportData // part of the app interface
@@ -63,7 +64,8 @@ func processAttachmentPaths(rctx request.CTX, files *[]imports.AttachmentImportD
 			}
 
 			if len(filesMap) > 0 {
-				if (*files)[i].Data, ok = filesMap[*f.Path]; !ok {
+				normalizedPath := utils.NormalizeFilename(*f.Path)
+				if (*files)[i].Data, ok = filesMap[normalizedPath]; !ok {
 					errs = append(errs, fmt.Errorf("attachment %q not found in map", originalPath))
 					continue
 				}
@@ -108,7 +110,8 @@ func processAttachments(rctx request.CTX, line *imports.LineImportData, basePath
 
 			*line.User.ProfileImage = path
 			if len(filesMap) > 0 {
-				if line.User.ProfileImageData, ok = filesMap[path]; !ok {
+				normalizedPath := utils.NormalizeFilename(path)
+				if line.User.ProfileImageData, ok = filesMap[normalizedPath]; !ok {
 					return fmt.Errorf("attachment %q not found in map", path)
 				}
 			}
@@ -122,7 +125,8 @@ func processAttachments(rctx request.CTX, line *imports.LineImportData, basePath
 
 			*line.Bot.ProfileImage = path
 			if len(filesMap) > 0 {
-				if line.Bot.ProfileImageData, ok = filesMap[path]; !ok {
+				normalizedPath := utils.NormalizeFilename(path)
+				if line.Bot.ProfileImageData, ok = filesMap[normalizedPath]; !ok {
 					return fmt.Errorf("attachment %q not found in map", path)
 				}
 			}
@@ -136,7 +140,8 @@ func processAttachments(rctx request.CTX, line *imports.LineImportData, basePath
 
 			*line.Emoji.Image = path
 			if len(filesMap) > 0 {
-				if line.Emoji.Data, ok = filesMap[path]; !ok {
+				normalizedPath := utils.NormalizeFilename(path)
+				if line.Emoji.Data, ok = filesMap[normalizedPath]; !ok {
 					return fmt.Errorf("attachment %q not found in map", path)
 				}
 			}
@@ -237,7 +242,7 @@ func (a *App) bulkImport(rctx request.CTX, jsonlReader io.Reader, attachmentsRea
 	if attachmentsReader != nil {
 		attachedFiles = make(map[string]*zip.File, len(attachmentsReader.File))
 		for _, fi := range attachmentsReader.File {
-			attachedFiles[fi.Name] = fi
+			attachedFiles[utils.NormalizeFilename(fi.Name)] = fi
 		}
 	}
 

--- a/server/channels/app/oauth.go
+++ b/server/channels/app/oauth.go
@@ -341,6 +341,10 @@ func (a *App) handleAuthorizationCodeGrant(rctx request.CTX, oauthApp *model.OAu
 		return nil, model.NewAppError("GetOAuthAccessToken", "api.oauth.get_access_token.expired_code.app_error", nil, "", http.StatusForbidden)
 	}
 
+	if authData.ClientId != clientId {
+		return nil, model.NewAppError("GetOAuthAccessToken", "api.oauth.get_access_token.client_id_mismatch.app_error", nil, "", http.StatusBadRequest)
+	}
+
 	if authData.RedirectUri != redirectURI {
 		return nil, model.NewAppError("GetOAuthAccessToken", "api.oauth.get_access_token.redirect_uri.app_error", nil, "", http.StatusBadRequest)
 	}
@@ -393,6 +397,10 @@ func (a *App) handleRefreshTokenGrant(rctx request.CTX, oauthApp *model.OAuthApp
 	accessData, nErr := a.Srv().Store().OAuth().GetAccessDataByRefreshToken(refreshToken)
 	if nErr != nil {
 		return nil, model.NewAppError("GetOAuthAccessToken", "api.oauth.get_access_token.refresh_token.app_error", nil, "", http.StatusNotFound).Wrap(nErr)
+	}
+
+	if accessData.ClientId != oauthApp.Id {
+		return nil, model.NewAppError("GetOAuthAccessToken", "api.oauth.get_access_token.client_id_mismatch.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	user, nErr := a.Srv().Store().User().Get(context.Background(), accessData.UserId)

--- a/server/channels/app/oauth_test.go
+++ b/server/channels/app/oauth_test.go
@@ -1400,6 +1400,64 @@ func TestGetOAuthAccessTokenForCodeFlow(t *testing.T) {
 			require.Contains(t, appErr.Id, "resource_mismatch")
 		})
 	})
+
+	t.Run("DifferentClient_CannotRedeemCode", func(t *testing.T) {
+		appA := createConfidentialOAuthApp("TestClientA")
+		appB := createConfidentialOAuthApp("TestClientB")
+		code := getAuthorizationCode(appA, "")
+
+		_, appErr := th.App.GetOAuthAccessTokenForCodeFlow(
+			th.Context,
+			appB.Id,
+			model.AccessTokenGrantType,
+			appA.CallbackUrls[0],
+			code,
+			appB.ClientSecret,
+			"",
+			"",
+			"",
+		)
+		require.NotNil(t, appErr)
+		require.Contains(t, appErr.Id, "client_id_mismatch")
+		require.Equal(t, http.StatusBadRequest, appErr.StatusCode)
+	})
+
+	t.Run("DifferentClient_CannotUseRefreshToken", func(t *testing.T) {
+		appA := createConfidentialOAuthApp("TestClientA")
+		appB := createConfidentialOAuthApp("TestClientB")
+		code := getAuthorizationCode(appA, "")
+
+		// Get a valid refresh token for appA
+		tokenResp, appErr := th.App.GetOAuthAccessTokenForCodeFlow(
+			th.Context,
+			appA.Id,
+			model.AccessTokenGrantType,
+			appA.CallbackUrls[0],
+			code,
+			appA.ClientSecret,
+			"",
+			"",
+			"",
+		)
+		require.Nil(t, appErr)
+		require.NotEmpty(t, tokenResp.RefreshToken)
+
+		// Try to use appA's refresh token with appB's credentials
+		_, appErr = th.App.GetOAuthAccessTokenForCodeFlow(
+			th.Context,
+			appB.Id,
+			model.RefreshTokenGrantType,
+			appB.CallbackUrls[0],
+			"",
+			appB.ClientSecret,
+			tokenResp.RefreshToken,
+			"",
+			"",
+		)
+		require.NotNil(t, appErr)
+		require.Contains(t, appErr.Id, "client_id_mismatch")
+		require.Equal(t, http.StatusBadRequest, appErr.StatusCode)
+	})
 }
 func TestParseOAuthStateTokenExtra(t *testing.T) {
 	t.Run("valid token with normal values", func(t *testing.T) {

--- a/server/channels/utils/unicode.go
+++ b/server/channels/utils/unicode.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package utils
+
+import "golang.org/x/text/unicode/norm"
+
+// NormalizeFilename normalizes a filename to NFC (composed) form.
+// This ensures consistent string comparison between filesystems that use
+// different Unicode normalization forms (macOS uses NFD, Linux/Windows use NFC).
+// This is particularly important for Japanese dakuten/handakuten characters
+// (e.g., "ガ" can be represented as U+30AC (NFC) or U+30AB + U+3099 (NFD)).
+func NormalizeFilename(name string) string {
+	return norm.NFC.String(name)
+}

--- a/server/channels/utils/unicode_test.go
+++ b/server/channels/utils/unicode_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "ASCII only",
+			input:    "test.jpg",
+			expected: "test.jpg",
+		},
+		{
+			name:     "Japanese katakana dakuten NFC",
+			input:    "\u30AC", // ガ (NFC)
+			expected: "\u30AC",
+		},
+		{
+			name:     "Japanese katakana dakuten NFD",
+			input:    "\u30AB\u3099", // カ + combining dakuten → ガ
+			expected: "\u30AC",
+		},
+		{
+			name:     "Japanese katakana handakuten NFC",
+			input:    "\u30D1", // パ (NFC)
+			expected: "\u30D1",
+		},
+		{
+			name:     "Japanese katakana handakuten NFD",
+			input:    "\u30CF\u309A", // ハ + combining handakuten → パ
+			expected: "\u30D1",
+		},
+		{
+			name:     "Japanese hiragana dakuten NFC",
+			input:    "\u3079", // べ (NFC)
+			expected: "\u3079",
+		},
+		{
+			name:     "Japanese hiragana dakuten NFD",
+			input:    "\u3078\u3099", // へ + combining dakuten → べ
+			expected: "\u3079",
+		},
+		{
+			name:     "Mixed path with NFD",
+			input:    "data/\u30AB\u3099test.jpg", // data/カ゛test.jpg
+			expected: "data/\u30ACtest.jpg",       // data/ガtest.jpg
+		},
+		{
+			name:     "Complex Japanese filename NFD",
+			input:    "\u304B\u3099\u304D\u3099\u3050", // が + ぎ + ぐ (NFD: か゛き゛く゛)
+			expected: "\u304C\u304E\u3050",             // がぎぐ (NFC)
+		},
+		{
+			name:     "Path with multiple NFD characters",
+			input:    "data/\u30D5\u309A\u30ED\u30B7\u3099\u30A7\u30AF\u30C8.png", // data/プロジェクト.png (NFD)
+			expected: "data/\u30D7\u30ED\u30B8\u30A7\u30AF\u30C8.png",             // data/プロジェクト.png (NFC)
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "Already NFC normalized",
+			input:    "ファイル名.txt",
+			expected: "ファイル名.txt",
+		},
+		{
+			name:     "Korean Hangul NFC",
+			input:    "\uAC00", // 가 (NFC precomposed)
+			expected: "\uAC00",
+		},
+		{
+			name:     "Korean Hangul NFD",
+			input:    "\u1100\u1161", // ᄀ + ᅡ (NFD Jamo) → 가
+			expected: "\uAC00",
+		},
+		{
+			name:     "Korean word NFD",
+			input:    "\u1112\u1161\u11AB\u1100\u1173\u11AF", // 한글 (NFD Jamo: 한글)
+			expected: "\uD55C\uAE00",                         // 한글 (NFC)
+		},
+		{
+			name:     "Korean filename with path NFD",
+			input:    "data/\u1111\u1161\u110B\u1175\u11AF.txt", // 파일 (NFD) + .txt
+			expected: "data/\uD30C\uC77C.txt",                   // 파일.txt (NFC)
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizeFilename(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNormalizeFilenameIdempotent(t *testing.T) {
+	// NFC normalization should be idempotent
+	inputs := []string{
+		"test.jpg",
+		"\u30AC",       // ガ (NFC)
+		"\u30AB\u3099", // カ + combining dakuten (NFD)
+		"data/テスト.jpg",
+		"\uD55C\uAE00",                         // 한글 (NFC)
+		"\u1112\u1161\u11AB\u1100\u1173\u11AF", // 한글 (NFD Jamo)
+		"",
+	}
+
+	for _, input := range inputs {
+		first := NormalizeFilename(input)
+		second := NormalizeFilename(first)
+		assert.Equal(t, first, second, "NormalizeFilename should be idempotent for input: %q", input)
+	}
+}

--- a/server/cmd/mmctl/client/client.go
+++ b/server/cmd/mmctl/client/client.go
@@ -56,6 +56,7 @@ type Client interface {
 	RemoveLicenseFile(ctx context.Context) (*model.Response, error)
 	GetLogs(ctx context.Context, page, perPage int) ([]string, *model.Response, error)
 	GetRoleByName(ctx context.Context, name string) (*model.Role, *model.Response, error)
+	GetAllRoles(ctx context.Context) ([]*model.Role, *model.Response, error)
 	PatchRole(ctx context.Context, roleID string, patch *model.RolePatch) (*model.Role, *model.Response, error)
 	UploadPlugin(ctx context.Context, file io.Reader) (*model.Manifest, *model.Response, error)
 	UploadPluginForced(ctx context.Context, file io.Reader) (*model.Manifest, *model.Response, error)

--- a/server/cmd/mmctl/commands/importer/validate.go
+++ b/server/cmd/mmctl/commands/importer/validate.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/v8/channels/app/imports"
+	"github.com/mattermost/mattermost/server/v8/channels/utils"
 	_ "golang.org/x/image/webp" // image decoder
 
 	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/printer"
@@ -262,10 +263,11 @@ func (v *Validator) Validate() error {
 			if zfile.FileInfo().IsDir() {
 				continue
 			}
-			if strings.HasPrefix(zfile.Name, "data/") {
-				v.attachments[zfile.Name] = zfile
+			normalizedName := utils.NormalizeFilename(zfile.Name)
+			if strings.HasPrefix(normalizedName, "data/") {
+				v.attachments[normalizedName] = zfile
 			}
-			v.allFileNames = append(v.allFileNames, zfile.Name)
+			v.allFileNames = append(v.allFileNames, normalizedName)
 		}
 	}
 
@@ -813,9 +815,9 @@ func (v *Validator) validatePost(info ImportFileInfo, line imports.LineImportDat
 				continue
 			}
 
-			attachmentPath := *attachment.Path
+			attachmentPath := utils.NormalizeFilename(*attachment.Path)
 			if _, ok := v.attachments[attachmentPath]; !ok {
-				attachmentPath = path.Join("data", *attachment.Path)
+				attachmentPath = utils.NormalizeFilename(path.Join("data", *attachment.Path))
 			}
 
 			if _, ok := v.attachments[attachmentPath]; !ok {
@@ -950,9 +952,9 @@ func (v *Validator) validateDirectPost(info ImportFileInfo, line imports.LineImp
 				continue
 			}
 
-			attachmentPath := *attachment.Path
+			attachmentPath := utils.NormalizeFilename(*attachment.Path)
 			if _, ok := v.attachments[attachmentPath]; !ok {
-				attachmentPath = path.Join("data", *attachment.Path)
+				attachmentPath = utils.NormalizeFilename(path.Join("data", *attachment.Path))
 			}
 
 			if _, ok := v.attachments[attachmentPath]; !ok {
@@ -1003,7 +1005,7 @@ func (v *Validator) validateEmoji(info ImportFileInfo, line imports.LineImportDa
 		}
 
 		if !v.ignoreAttachments && data.Image != nil {
-			attachmentPath := path.Join("data", *data.Image)
+			attachmentPath := utils.NormalizeFilename(path.Join("data", *data.Image))
 
 			zfile, ok := v.attachments[attachmentPath]
 			if !ok {

--- a/server/cmd/mmctl/commands/plugin_e2e_test.go
+++ b/server/cmd/mmctl/commands/plugin_e2e_test.go
@@ -462,3 +462,138 @@ func (s *MmctlE2ETestSuite) TestPluginListCmdF() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 }
+
+func (s *MmctlE2ETestSuite) TestPluginDisableCmd() {
+	s.SetupTestHelper().InitBasic(s.T())
+
+	pluginID := "testplugin"
+	pluginURL := filepath.Join(server.GetPackagePath(), "tests", "testplugin.tar.gz")
+	nonExistentPluginID := "nonExistentPluginID"
+
+	enablePlugin := *s.th.App.Config().PluginSettings.Enable
+	enableUploads := *s.th.App.Config().PluginSettings.EnableUploads
+	defer func() {
+		appErr := s.th.App.Channels().RemovePlugin(pluginID)
+		if appErr != nil {
+			s.Require().Contains(appErr.Error(), "Plugin is not installed.")
+		}
+		plugins, appErr := s.th.App.GetPlugins()
+		s.Require().Nil(appErr)
+		s.Require().Len(plugins.Active, 0)
+		s.Require().Len(plugins.Inactive, 0)
+
+		s.th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = enablePlugin
+			*cfg.PluginSettings.EnableUploads = enableUploads
+		})
+	}()
+	// Enable plugin uploads
+	s.th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.PluginSettings.Enable = true
+		*cfg.PluginSettings.EnableUploads = true
+	})
+
+	// Install plugin first
+	err := pluginAddCmdF(s.th.SystemAdminClient, &cobra.Command{}, []string{pluginURL})
+	s.Require().Nil(err)
+
+	s.RunForSystemAdminAndLocal("Successful disable plugin", func(c client.Client) {
+		printer.Clean()
+
+		appErr := s.th.App.EnablePlugin(pluginID)
+		s.Require().Nil(appErr)
+
+		plugins, appErr := s.th.App.GetPlugins()
+		s.Require().Nil(appErr)
+		s.Require().Len(plugins.Active, 1)
+		s.Require().Len(plugins.Inactive, 0)
+
+		cmd := &cobra.Command{}
+		err := pluginDisableCmdF(c, cmd, []string{pluginID})
+		s.Require().Nil(err)
+
+		plugins, appErr = s.th.App.GetPlugins()
+		s.Require().Nil(appErr)
+		s.Require().Len(plugins.Active, 0)
+		s.Require().Len(plugins.Inactive, 1)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], "Disabled plugin: "+pluginID)
+	})
+
+	s.Run("error for disable plugin due insufficient permissions", func() {
+		printer.Clean()
+
+		appErr := s.th.App.EnablePlugin(pluginID)
+		s.Require().Nil(appErr)
+
+		plugins, appErr := s.th.App.GetPlugins()
+		s.Require().Nil(appErr)
+		s.Require().Len(plugins.Active, 1)
+		s.Require().Len(plugins.Inactive, 0)
+
+		cmd := &cobra.Command{}
+		err := pluginDisableCmdF(s.th.Client, cmd, []string{pluginID})
+		s.Require().NotNil(err)
+		s.Require().ErrorContains(err, "You do not have the appropriate permissions.")
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+		s.Require().Equal(printer.GetErrorLines()[0], "Unable to disable plugin: "+pluginID+". Error: You do not have the appropriate permissions.")
+
+		plugins, appErr = s.th.App.GetPlugins()
+		s.Require().Nil(appErr)
+		s.Require().Len(plugins.Active, 1)
+		s.Require().Len(plugins.Inactive, 0)
+
+		appErr = s.th.App.DisablePlugin(pluginID)
+		s.Require().Nil(appErr)
+	})
+
+	s.RunForSystemAdminAndLocal("error for disabling non existent plugin", func(c client.Client) {
+		printer.Clean()
+
+		plugins, appErr := s.th.App.GetPlugins()
+		s.Require().Nil(appErr)
+		s.Require().Len(plugins.Active, 0)
+		s.Require().Len(plugins.Inactive, 1)
+
+		cmd := &cobra.Command{}
+		err := pluginDisableCmdF(c, cmd, []string{nonExistentPluginID})
+		s.Require().NotNil(err)
+		s.Require().ErrorContains(err, "Plugin is not installed.")
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+		s.Require().Equal(printer.GetErrorLines()[0], "Unable to disable plugin: "+nonExistentPluginID+". Error: Plugin is not installed.")
+
+		plugins, appErr = s.th.App.GetPlugins()
+		s.Require().Nil(appErr)
+		s.Require().Len(plugins.Active, 0)
+		s.Require().Len(plugins.Inactive, 1)
+	})
+
+	s.RunForSystemAdminAndLocal("error when plugin configs are disabled", func(c client.Client) {
+		printer.Clean()
+
+		appErr := s.th.App.EnablePlugin(pluginID)
+		s.Require().Nil(appErr)
+		plugins, appErr := s.th.App.GetPlugins()
+		s.Require().Nil(appErr)
+		s.Require().Len(plugins.Active, 1)
+		s.Require().Len(plugins.Inactive, 0)
+
+		enablePlugin2 := *s.th.App.Config().PluginSettings.Enable
+		defer s.th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = enablePlugin2
+		})
+		s.th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = false
+		})
+
+		cmd := &cobra.Command{}
+		err := pluginDisableCmdF(c, cmd, []string{pluginID})
+		s.Require().NotNil(err)
+		s.Require().ErrorContains(err, "Plugins have been disabled. Please check your logs for details.")
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+		s.Require().Equal(printer.GetErrorLines()[0], "Unable to disable plugin: "+pluginID+". Error: Plugins have been disabled. Please check your logs for details.")
+	})
+}

--- a/server/cmd/mmctl/commands/roles.go
+++ b/server/cmd/mmctl/commands/roles.go
@@ -48,14 +48,36 @@ var RolesMemberCmd = &cobra.Command{
 	RunE: withClient(rolesMemberCmdF),
 	Args: cobra.MinimumNArgs(1),
 }
+var RolesListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available roles",
+	Example: `  $ mmctl roles list
+  $ mmctl roles list --json`,
+	RunE: withClient(rolesListCmdF),
+	Args: cobra.NoArgs,
+}
 
 func init() {
 	RolesCmd.AddCommand(
 		RolesSystemAdminCmd,
 		RolesMemberCmd,
+		RolesListCmd,
 	)
 
 	RootCmd.AddCommand(RolesCmd)
+}
+
+func rolesListCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	roles, _, err := c.GetAllRoles(context.TODO())
+	if err != nil {
+		return fmt.Errorf("failed to get roles: %w", err)
+	}
+
+	for _, role := range roles {
+		printer.PrintT("{{.Name}}", role)
+	}
+
+	return nil
 }
 
 func rolesSystemAdminCmdF(c client.Client, _ *cobra.Command, args []string) error {

--- a/server/cmd/mmctl/commands/roles_list_e2e_test.go
+++ b/server/cmd/mmctl/commands/roles_list_e2e_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/client"
+	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/printer"
+)
+
+func (s *MmctlE2ETestSuite) TestRolesListCmd() {
+	s.SetupTestHelper().InitBasic(s.T())
+
+	s.RunForSystemAdminAndLocal("List all available roles", func(c client.Client) {
+		printer.Clean()
+
+		err := rolesListCmdF(c, &cobra.Command{}, []string{})
+		s.Require().Nil(err)
+
+		lines := printer.GetLines()
+		s.Require().NotEmpty(lines, "Should return at least one role")
+
+		// Verify all returned items are valid Role objects with names
+		for i, line := range lines {
+			role, ok := line.(*model.Role)
+			s.Require().True(ok, "Line %d should be a *model.Role object", i)
+			s.Require().NotEmpty(role.Name, "Role %d should have a non-empty name", i)
+		}
+
+		s.Len(printer.GetErrorLines(), 0, "Should not have any error output")
+	})
+
+	s.Run("List roles without permissions should fail", func() {
+		printer.Clean()
+
+		err := rolesListCmdF(s.th.Client, &cobra.Command{}, []string{})
+
+		s.Require().Error(err)
+		s.Require().Contains(err.Error(), "failed to get roles")
+	})
+}

--- a/server/cmd/mmctl/commands/roles_list_test.go
+++ b/server/cmd/mmctl/commands/roles_list_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/spf13/viper"
+
+	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/printer"
+)
+
+func (s *MmctlUnitTestSuite) TestRolesListPlain() {
+	s.Run("Prints all role names", func() {
+		printer.Clean()
+
+		roles := []*model.Role{
+			{Id: "r1", Name: "system_admin"},
+			{Id: "r2", Name: "system_user"},
+		}
+
+		s.client.
+			EXPECT().
+			GetAllRoles(context.TODO()).
+			Return(roles, &model.Response{StatusCode: http.StatusOK}, nil).
+			Times(1)
+
+		err := rolesListCmdF(s.client, nil, nil)
+		s.Require().NoError(err)
+
+		lines := printer.GetLines()
+		s.Require().NotEmpty(lines)
+	})
+}
+
+func (s *MmctlUnitTestSuite) TestRolesListJSON() {
+	s.Run("prints JSON list of all role objects", func() {
+		printer.Clean()
+
+		roles := []*model.Role{
+			{Id: "r1", Name: "system_admin"},
+			{Id: "r2", Name: "system_user"},
+		}
+
+		s.client.
+			EXPECT().
+			GetAllRoles(context.TODO()).
+			Return(roles, &model.Response{StatusCode: http.StatusOK}, nil).
+			Times(1)
+
+		viper.Set("json", true)
+		defer viper.Set("json", false)
+
+		err := rolesListCmdF(s.client, nil, nil)
+		s.Require().NoError(err)
+
+		lines := printer.GetLines()
+		s.Require().NotEmpty(lines)
+
+		_, jerr := json.Marshal(lines)
+		s.Require().NoError(jerr)
+	})
+}
+
+func (s *MmctlUnitTestSuite) TestRolesListPermissionError() {
+	s.Run("Test permission denied message for getting roles", func() {
+		printer.Clean()
+
+		forbiddenErr := fmt.Errorf("forbidden")
+		s.client.
+			EXPECT().
+			GetAllRoles(context.TODO()).
+			Return(nil, &model.Response{StatusCode: http.StatusForbidden}, forbiddenErr).
+			Times(1)
+
+		err := rolesListCmdF(s.client, nil, nil)
+
+		s.Require().Error(err)
+		s.Require().Contains(err.Error(), "failed to get roles")
+	})
+}

--- a/server/cmd/mmctl/mocks/client_mock.go
+++ b/server/cmd/mmctl/mocks/client_mock.go
@@ -1372,6 +1372,22 @@ func (mr *MockClientMockRecorder) GetRoleByName(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRoleByName", reflect.TypeOf((*MockClient)(nil).GetRoleByName), arg0, arg1)
 }
 
+// GetAllRoles mocks base method.
+func (m *MockClient) GetAllRoles(arg0 context.Context) ([]*model.Role, *model.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllRoles", arg0)
+	ret0, _ := ret[0].([]*model.Role)
+	ret1, _ := ret[1].(*model.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetAllRoles indicates an expected call of GetAllRoles.
+func (mr *MockClientMockRecorder) GetAllRoles(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllRoles", reflect.TypeOf((*MockClient)(nil).GetAllRoles), arg0)
+}
+
 // GetServerBusy mocks base method.
 func (m *MockClient) GetServerBusy(arg0 context.Context) (*model.ServerBusyState, *model.Response, error) {
 	m.ctrl.T.Helper()

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -2597,6 +2597,10 @@
     "translation": "invalid_request: Bad request."
   },
   {
+    "id": "api.oauth.get_access_token.client_id_mismatch.app_error",
+    "translation": "invalid_grant: Token grant was not issued to this client."
+  },
+  {
     "id": "api.oauth.get_access_token.credentials.app_error",
     "translation": "invalid_client: Invalid client credentials."
   },

--- a/server/i18n/ko.json
+++ b/server/i18n/ko.json
@@ -2429,6 +2429,10 @@
     "translation": "invalid_request: 잘못된 요청입니다."
   },
   {
+    "id": "api.oauth.get_access_token.client_id_mismatch.app_error",
+    "translation": "invalid_grant: 이 클라이언트에 발급된 토큰이 아닙니다."
+  },
+  {
     "id": "api.oauth.get_access_token.credentials.app_error",
     "translation": "invalid_client: 잘못된 클라이언트 인증 정보입니다."
   },

--- a/server/public/model/scheduled_post.go
+++ b/server/public/model/scheduled_post.go
@@ -84,7 +84,7 @@ func (s *ScheduledPost) PreUpdate() {
 	s.Draft.PreCommit()
 }
 
-// ToPost converts a scheduled post toa  regular, mattermost post object.
+// ToPost converts a scheduled post to a regular, mattermost post object.
 func (s *ScheduledPost) ToPost() (*Post, error) {
 	post := &Post{
 		UserId:    s.UserId,

--- a/server/public/model/scheduled_post_test.go
+++ b/server/public/model/scheduled_post_test.go
@@ -1,0 +1,643 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScheduledPostBaseIsValid(t *testing.T) {
+	t.Run("missing id", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis(),
+				UpdateAt:  GetMillis(),
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   "test",
+			},
+			ScheduledAt: GetMillis() + 100000,
+		}
+		err := s.BaseIsValid()
+		require.NotNil(t, err)
+		assert.Equal(t, "model.scheduled_post.is_valid.id.app_error", err.Id)
+	})
+
+	t.Run("empty message and no file ids", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis(),
+				UpdateAt:  GetMillis(),
+				UserId:    NewId(),
+				ChannelId: NewId(),
+			},
+			Id:          NewId(),
+			ScheduledAt: GetMillis() + 100000,
+		}
+		err := s.BaseIsValid()
+		require.NotNil(t, err)
+		assert.Equal(t, "model.scheduled_post.is_valid.empty_post.app_error", err.Id)
+	})
+
+	t.Run("scheduled_at in the past", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis(),
+				UpdateAt:  GetMillis(),
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   "test",
+			},
+			Id:          NewId(),
+			ScheduledAt: GetMillis() - 10000,
+		}
+		err := s.BaseIsValid()
+		require.NotNil(t, err)
+		assert.Equal(t, "model.scheduled_post.is_valid.scheduled_at.app_error", err.Id)
+	})
+
+	t.Run("negative processed_at", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis(),
+				UpdateAt:  GetMillis(),
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   "test",
+			},
+			Id:          NewId(),
+			ScheduledAt: GetMillis() + 100000,
+			ProcessedAt: -1,
+		}
+		err := s.BaseIsValid()
+		require.NotNil(t, err)
+		assert.Equal(t, "model.scheduled_post.is_valid.processed_at.app_error", err.Id)
+	})
+
+	t.Run("valid with message", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis(),
+				UpdateAt:  GetMillis(),
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   "test",
+			},
+			Id:          NewId(),
+			ScheduledAt: GetMillis() + 100000,
+		}
+		err := s.BaseIsValid()
+		require.Nil(t, err)
+	})
+
+	t.Run("valid with file ids and no message", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis(),
+				UpdateAt:  GetMillis(),
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				FileIds:   StringArray{NewId()},
+			},
+			Id:          NewId(),
+			ScheduledAt: GetMillis() + 100000,
+		}
+		err := s.BaseIsValid()
+		require.Nil(t, err)
+	})
+
+	t.Run("draft base validation fails with missing update_at", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis(),
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   "test",
+			},
+			Id:          NewId(),
+			ScheduledAt: GetMillis() + 100000,
+		}
+		err := s.BaseIsValid()
+		require.NotNil(t, err)
+		assert.Equal(t, "model.draft.is_valid.update_at.app_error", err.Id)
+	})
+
+	t.Run("draft base validation fails with invalid user_id", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis(),
+				UpdateAt:  GetMillis(),
+				UserId:    "invalid",
+				ChannelId: NewId(),
+				Message:   "test",
+			},
+			Id:          NewId(),
+			ScheduledAt: GetMillis() + 100000,
+		}
+		err := s.BaseIsValid()
+		require.NotNil(t, err)
+		assert.Equal(t, "model.draft.is_valid.user_id.app_error", err.Id)
+	})
+
+	t.Run("draft base validation fails with invalid channel_id", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis(),
+				UpdateAt:  GetMillis(),
+				UserId:    NewId(),
+				ChannelId: "invalid",
+				Message:   "test",
+			},
+			Id:          NewId(),
+			ScheduledAt: GetMillis() + 100000,
+		}
+		err := s.BaseIsValid()
+		require.NotNil(t, err)
+		assert.Equal(t, "model.draft.is_valid.channel_id.app_error", err.Id)
+	})
+
+	t.Run("draft base validation fails with missing create_at", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   "test",
+			},
+			Id:          NewId(),
+			ScheduledAt: GetMillis() + 100000,
+		}
+		err := s.BaseIsValid()
+		require.NotNil(t, err)
+		assert.Equal(t, "model.draft.is_valid.create_at.app_error", err.Id)
+	})
+}
+
+func TestScheduledPostIsValid(t *testing.T) {
+	maxMessageSize := 10000
+
+	t.Run("draft validation fails for message too long", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis(),
+				UpdateAt:  GetMillis(),
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   strings.Repeat("a", maxMessageSize+1),
+			},
+			Id:          NewId(),
+			ScheduledAt: GetMillis() + 100000,
+		}
+		err := s.IsValid(maxMessageSize)
+		require.NotNil(t, err)
+		assert.Equal(t, "model.draft.is_valid.message_length.app_error", err.Id)
+	})
+
+	t.Run("base validation fails for missing id", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis(),
+				UpdateAt:  GetMillis(),
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   "test",
+			},
+			ScheduledAt: GetMillis() + 100000,
+		}
+		err := s.IsValid(maxMessageSize)
+		require.NotNil(t, err)
+		assert.Equal(t, "model.scheduled_post.is_valid.id.app_error", err.Id)
+	})
+
+	t.Run("valid scheduled post", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis(),
+				UpdateAt:  GetMillis(),
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   "test",
+			},
+			Id:          NewId(),
+			ScheduledAt: GetMillis() + 100000,
+		}
+		err := s.IsValid(maxMessageSize)
+		require.Nil(t, err)
+	})
+}
+
+func TestScheduledPostPreSave(t *testing.T) {
+	t.Run("generates id when empty", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				Message: "test",
+			},
+		}
+		s.PreSave()
+		assert.NotEmpty(t, s.Id)
+		assert.True(t, IsValidId(s.Id))
+	})
+
+	t.Run("preserves existing id", func(t *testing.T) {
+		existingId := NewId()
+		s := ScheduledPost{
+			Draft: Draft{
+				Message: "test",
+			},
+			Id: existingId,
+		}
+		s.PreSave()
+		assert.Equal(t, existingId, s.Id)
+	})
+
+	t.Run("resets processed_at and error_code", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				Message: "test",
+			},
+			ProcessedAt: GetMillis(),
+			ErrorCode:   ScheduledPostErrorUnknownError,
+		}
+		s.PreSave()
+		assert.Equal(t, int64(0), s.ProcessedAt)
+		assert.Empty(t, s.ErrorCode)
+	})
+
+	t.Run("calls draft pre save", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				Message: "test",
+			},
+		}
+		s.PreSave()
+		assert.NotEqual(t, int64(0), s.CreateAt)
+		assert.NotEqual(t, int64(0), s.UpdateAt)
+		assert.NotNil(t, s.GetProps())
+		assert.NotNil(t, s.FileIds)
+	})
+}
+
+func TestScheduledPostPreUpdate(t *testing.T) {
+	t.Run("sets update_at to current time", func(t *testing.T) {
+		createAt := GetMillis() - 10000
+		s := ScheduledPost{
+			Draft: Draft{
+				Message:  "test",
+				CreateAt: createAt,
+			},
+		}
+		before := GetMillis()
+		s.PreUpdate()
+
+		assert.GreaterOrEqual(t, s.UpdateAt, before)
+		assert.Equal(t, createAt, s.CreateAt)
+	})
+
+	t.Run("initializes props and file ids via PreCommit", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				Message: "test",
+			},
+		}
+		s.PreUpdate()
+
+		assert.NotNil(t, s.GetProps())
+		assert.NotNil(t, s.FileIds)
+	})
+}
+
+func TestScheduledPostToPost(t *testing.T) {
+	t.Run("without priority", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   "hello",
+				FileIds:   StringArray{NewId()},
+				RootId:    NewId(),
+				Type:      "custom_type",
+			},
+			Id: NewId(),
+		}
+		s.SetProps(StringInterface{"key": "value"})
+
+		post, err := s.ToPost()
+		require.NoError(t, err)
+		assert.Equal(t, s.UserId, post.UserId)
+		assert.Equal(t, s.ChannelId, post.ChannelId)
+		assert.Equal(t, s.Message, post.Message)
+		assert.Equal(t, s.FileIds, post.FileIds)
+		assert.Equal(t, s.RootId, post.RootId)
+		assert.Equal(t, s.Type, post.Type)
+		assert.Equal(t, "value", post.GetProp("key"))
+		assert.Nil(t, post.Metadata)
+	})
+
+	t.Run("with metadata but no priority preserves metadata", func(t *testing.T) {
+		embeds := []*PostEmbed{{Type: PostEmbedImage, URL: "http://example.com/img.png"}}
+		s := ScheduledPost{
+			Draft: Draft{
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   "test",
+				Metadata:  &PostMetadata{Embeds: embeds},
+			},
+			Id: NewId(),
+		}
+
+		post, err := s.ToPost()
+		require.NoError(t, err)
+		require.NotNil(t, post.Metadata)
+		assert.Nil(t, post.Metadata.Priority)
+		assert.Equal(t, embeds, post.Metadata.Embeds)
+	})
+
+	t.Run("with valid priority", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   "urgent",
+				Priority: StringInterface{
+					"priority":                 "urgent",
+					"requested_ack":            true,
+					"persistent_notifications": false,
+				},
+			},
+			Id: NewId(),
+		}
+
+		post, err := s.ToPost()
+		require.NoError(t, err)
+		require.NotNil(t, post.Metadata)
+		require.NotNil(t, post.Metadata.Priority)
+		require.NotNil(t, post.Metadata.Priority.Priority)
+		require.NotNil(t, post.Metadata.Priority.RequestedAck)
+		require.NotNil(t, post.Metadata.Priority.PersistentNotifications)
+		assert.Equal(t, "urgent", *post.Metadata.Priority.Priority)
+		assert.True(t, *post.Metadata.Priority.RequestedAck)
+		assert.False(t, *post.Metadata.Priority.PersistentNotifications)
+	})
+
+	t.Run("with valid priority and existing metadata", func(t *testing.T) {
+		embeds := []*PostEmbed{{Type: PostEmbedLink, URL: "http://example.com"}}
+		s := ScheduledPost{
+			Draft: Draft{
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   "test",
+				Metadata:  &PostMetadata{Embeds: embeds},
+				Priority: StringInterface{
+					"priority":                 "important",
+					"requested_ack":            false,
+					"persistent_notifications": false,
+				},
+			},
+			Id: NewId(),
+		}
+
+		post, err := s.ToPost()
+		require.NoError(t, err)
+		require.NotNil(t, post.Metadata)
+		require.NotNil(t, post.Metadata.Priority)
+		require.NotNil(t, post.Metadata.Priority.Priority)
+		assert.Equal(t, "important", *post.Metadata.Priority.Priority)
+		assert.Equal(t, embeds, post.Metadata.Embeds)
+	})
+
+	t.Run("error when priority is not a string", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   "test",
+				Priority: StringInterface{
+					"priority":                 123,
+					"requested_ack":            true,
+					"persistent_notifications": false,
+				},
+			},
+			Id: NewId(),
+		}
+
+		post, err := s.ToPost()
+		require.Nil(t, post)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "priority is not a string")
+	})
+
+	t.Run("error when requested_ack is not a bool", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   "test",
+				Priority: StringInterface{
+					"priority":                 "urgent",
+					"requested_ack":            "yes",
+					"persistent_notifications": false,
+				},
+			},
+			Id: NewId(),
+		}
+
+		post, err := s.ToPost()
+		require.Nil(t, post)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requested_ack is not a bool")
+	})
+
+	t.Run("error when persistent_notifications is not a bool", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Message:   "test",
+				Priority: StringInterface{
+					"priority":                 "urgent",
+					"requested_ack":            true,
+					"persistent_notifications": "no",
+				},
+			},
+			Id: NewId(),
+		}
+
+		post, err := s.ToPost()
+		require.Nil(t, post)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "persistent_notifications is not a bool")
+	})
+}
+
+func TestScheduledPostAuditable(t *testing.T) {
+	t.Run("with nil metadata", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis(),
+				UpdateAt:  GetMillis(),
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				RootId:    NewId(),
+				FileIds:   StringArray{NewId()},
+			},
+			Id: NewId(),
+		}
+
+		result := s.Auditable()
+		assert.Equal(t, s.Id, result["id"])
+		assert.Equal(t, s.CreateAt, result["create_at"])
+		assert.Equal(t, s.UpdateAt, result["update_at"])
+		assert.Equal(t, s.UserId, result["user_id"])
+		assert.Equal(t, s.ChannelId, result["channel_id"])
+		assert.Equal(t, s.RootId, result["root_id"])
+		assert.Equal(t, s.FileIds, result["file_ids"])
+		assert.Nil(t, result["metadata"])
+	})
+
+	t.Run("with non-nil metadata", func(t *testing.T) {
+		metadata := &PostMetadata{
+			Emojis: []*Emoji{{Name: "smile"}},
+		}
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis(),
+				UpdateAt:  GetMillis(),
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				Metadata:  metadata,
+			},
+			Id: NewId(),
+		}
+
+		result := s.Auditable()
+		assert.Equal(t, metadata.Auditable(), result["metadata"])
+	})
+}
+
+func TestScheduledPostRestoreNonUpdatableFields(t *testing.T) {
+	t.Run("restores non-updatable fields from original", func(t *testing.T) {
+		original := &ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis() - 50000,
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				RootId:    NewId(),
+				Type:      "custom_type",
+			},
+			Id: NewId(),
+		}
+
+		scheduledAt := GetMillis() + 100000
+		updated := &ScheduledPost{
+			Draft: Draft{
+				CreateAt:  GetMillis(),
+				UserId:    NewId(),
+				ChannelId: NewId(),
+				RootId:    NewId(),
+				Message:   "updated message",
+				Type:      "different_type",
+			},
+			Id:          NewId(),
+			ScheduledAt: scheduledAt,
+		}
+
+		updated.RestoreNonUpdatableFields(original)
+
+		assert.Equal(t, original.Id, updated.Id)
+		assert.Equal(t, original.CreateAt, updated.CreateAt)
+		assert.Equal(t, original.UserId, updated.UserId)
+		assert.Equal(t, original.ChannelId, updated.ChannelId)
+		assert.Equal(t, original.RootId, updated.RootId)
+		assert.Equal(t, original.Type, updated.Type)
+		// Updatable fields should remain changed
+		assert.Equal(t, "updated message", updated.Message)
+		assert.Equal(t, scheduledAt, updated.ScheduledAt)
+	})
+}
+
+func TestScheduledPostSanitizeInput(t *testing.T) {
+	t.Run("zeros create_at", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt: GetMillis(),
+				Message:  "test",
+			},
+		}
+		s.SanitizeInput()
+		assert.Equal(t, int64(0), s.CreateAt)
+	})
+
+	t.Run("clears metadata embeds", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt: GetMillis(),
+				Message:  "test",
+				Metadata: &PostMetadata{
+					Embeds: []*PostEmbed{
+						{Type: PostEmbedImage, URL: "http://example.com/image.png"},
+					},
+				},
+			},
+		}
+		s.SanitizeInput()
+		assert.Nil(t, s.Metadata.Embeds)
+	})
+
+	t.Run("nil metadata is safe", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				CreateAt: GetMillis(),
+				Message:  "test",
+			},
+		}
+		assert.NotPanics(t, func() {
+			s.SanitizeInput()
+		})
+	})
+}
+
+func TestScheduledPostGetPriority(t *testing.T) {
+	t.Run("nil metadata returns nil", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				Message: "test",
+			},
+		}
+		assert.Nil(t, s.GetPriority())
+	})
+
+	t.Run("metadata without priority returns nil", func(t *testing.T) {
+		s := ScheduledPost{
+			Draft: Draft{
+				Message:  "test",
+				Metadata: &PostMetadata{},
+			},
+		}
+		assert.Nil(t, s.GetPriority())
+	})
+
+	t.Run("metadata with priority returns priority", func(t *testing.T) {
+		priority := &PostPriority{
+			Priority:     NewPointer("urgent"),
+			RequestedAck: NewPointer(true),
+		}
+		s := ScheduledPost{
+			Draft: Draft{
+				Message: "test",
+				Metadata: &PostMetadata{
+					Priority: priority,
+				},
+			},
+		}
+		result := s.GetPriority()
+		require.NotNil(t, result)
+		require.NotNil(t, result.Priority)
+		require.NotNil(t, result.RequestedAck)
+		assert.Equal(t, "urgent", *result.Priority)
+		assert.True(t, *result.RequestedAck)
+	})
+}

--- a/webapp/channels/src/components/about_build_modal/about_build_modal.test.tsx
+++ b/webapp/channels/src/components/about_build_modal/about_build_modal.test.tsx
@@ -126,7 +126,7 @@ describe('components/AboutBuildModal', () => {
         );
 
         expect(screen.getByText('Mattermost Cloud')).toBeInTheDocument();
-        expect(screen.getByText('High trust messaging for the enterprise')).toBeInTheDocument();
+        expect(screen.getByText('High-trust messaging for the enterprise')).toBeInTheDocument();
         expect(screen.getByTestId('aboutModalVersion')).toHaveTextContent('Mattermost Version: 3.6.0');
         expect(screen.getByText('0123456789abcdef', {exact: false})).toBeInTheDocument();
         expect(screen.getByRole('link', {name: 'server'})).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-server/blob/master/NOTICE.txt');

--- a/webapp/channels/src/components/about_build_modal/about_build_modal_cloud/about_build_modal_cloud.tsx
+++ b/webapp/channels/src/components/about_build_modal/about_build_modal_cloud/about_build_modal_cloud.tsx
@@ -43,7 +43,7 @@ export default function AboutBuildModalCloud(props: Props) {
     const subTitle = (
         <FormattedMessage
             id='about.enterpriseEditionSst'
-            defaultMessage='High trust messaging for the enterprise'
+            defaultMessage='High-trust messaging for the enterprise'
         />
     );
 

--- a/webapp/channels/src/components/admin_console/feature_flags.tsx
+++ b/webapp/channels/src/components/admin_console/feature_flags.tsx
@@ -30,12 +30,12 @@ const FeatureFlags: React.FC<Props> = (props: Props) => {
     }
 
     return (
-        <div className='wrapper--admin'>
+        <div className='wrapper--fixed'>
             <AdminHeader>
                 <FormattedMessage {...messages.title}/>
             </AdminHeader>
             <div className='admin-console__wrapper'>
-                <div className='admin-logs-content admin-console__content'>
+                <div className='admin-console__content'>
                     <div className={'banner info'}>
                         <div className='banner__content'>
                             <FormattedMessage
@@ -45,7 +45,7 @@ const FeatureFlags: React.FC<Props> = (props: Props) => {
                         </div>
                     </div>
                     <div className='job-table__panel'>
-                        <div className='job-table__table'>
+                        <div className='job-table__table job-table__table--full-height'>
                             <table
                                 className='table'
                             >

--- a/webapp/channels/src/components/admin_console/server_logs/__snapshots__/logs.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/server_logs/__snapshots__/logs.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`components/admin_console/server_logs/Logs should display the logs correctly after loading 1`] = `
 <div>
   <div
-    class="wrapper--admin"
+    class="wrapper--fixed"
   >
     <div
       class="admin-console__header"

--- a/webapp/channels/src/components/admin_console/server_logs/log_list.scss
+++ b/webapp/channels/src/components/admin_console/server_logs/log_list.scss
@@ -1,5 +1,5 @@
 .LogTable {
-    overflow: auto;
+    overflow: hidden;
 
     .DataGrid {
         .DataGrid_row {

--- a/webapp/channels/src/components/admin_console/server_logs/logs.tsx
+++ b/webapp/channels/src/components/admin_console/server_logs/logs.tsx
@@ -217,7 +217,7 @@ export default class Logs extends React.PureComponent<Props, State> {
         }
 
         return (
-            <div className='wrapper--admin'>
+            <div className='wrapper--fixed'>
                 <AdminHeader>
                     <FormattedMessage {...messages.title}/>
                 </AdminHeader>

--- a/webapp/channels/src/components/admin_console/server_logs/plain_log_list.tsx
+++ b/webapp/channels/src/components/admin_console/server_logs/plain_log_list.tsx
@@ -138,7 +138,7 @@ class PlainLogList extends React.PureComponent<Props, State> {
             );
         }
         return (
-            <div>
+            <div className='plain-log-list'>
                 <div
                     tabIndex={-1}
                     ref={this.logPanel}

--- a/webapp/channels/src/components/post_view/post_list_virtualized/post_list_virtualized.test.tsx
+++ b/webapp/channels/src/components/post_view/post_list_virtualized/post_list_virtualized.test.tsx
@@ -336,13 +336,13 @@ describe('PostList', () => {
                 expected: false,
             },
             {
-                name: 'when 11 pixel from the bottom',
-                scrollOffset: 489,
+                name: 'when 101 pixel from the bottom',
+                scrollOffset: 399,
                 expected: false,
             },
             {
-                name: 'when 9 pixel from the bottom also considered to be bottom',
-                scrollOffset: 490,
+                name: 'when 100 pixel from the bottom also considered to be bottom',
+                scrollOffset: 400,
                 expected: true,
             },
             {

--- a/webapp/channels/src/components/post_view/post_list_virtualized/post_list_virtualized.tsx
+++ b/webapp/channels/src/components/post_view/post_list_virtualized/post_list_virtualized.tsx
@@ -31,7 +31,7 @@ import LatestPostReader from './latest_post_reader';
 const OVERSCAN_COUNT_BACKWARD = 80;
 const OVERSCAN_COUNT_FORWARD = 80;
 const HEIGHT_TRIGGER_FOR_MORE_POSTS = 1000;
-const BUFFER_TO_BE_CONSIDERED_BOTTOM = 10;
+const BUFFER_TO_BE_CONSIDERED_BOTTOM = 100;
 
 const MAXIMUM_POSTS_FOR_SLICING = {
     channel: 50,

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -8,7 +8,7 @@
   "about.desktopVersion": "Desktop Version:",
   "about.enterpriseEditionLearn": "Learn more about Mattermost {planName} at ",
   "about.enterpriseEditionLearnUnlicensed": "Learn more about Enterprise Edition at ",
-  "about.enterpriseEditionSst": "High trust messaging for the enterprise",
+  "about.enterpriseEditionSst": "High-trust messaging for the enterprise",
   "about.enterpriseEditionSt": "Modern communication from behind your firewall.",
   "about.hash": "Build Hash:",
   "about.hashee": "EE Build Hash:",

--- a/webapp/channels/src/sass/routes/_admin-console.scss
+++ b/webapp/channels/src/sass/routes/_admin-console.scss
@@ -37,13 +37,6 @@
         flex: 1 1 auto;
         padding: 20px;
 
-        > .wrapper--admin {
-            display: flex;
-            overflow: auto;
-            height: 100%;
-            flex-direction: column;
-        }
-
         .admin-console__filters-rows {
             display: flex;
             flex-wrap: wrap;
@@ -196,7 +189,8 @@
     .log__panel {
         overflow: scroll;
         width: 100%;
-        height: calc(100vh - 280px);
+        min-height: 0;
+        flex: 1;
         padding: 10px;
         border: variables.$border-gray;
         margin-top: 14px;
@@ -610,6 +604,10 @@
     border: variables.$border-gray;
     margin: 20px 0 10px;
     background-color: variables.$white;
+
+    &--full-height {
+        max-height: none;
+    }
 }
 
 .admin-console__disabled-text {
@@ -1112,6 +1110,7 @@
 
 .admin-console .admin-console__content.admin-logs-content {
     display: flex;
+    overflow: hidden;
     max-width: none;
     height: 100%;
     flex-direction: column;
@@ -1148,7 +1147,8 @@
     }
 
     .LogTable {
-        height: 100%;
+        min-height: 0;
+        flex: 1;
 
         .DataGrid {
             display: flex;
@@ -1157,10 +1157,17 @@
 
             .DataGrid_rows {
                 overflow: auto;
-                height: 100%;
-                min-height: 100% !important;
+                min-height: 0 !important;
+                flex: 1;
             }
         }
+    }
+
+    .plain-log-list {
+        display: flex;
+        min-height: 0;
+        flex: 1;
+        flex-direction: column;
     }
 }
 

--- a/webapp/channels/src/utils/post_utils.ts
+++ b/webapp/channels/src/utils/post_utils.ts
@@ -87,6 +87,11 @@ export function getImageSrc(src: string, hasImageProxy = false): string {
         return src;
     }
 
+    // Don't proxy base64-encoded images
+    if (src.startsWith('data:image/')) {
+        return src;
+    }
+
     const imageAPI = Client4.getBaseRoute() + '/image?url=';
 
     if (hasImageProxy && !src.startsWith(imageAPI)) {


### PR DESCRIPTION
- [MM-67886] Remove height cap on Feature Flags table in System Console (#35556)
- [MM-29973] Adds E2E tests for `mmctl plugin disable` (#35464)
- mmctl: Add support for listing user roles through mmctl (#34064)
- MM-55536 Support Inline image when image proxy is enabled (#31020)
- Hyphenation (#30373)
- Fix import failures for Japanese filenames with dakuten on macOS (#35204)
- Run i18n-extract (#35675)
- Add unit tests for ScheduledPost model (#35565)
- oauth check (#35553)
- MM-67518 Increase amount that the post list is considered to be at the bottom (#35680)
- docs: upstream sync 진행 (picked 9, adapted 1)
- i18n(ko): OAuth client_id_mismatch 에러 메시지 번역 추가