### PR TITLE
upstream sync 2026-03-20 (picked 5)

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -17,6 +17,9 @@ on:
       - ".github/workflows/mmctl-test-template.yml"
       - "!server/build/Dockerfile.buildenv"
       - "!server/build/Dockerfile.buildenv-fips"
+      - "!server/**/*.md"
+      - "!server/NOTICE.txt"
+      - "!server/CHANGELOG.md"
 
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || github.run_id }}

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -77,8 +77,6 @@ jobs:
     defaults:
       run:
         working-directory: server
-    env:
-      GOFLAGS: -buildvcs=false # TODO: work around "error obtaining VCS status: exit status 128" in a container
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -275,7 +273,6 @@ jobs:
       run:
         working-directory: server
     env:
-      GOFLAGS: -buildvcs=false # TODO: work around "error obtaining VCS status: exit status 128" in a container
       BUILD_NUMBER: "${GITHUB_HEAD_REF}-${GITHUB_RUN_ID}"
       FIPS_ENABLED: false
     steps:

--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,19 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-12 16:05
+- 갱신일: 2026-08-12 16:32
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 920개
+- 남은 커밋: 915개
 
-**마지막 반영 커밋:** `d5fdc1f5` | [chore(i18n): add i18n-verify-translations script (#34917)](https://github.com/mattermost/mattermost/commit/d5fdc1f534ff01301a998116d14211901d9f9a80) | 2026-03-19
+**마지막 반영 커밋:** `5f8c77a3` | [MM-67953 Changed sorting of channels in some places to prioritize display name matches (#35679)](https://github.com/mattermost/mattermost/commit/5f8c77a3efcc31260cde2d8e800577a2c4a18d68) | 2026-03-20
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 5af5b6df | [\[MM-67744\] Add -buildvcs=false to default GOFLAGS (#35587)](https://github.com/mattermost/mattermost/commit/5af5b6dfacd71a2ffbb8d5636f9f41af2b19d3bb) | 2026-03-20 |
-| 8740152d | [MM-66944 Change PlatformService.IsLeader to always be true when license doesn't support clustering (#35577)](https://github.com/mattermost/mattermost/commit/8740152df7d95d88ce2079a1647819ad2621e65b) | 2026-03-20 |
-| a357d4f0 | [ci: skip server CI for docs-only changes (#35719)](https://github.com/mattermost/mattermost/commit/a357d4f024408b4726dd47e8a690a73669088632) | 2026-03-20 |
-| 4c25d03f | [Automate setup-go-work as a dependency for Make targets (#35476)](https://github.com/mattermost/mattermost/commit/4c25d03f67d851bb438e9585035267ba4e9815cf) | 2026-03-20 |
-| 5f8c77a3 | [MM-67953 Changed sorting of channels in some places to prioritize display name matches (#35679)](https://github.com/mattermost/mattermost/commit/5f8c77a3efcc31260cde2d8e800577a2c4a18d68) | 2026-03-20 |
 | e6b8e12f | [SEC-9862: Add CI check for test analysis (#35555)](https://github.com/mattermost/mattermost/commit/e6b8e12fb94e8d4ef45b3f0d765c00f8f7087fe7) | 2026-03-22 |
 | b4163449 | [ci: cache prepackaged plugins in mmctl tests (#35720)](https://github.com/mattermost/mattermost/commit/b4163449319c422f462a845294808084d0c6b332) | 2026-03-22 |
 | ae1691a3 | [fix(pr-analysis): on large diff and reduce gh pr calls (#35734)](https://github.com/mattermost/mattermost/commit/ae1691a3685d7ff4817593adab7741b4ce884784) | 2026-03-23 |

--- a/e2e-tests/playwright/lib/src/ui/components/channels/browse_channels_modal.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/browse_channels_modal.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Locator, expect} from '@playwright/test';
+
+export default class BrowseChannelsModal {
+    readonly container: Locator;
+
+    readonly createNewChannelButton: Locator;
+    readonly hideJoinedCheckbox: Locator;
+    readonly searchInput: Locator;
+
+    readonly results: Locator;
+
+    constructor(container: Locator) {
+        this.container = container;
+
+        this.createNewChannelButton = container.getByRole('button', {name: 'Create New Channel'});
+        this.hideJoinedCheckbox = container.getByRole('checkbox', {name: 'Hide Joined'});
+        this.searchInput = container.getByRole('textbox', {name: 'Search channels'});
+
+        // This role seems incorrect and will likely need to be changed later
+        this.results = this.container.getByRole('search');
+    }
+
+    async toBeVisible() {
+        await expect(this.container).toBeVisible();
+    }
+
+    async toBeDoneLoading() {
+        await expect(this.container.locator('.loading-screen')).toHaveCount(0);
+    }
+
+    async toHaveNResults(count: number) {
+        await expect(this.results.locator('.more-modal__row')).toHaveCount(count);
+    }
+
+    async fillSearchInput(text: string) {
+        await this.searchInput.fill(text);
+    }
+
+    async toHaveChannelAsNthResult(channelName: string, index: number) {
+        const row = this.results.locator('.more-modal__row').nth(index);
+
+        expect(await row.getAttribute('data-testid')).toEqual(`ChannelRow-${channelName}`);
+    }
+}

--- a/e2e-tests/playwright/lib/src/ui/components/index.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/index.ts
@@ -7,6 +7,7 @@ import GlobalHeader from './global_header';
 import MainHeader from './main_header';
 import UserAccountMenu from './user_account_menu';
 // Channels Components
+import BrowseChannelsModal from './channels/browse_channels_modal';
 import ChannelsAppBar from './channels/app_bar';
 import ChannelsCenterView from './channels/center_view';
 import CreateTeamForm from './channels/create_team_form';
@@ -88,6 +89,7 @@ const components = {
     FindChannelsModal,
     FlagPostConfirmationDialog,
     NewChannelModal,
+    BrowseChannelsModal,
     GenericConfirmModal,
     InvitePeopleModal,
     MembersInvitedModal,
@@ -158,6 +160,7 @@ export {
     FindChannelsModal,
     FlagPostConfirmationDialog,
     NewChannelModal,
+    BrowseChannelsModal,
     GenericConfirmModal,
     InvitePeopleModal,
     MembersInvitedModal,

--- a/e2e-tests/playwright/lib/src/ui/pages/channels.ts
+++ b/e2e-tests/playwright/lib/src/ui/pages/channels.ts
@@ -5,6 +5,7 @@ import {expect, Page} from '@playwright/test';
 import {waitUntil} from 'async-wait-until';
 
 import {
+    BrowseChannelsModal,
     ChannelsPost,
     ChannelSettingsModal,
     CreateTeamForm,
@@ -36,6 +37,7 @@ export default class ChannelsPage {
     readonly deletePostModal;
     readonly findChannelsModal;
     readonly newChannelModal;
+    readonly browseChannelsModal;
     public invitePeopleModal: InvitePeopleModal | undefined;
     public membersInvitedModal: MembersInvitedModal | undefined;
     readonly profileModal;
@@ -72,7 +74,8 @@ export default class ChannelsPage {
         this.createTeamForm = new CreateTeamForm(page.locator('.signup-team__container'));
         this.deletePostModal = new components.DeletePostModal(page.locator('#deletePostModal'));
         this.findChannelsModal = new components.FindChannelsModal(page.getByRole('dialog', {name: 'Find Channels'}));
-        this.newChannelModal = new NewChannelModal(page.locator('#new-channel-modal'));
+        this.newChannelModal = new NewChannelModal(page.getByRole('dialog', {name: 'Create a new channel'}));
+        this.browseChannelsModal = new BrowseChannelsModal(page.getByRole('dialog', {name: 'Browse Channels'}));
         this.profileModal = new components.ProfileModal(page.getByRole('dialog', {name: 'Profile'}));
         this.settingsModal = new components.SettingsModal(page.getByRole('dialog', {name: 'Settings'}));
         this.teamSettingsModal = new components.TeamSettingsModal(page.getByRole('dialog', {name: 'Team Settings'}));
@@ -208,10 +211,18 @@ export default class ChannelsPage {
 
     async openNewChannelModal(): Promise<NewChannelModal> {
         await this.sidebarLeft.browseOrCreateChannelButton.click();
-        await this.page.locator('#createNewChannelMenuItem').click();
+        await this.page.getByText('Create new channel').click();
         await this.newChannelModal.toBeVisible();
 
         return this.newChannelModal;
+    }
+
+    async openBrowseChannelsModal(): Promise<BrowseChannelsModal> {
+        await this.sidebarLeft.browseOrCreateChannelButton.click();
+        await this.page.getByText('Browse channels').click();
+        await this.browseChannelsModal.toBeVisible();
+
+        return this.browseChannelsModal;
     }
 
     async openCreateTeamForm(): Promise<CreateTeamForm> {

--- a/e2e-tests/playwright/specs/accessibility/channels/browse_channels_dialog.spec.ts
+++ b/e2e-tests/playwright/specs/accessibility/channels/browse_channels_dialog.spec.ts
@@ -40,32 +40,22 @@ test(
         await channelsPage.goto(team.name, 'town-square');
         await channelsPage.toBeVisible();
 
-        // # Click on Browse or Create Channel button and then Browse Channels
-        await channelsPage.sidebarLeft.browseOrCreateChannelButton.click();
-        const browseChannelsMenuItem = page.locator('#browseChannelsMenuItem');
-        await browseChannelsMenuItem.click();
-
-        // * Verify the Browse Channels dialog is visible
-        const dialog = page.getByRole('dialog', {name: 'Browse Channels'});
-        await expect(dialog).toBeVisible();
-
-        // * Verify the heading
-        await expect(dialog.getByRole('heading', {name: 'Browse Channels'})).toBeVisible();
+        // # Open the Browse Channels modal
+        const dialog = await channelsPage.openBrowseChannelsModal();
 
         // * Verify the search input exists
-        const searchInput = dialog.getByPlaceholder('Search channels');
+        const searchInput = dialog.searchInput;
         await expect(searchInput).toBeVisible();
 
         // # Wait for channel list to load
-        const channelList = dialog.locator('#moreChannelsList');
-        await expect(channelList).toBeVisible();
+        await dialog.toBeDoneLoading();
 
         // # Hide already joined channels
-        const hideJoinedCheckbox = dialog.getByText('Hide Joined');
+        const hideJoinedCheckbox = dialog.hideJoinedCheckbox;
         await hideJoinedCheckbox.click();
 
         // # Focus on Create Channel button and tab through elements
-        const createChannelButton = dialog.locator('#createNewChannelButton');
+        const createChannelButton = dialog.createNewChannelButton;
         await createChannelButton.focus();
         await page.keyboard.press('Tab');
         await page.keyboard.press('Tab');
@@ -74,8 +64,9 @@ test(
         await page.keyboard.press('Tab');
 
         // * Verify channel name is highlighted and has proper aria-label
+        await dialog.toHaveChannelAsNthResult(channel1.name, 0);
         const channel1AriaLabel = `${channel1.display_name.toLowerCase()}, ${channel1.purpose.toLowerCase()}`;
-        const channel1Item = dialog.getByLabel(channel1AriaLabel);
+        const channel1Item = dialog.container.getByLabel(channel1AriaLabel);
         await expect(channel1Item).toBeVisible();
         await expect(channel1Item).toBeFocused();
 
@@ -83,8 +74,9 @@ test(
         await page.keyboard.press('Tab');
 
         // * Verify focus moved to next channel
+        await dialog.toHaveChannelAsNthResult(channel2.name, 1);
         const channel2AriaLabel = `${channel2.display_name.toLowerCase()}, ${channel2.purpose.toLowerCase()}`;
-        const channel2Item = dialog.getByLabel(channel2AriaLabel);
+        const channel2Item = dialog.container.getByLabel(channel2AriaLabel);
         await expect(channel2Item).toBeFocused();
     },
 );
@@ -109,18 +101,11 @@ test(
         await channelsPage.goto(team.name, 'town-square');
         await channelsPage.toBeVisible();
 
-        // # Click on Browse or Create Channel button and then Browse Channels
-        await channelsPage.sidebarLeft.browseOrCreateChannelButton.click();
-        const browseChannelsMenuItem = page.locator('#browseChannelsMenuItem');
-        await browseChannelsMenuItem.click();
-
-        // * Verify the Browse Channels dialog is visible
-        const dialog = page.getByRole('dialog', {name: 'Browse Channels'});
-        await expect(dialog).toBeVisible();
-        await pw.wait(pw.duration.one_sec);
+        // # Open the Browse Channels modal
+        const dialog = await channelsPage.openBrowseChannelsModal();
 
         // * Verify aria snapshot of Browse Channels dialog
-        await expect(dialog).toMatchAriaSnapshot(`
+        await expect(dialog.container).toMatchAriaSnapshot(`
             - dialog "Browse Channels":
               - document:
                 - heading "Browse Channels" [level=1]

--- a/e2e-tests/playwright/specs/functional/channels/post_textbox/channel_autocomplete_sorting.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/post_textbox/channel_autocomplete_sorting.spec.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+/**
+ * @objective Verify that the "Other Channels" group in the ~channel autocomplete in the message input prioritizes
+ * channels whose DisplayName matches the search term.
+ */
+test(
+    'MM-67953 channel mention autocomplete prioritizes DisplayName matches in Other Channels',
+    {tag: ['@mentions']},
+    async ({pw}) => {
+        // # Initialize setup
+        const {team, user, adminClient} = await pw.initSetup();
+
+        // # Create channels whose DisplayName matches the search term (user is NOT a member)
+        await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-gamma-conversation-' + Date.now(),
+            display_name: 'Gamma: Conversation',
+            type: 'O',
+        });
+        await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-gamma-logs-' + Date.now(),
+            display_name: 'Gamma: Logs',
+            type: 'O',
+        });
+
+        // # Create channels whose Purpose matches but DisplayName does NOT (user is NOT a member)
+        await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-alpha-channel-' + Date.now(),
+            display_name: 'Alpha Channel',
+            type: 'O',
+            purpose: 'alpha release of gamma',
+        });
+        await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-beta-channel-' + Date.now(),
+            display_name: 'Beta Channel',
+            type: 'O',
+            purpose: 'beta release of gamma',
+        });
+
+        // # Log in as regular user
+        const {channelsPage} = await pw.testBrowser.login(user);
+
+        // # Visit town-square channel
+        await channelsPage.goto(team.name, 'town-square');
+        await channelsPage.toBeVisible();
+
+        // # Type a channel mention in the message input to trigger autocomplete
+        await channelsPage.centerView.postCreate.writeMessage('~gamma');
+
+        // # Wait for the suggestion list to appear
+        const suggestionList = channelsPage.centerView.postCreate.suggestionList;
+        await expect(suggestionList).toBeVisible();
+
+        // # Get all suggestion items within the "Other Channels" group
+        const otherChannelsGroup = suggestionList.getByRole('group', {name: 'Other Channels'});
+        await expect(otherChannelsGroup).toBeVisible();
+
+        const suggestions = otherChannelsGroup.getByRole('option');
+
+        // * Verify at least 4 suggestions are shown in "Other Channels"
+        await expect(suggestions).toHaveCount(4);
+
+        // * Verify DisplayName-matching channels appear first, sorted alphabetically
+        await expect(suggestions.nth(0)).toContainText('Gamma: Conversation');
+        await expect(suggestions.nth(1)).toContainText('Gamma: Logs');
+
+        // * Verify Purpose-only-matching channels appear after, sorted alphabetically by DisplayName
+        await expect(suggestions.nth(2)).toContainText('Alpha Channel');
+        await expect(suggestions.nth(3)).toContainText('Beta Channel');
+    },
+);

--- a/e2e-tests/playwright/specs/functional/channels/search/browse_channels_sorting.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/search/browse_channels_sorting.spec.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test} from '@mattermost/playwright-lib';
+
+/**
+ * @objective Verify that Browse Channels modal search results prioritize channels whose DisplayName matches the search
+ * term over channels that only match on other fields.
+ */
+test(
+    'MM-67953 Browse Channels modal prioritizes DisplayName matches in search results',
+    {tag: ['@browse_channels']},
+    async ({pw}) => {
+        // # Initialize setup
+        const {team, user, adminClient} = await pw.initSetup();
+
+        // # Create channels whose DisplayName matches the search term
+        const displayMatchA = await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-gamma-conversation-' + Date.now(),
+            display_name: 'Gamma: Conversation',
+            type: 'O',
+        });
+        const displayMatchB = await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-gamma-logs-' + Date.now(),
+            display_name: 'Gamma: Logs',
+            type: 'O',
+        });
+
+        // # Create channels whose Purpose matches but DisplayName does NOT
+        const purposeMatchA = await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-alpha-channel-' + Date.now(),
+            display_name: 'Alpha Channel',
+            type: 'O',
+            purpose: 'alpha release of gamma',
+        });
+        const purposeMatchB = await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-beta-channel-' + Date.now(),
+            display_name: 'Beta Channel',
+            type: 'O',
+            purpose: 'beta release of gamma',
+        });
+
+        // # Log in as regular user
+        const {channelsPage} = await pw.testBrowser.login(user);
+
+        // # Visit town-square channel
+        await channelsPage.goto(team.name, 'town-square');
+        await channelsPage.toBeVisible();
+
+        // # Open the Browse Channels modal
+        const dialog = await channelsPage.openBrowseChannelsModal();
+        await dialog.toBeVisible();
+
+        // # Search for the term that matches DisplayName on some channels and Purpose on others
+        await dialog.fillSearchInput('gamma');
+        await dialog.toBeDoneLoading();
+        await dialog.toHaveNResults(4);
+
+        // DisplayName matches come first, sorted alphabetically
+        await dialog.toHaveChannelAsNthResult(displayMatchA.name, 0);
+        await dialog.toHaveChannelAsNthResult(displayMatchB.name, 1);
+
+        // Purpose-only matches come after, sorted alphabetically by DisplayName
+        await dialog.toHaveChannelAsNthResult(purposeMatchA.name, 2);
+        await dialog.toHaveChannelAsNthResult(purposeMatchB.name, 3);
+    },
+);

--- a/server/Makefile
+++ b/server/Makefile
@@ -248,7 +248,7 @@ ifneq ($(DOCKER_SERVICES_OVERRIDE),true)
   ENABLED_DOCKER_SERVICES:=$(ENABLED_DOCKER_SERVICES) $(TEMP_DOCKER_SERVICES)
 endif
 
-start-docker: ## Starts the docker containers for local development.
+start-docker: setup-go-work ## Starts the docker containers for local development.
 ifneq ($(IS_CI),false)
 	@echo CI Build: skipping docker start
 else ifeq ($(MM_NO_DOCKER),true)
@@ -269,7 +269,7 @@ endif
   endif
 endif
 
-update-docker: stop-docker ## Updates the docker containers for local development.
+update-docker: setup-go-work stop-docker ## Updates the docker containers for local development.
 	@echo Updating docker containers
 
 	$(GO) run ./build/docker-compose-generator/main.go $(ENABLED_DOCKER_SERVICES) | docker compose -f docker-compose.makefile.yml -f /dev/stdin $(DOCKER_COMPOSE_OVERRIDE) up --no-start
@@ -306,7 +306,7 @@ else
 	docker volume rm mattermost-server_postgres-14-data || true
 endif
 
-plugin-checker:
+plugin-checker: setup-go-work
 	$(GO) run $(GOFLAGS) ./public/plugin/checker
 
 prepackaged-plugins: ## Populate the prepackaged-plugins directory.
@@ -331,7 +331,7 @@ golang-versions: ## Install Golang versions used for compatibility testing (e.g.
 	done
 	export GO_COMPATIBILITY_TEST_VERSIONS="${GO_COMPATIBILITY_TEST_VERSIONS}"
 
-golangci-lint: ## Run golangci-lint on codebase
+golangci-lint: setup-go-work ## Run golangci-lint on codebase
 	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.0
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	$(GOBIN)/golangci-lint run ./... ./public/... $(BUILD_ENTERPRISE_DIR)/...
@@ -348,16 +348,16 @@ i18n-check: ## Exit on empty translation strings and translation source strings
 	$(GOBIN)/mmgotool i18n clean-empty --portal-dir="" --check
 	$(GOBIN)/mmgotool i18n check-empty-src --portal-dir=""
 
-store-mocks: ## Creates mock files.
+store-mocks: setup-go-work ## Creates mock files.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config channels/store/.mockery.yaml
 
-cache-mocks:
+cache-mocks: setup-go-work
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config platform/services/cache/.mockery.yaml
 
 
-store-layers: ## Generate layers for the store
+store-layers: setup-go-work ## Generate layers for the store
 	$(GO) generate $(GOFLAGS) ./channels/store
 
 new-migration: ## Creates a new migration. Run with make new-migration name=<>
@@ -365,47 +365,47 @@ new-migration: ## Creates a new migration. Run with make new-migration name=<>
 	@echo "Generating new migration for postgres"
 	$(GOBIN)/morph new script $(name) --driver postgres --dir channels/db/migrations --sequence
 
-filestore-mocks: ## Creates mock files.
+filestore-mocks: setup-go-work ## Creates mock files.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config platform/shared/filestore/.mockery.yaml
 
-ldap-mocks: ## Creates mock files for ldap.
+ldap-mocks: setup-go-work ## Creates mock files for ldap.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --dir $(BUILD_ENTERPRISE_DIR)/ldap --all --inpackage --note 'Regenerate this file using `make ldap-mocks`.'
 
-plugin-mocks: ## Creates mock files for plugins.
+plugin-mocks: setup-go-work ## Creates mock files for plugins.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config public/plugin/.mockery.yaml
 
-einterfaces-mocks: ## Creates mock files for einterfaces.
+einterfaces-mocks: setup-go-work ## Creates mock files for einterfaces.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config einterfaces/.mockery.yaml
 
-searchengine-mocks: ## Creates mock files for searchengines.
+searchengine-mocks: setup-go-work ## Creates mock files for searchengines.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config platform/services/searchengine/.mockery.yaml
 
-sharedchannel-mocks: ## Creates mock files for shared channels.
+sharedchannel-mocks: setup-go-work ## Creates mock files for shared channels.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config platform/services/sharedchannel/.mockery.yaml
 
-misc-mocks: ## Creates mocks for misc interfaces.
+misc-mocks: setup-go-work ## Creates mocks for misc interfaces.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config channels/utils/.mockery.yaml
 
-email-mocks: ## Creates mocks for misc interfaces.
+email-mocks: setup-go-work ## Creates mocks for misc interfaces.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config channels/app/email/.mockery.yaml
 
-platform-mocks: ## Creates mocks for platform interfaces.
+platform-mocks: setup-go-work ## Creates mocks for platform interfaces.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config channels/app/platform/.mockery.yaml
 
-mmctl-mocks: ## Creates mocks for mmctl
+mmctl-mocks: setup-go-work ## Creates mocks for mmctl
 	$(GO) install github.com/golang/mock/mockgen@v1.6.0
 	$(GOBIN)/mockgen -destination=cmd/mmctl/mocks/client_mock.go -copyright_file=cmd/mmctl/mocks/copyright.txt -package=mocks github.com/mattermost/mattermost/server/v8/cmd/mmctl/client Client
 
-pluginapi: ## Generates api and hooks glue code for plugins
+pluginapi: setup-go-work ## Generates api and hooks glue code for plugins
 	cd ./public && $(GO) generate $(GOFLAGS) ./plugin
 
 mocks: store-mocks filestore-mocks ldap-mocks plugin-mocks einterfaces-mocks searchengine-mocks sharedchannel-mocks misc-mocks email-mocks platform-mocks mmctl-mocks mocks-public cache-mocks
@@ -421,15 +421,22 @@ endif
 
 setup-go-work: export BUILD_ENTERPRISE_READY := $(BUILD_ENTERPRISE_READY)
 setup-go-work: ## Sets up your go.work file
-ifneq ($(IGNORE_GO_WORK_IF_EXISTS),true)
-	@echo "Creating a go.work file"
-	rm -f go.work
-	$(GO) work init
-	$(GO) work use .
-	$(GO) work use ./public
-ifeq ($(BUILD_ENTERPRISE_READY),true)
-	$(GO) work use $(BUILD_ENTERPRISE_DIR)
-endif
+ifneq ($(SKIP_SETUP_GO_WORK),true)
+	@set -e; \
+	if [ -f go.work ]; then cp -p go.work go.work.bak; fi; \
+	rm -f go.work; \
+	$(GO) work init; \
+	$(GO) work use .; \
+	$(GO) work use ./public; \
+	if [ "$(BUILD_ENTERPRISE_READY)" = "true" ]; then \
+		$(GO) work use $(BUILD_ENTERPRISE_DIR); \
+	fi; \
+	if [ -f go.work.bak ] && cmp -s go.work go.work.bak; then \
+		mv go.work.bak go.work; \
+	else \
+		rm -f go.work.bak; \
+		echo "Created go.work file"; \
+	fi
 endif
 
 check-style: plugin-checker vet golangci-lint ## Runs style/lint checks
@@ -437,7 +444,7 @@ check-style: plugin-checker vet golangci-lint ## Runs style/lint checks
 gotestsum:
 	$(GO) install gotest.tools/gotestsum@v1.11.0
 
-test-compile: gotestsum ## Compile tests.
+test-compile: setup-go-work gotestsum ## Compile tests.
 	@echo COMPILE TESTS
 
 	for package in $(TE_PACKAGES) $(EE_PACKAGES); do \
@@ -508,10 +515,10 @@ else
 	$(GOBIN)/gotestsum --packages="$(TE_PACKAGES)" -- $(GOFLAGS) -short
 endif
 
-internal-test-web-client: ## Runs web client tests.
+internal-test-web-client: setup-go-work ## Runs web client tests.
 	$(GO) run $(GOFLAGS) $(PLATFORM_FILES) test web_client_tests
 
-run-server-for-web-client-tests: ## Tests the server for web client.
+run-server-for-web-client-tests: setup-go-work ## Tests the server for web client.
 	$(GO) run $(GOFLAGS) $(PLATFORM_FILES) test web_client_tests_server
 
 test-client: ## Test client app.
@@ -599,7 +606,7 @@ endif
 run-server-pgvector: ## Starts the server with pgvector PostgreSQL image.
 	@MM_USE_PGVECTOR=true $(MAKE) run-server
 
-debug-server: start-docker ## Compile and start server using delve.
+debug-server: setup-go-work start-docker ## Compile and start server using delve.
 	mkdir -p $(BUILD_WEBAPP_DIR)/channels/dist/files
 	$(DELVE) debug $(PLATFORM_FILES) --build-flags="-ldflags '\
 		-X github.com/mattermost/mattermost/server/public/model.BuildNumber=$(BUILD_NUMBER)\
@@ -609,7 +616,7 @@ debug-server: start-docker ## Compile and start server using delve.
 		-X github.com/mattermost/mattermost/server/public/model.BuildEnterpriseReady=$(BUILD_ENTERPRISE_READY)'\
 		-tags '$(BUILD_TAGS)'"
 
-debug-server-headless: start-docker ## Debug server from within an IDE like VSCode or IntelliJ.
+debug-server-headless: setup-go-work start-docker ## Debug server from within an IDE like VSCode or IntelliJ.
 	mkdir -p $(BUILD_WEBAPP_DIR)/channels/dist/files
 	$(DELVE) debug --headless --listen=:2345 --api-version=2 --accept-multiclient $(PLATFORM_FILES) --build-flags="-ldflags '\
 		-X github.com/mattermost/mattermost/server/public/model.BuildNumber=$(BUILD_NUMBER)\
@@ -626,12 +633,12 @@ run-node: export MM_SERVICESETTINGS_LOCALMODESOCKETLOCATION=/var/tmp/mattermost_
 run-node: export MM_SQLSETTINGS_DRIVERNAME=postgres
 run-node: export MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mostest@localhost/mattermost_node_test?sslmode=disable&sslmode=disable&connect_timeout=10&binary_parameters=yes
 
-run-node: start-docker ## Runs a shared channel node.
+run-node: setup-go-work start-docker ## Runs a shared channel node.
 	@echo Running mattermost node
 
 	$(GO) run $(GOFLAGS) -ldflags '$(LDFLAGS)' -tags '$(BUILD_TAGS)' $(PLATFORM_FILES) $(RUN_IN_BACKGROUND)
 
-run-cli: start-docker ## Runs CLI.
+run-cli: setup-go-work start-docker ## Runs CLI.
 	@echo Running mattermost for development
 	@echo Example should be like 'make ARGS="-version" run-cli'
 
@@ -699,7 +706,7 @@ restart-haserver:
 
 restart-client: | stop-client run-client ## Restarts the webapp.
 
-run-job-server: ## Runs the background job server.
+run-job-server: setup-go-work ## Runs the background job server.
 	@echo Running job server for development
 	$(GO) run $(GOFLAGS) -ldflags '$(LDFLAGS)' -tags '$(BUILD_TAGS)' $(PLATFORM_FILES) jobserver &
 
@@ -740,7 +747,7 @@ config-openid: ## Configures OpenID.
 
 	@echo Finished setting up configuration for local OpenID with keycloak
 
-config-reset: ## Resets the config/config.json file to the default production values.
+config-reset: setup-go-work ## Resets the config/config.json file to the default production values.
 	@echo Resetting configuration to production default
 	rm -f config/config.json
 	OUTPUT_CONFIG=$(PWD)/config/config.json $(GO) run $(GOFLAGS) -tags production ./scripts/config_generator
@@ -748,7 +755,7 @@ config-reset: ## Resets the config/config.json file to the default production va
 diff-config: ## Compares default configuration between two mattermost versions
 	@./scripts/diff-config.sh
 
-clean: stop-docker ## Clean up everything except persistent server data.
+clean: setup-go-work stop-docker ## Clean up everything except persistent server data.
 	@echo Cleaning
 
 	rm -Rf $(DIST_ROOT)
@@ -797,7 +804,7 @@ ifeq ($(BUILD_ENTERPRISE_READY),true)
 	mv enterprise/external_imports.go.orig enterprise/external_imports.go
 endif
 
-vet: ## Run mattermost go vet specific checks
+vet: setup-go-work ## Run mattermost go vet specific checks
 	$(GO) install github.com/mattermost/mattermost-govet/v2@7d8db289e508999dfcac47b97c9490a0fec12d66
 	$(GO) vet -vettool=$(GOBIN)/mattermost-govet \
 		-structuredLogging \
@@ -826,7 +833,7 @@ vet-api: ## Run mattermost go vet to verify api4 documentation, currently not pa
 	./scripts/vet-api-check.sh
 
 gen-serialized:	export LICENSE_HEADER:=$(LICENSE_HEADER)
-gen-serialized: ## Generates serialization methods for hot structs
+gen-serialized: setup-go-work ## Generates serialization methods for hot structs
 	# This tool only works at a file level, not at a package level.
 	# There will be some warnings about "unresolved identifiers",
 	# but that is because of the above problem. Since we are generating
@@ -858,10 +865,10 @@ ifeq ($(BUILD_ENTERPRISE_READY),true)
 	@! ag --ignore Makefile --ignore-dir runtime '(TODO|XXX|FIXME|"FIX ME")[: ]+' $(BUILD_ENTERPRISE_DIR)/
 endif
 
-mmctl-build: ## Compiles and generates the mmctl binary
+mmctl-build: setup-go-work ## Compiles and generates the mmctl binary
 	$(GO) build $(GOFLAGS) -trimpath -ldflags '$(MMCTL_LDFLAGS)' -o bin/mmctl ./cmd/mmctl
 
-mmctl-docs: ## Generate the mmctl docs
+mmctl-docs: setup-go-work ## Generate the mmctl docs
 	rm -rf ./cmd/mmctl/docs
 	cd ./cmd/mmctl && $(GO) run mmctl.go docs
 
@@ -877,5 +884,5 @@ migrations-extract:
 	@echo "# Autogenerated file to synchronize migrations sequence in the PR workflow, please do not edit." > channels/db/migrations/migrations.list
 	find channels/db/migrations -maxdepth 2 -mindepth 2 | sort >> channels/db/migrations/migrations.list
 
-test-local-filestore: # Run tests for local filestore
+test-local-filestore: setup-go-work # Run tests for local filestore
 	$(GO) test ./platform/shared/filestore -run '^TestLocalFileBackend' -v

--- a/server/Makefile
+++ b/server/Makefile
@@ -52,7 +52,13 @@ MMCTL_BUILD_TAGS =
 MMCTL_TESTFLAGS ?= -timeout 30m
 MMCTL_PKG = github.com/mattermost/mattermost/server/v8/cmd/mmctl/commands
 MMCTL_BUILD_DATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+MMCTL_GIT_COMMIT = $(shell git rev-parse HEAD)
+MMCTL_GIT_TREE_STATE = $(shell if [ -n "$$(git status --porcelain 2>/dev/null)" ]; then echo "dirty"; else echo "clean"; fi)
+MMCTL_COMMIT_DATE = $(shell TZ=UTC git log -1 --date=format-local:'%Y-%m-%dT%H:%M:%SZ' --format='%cd' 2>/dev/null || echo "dev")
 MMCTL_LDFLAGS += -X "$(MMCTL_PKG).buildDate=$(MMCTL_BUILD_DATE)"
+MMCTL_LDFLAGS += -X "$(MMCTL_PKG).gitCommit=$(MMCTL_GIT_COMMIT)"
+MMCTL_LDFLAGS += -X "$(MMCTL_PKG).gitTreeState=$(MMCTL_GIT_TREE_STATE)"
+MMCTL_LDFLAGS += -X "$(MMCTL_PKG).commitDate=$(MMCTL_COMMIT_DATE)"
 
 # Enterprise
 BUILD_ENTERPRISE_DIR ?= ../../enterprise
@@ -106,7 +112,8 @@ ifeq ($(HOME),/)
 endif
 
 # Go Flags
-GOFLAGS ?= $(GOFLAGS:)
+# Use -buildvcs=false to avoid embedding VCS info which can cause false positives in container scanning tools
+export GOFLAGS ?= -buildvcs=false
 # We need to export GOBIN to allow it to be set
 # for processes spawned from the Makefile
 export GOBIN ?= $(PWD)/bin
@@ -852,11 +859,11 @@ ifeq ($(BUILD_ENTERPRISE_READY),true)
 endif
 
 mmctl-build: ## Compiles and generates the mmctl binary
-	go build -trimpath -ldflags '$(MMCTL_LDFLAGS)' -o bin/mmctl ./cmd/mmctl
+	$(GO) build $(GOFLAGS) -trimpath -ldflags '$(MMCTL_LDFLAGS)' -o bin/mmctl ./cmd/mmctl
 
 mmctl-docs: ## Generate the mmctl docs
 	rm -rf ./cmd/mmctl/docs
-	cd ./cmd/mmctl && go run mmctl.go docs
+	cd ./cmd/mmctl && $(GO) run mmctl.go docs
 
 ## Help documentation à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:

--- a/server/build/release.mk
+++ b/server/build/release.mk
@@ -2,7 +2,7 @@ dist: | check-style test package
 
 build-linux: build-linux-amd64 build-linux-arm64
 
-build-linux-amd64:
+build-linux-amd64: setup-go-work
 	@echo Build Linux amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"linux_amd64")
 	env GOOS=linux GOARCH=amd64 $(GO) build -o $(GOBIN) $(GOFLAGS) -trimpath -tags '$(BUILD_TAGS) production' -ldflags '$(LDFLAGS)' ./...
@@ -20,7 +20,7 @@ ifeq ($(FIPS_ENABLED),true)
 	$(GO) tool nm $(GOBIN)/$(MMCTL_BIN_NAME) | grep -q "func_go_openssl_OpenSSL_version" || (echo "ERROR: FIPS mmctl binary missing OpenSSL integration" && exit 1)
 endif
 
-build-linux-arm64:
+build-linux-arm64: setup-go-work
 ifeq ($(FIPS_ENABLED),true)
 	@echo Skipping Build Linux arm64 for FIPS
 else
@@ -33,7 +33,7 @@ else
 endif
 endif
 
-build-osx:
+build-osx: setup-go-work
 	@echo Build OSX amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"darwin_amd64")
 	env GOOS=darwin GOARCH=amd64 $(GO) build -o $(GOBIN) $(GOFLAGS) -trimpath -tags '$(BUILD_TAGS) production' -ldflags '$(LDFLAGS)' ./...
@@ -51,7 +51,7 @@ endif
 
 build-freebsd: build-freebsd-amd64 build-freebsd-arm64
 
-build-freebsd-amd64:
+build-freebsd-amd64: setup-go-work
 	@echo Build FreeBSD amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"freebsd_amd64")
 	env GOOS=freebsd GOARCH=amd64 $(GO) build -o $(GOBIN) $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./...
@@ -60,7 +60,7 @@ else
 	env GOOS=freebsd GOARCH=amd64 $(GO) build -o $(GOBIN)/freebsd_amd64 $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./...
 endif
 
-build-freebsd-arm64:
+build-freebsd-arm64: setup-go-work
 	@echo Build FreeBSD arm64
 ifeq ($(BUILDER_GOOS_GOARCH),"freebsd_arm64")
 	env GOOS=freebsd GOARCH=arm64 $(GO) build -o $(GOBIN) $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./...
@@ -69,7 +69,7 @@ else
 	env GOOS=freebsd GOARCH=arm64 $(GO) build -o $(GOBIN)/freebsd_arm64 $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./...
 endif
 
-build-windows:
+build-windows: setup-go-work
 	@echo Build Windows amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"windows_amd64")
 	env GOOS=windows GOARCH=amd64 $(GO) build -o $(GOBIN) $(GOFLAGS) -trimpath -tags '$(BUILD_TAGS) production' -ldflags '$(LDFLAGS)' ./...
@@ -78,7 +78,7 @@ else
 	env GOOS=windows GOARCH=amd64 $(GO) build -o $(GOBIN)/windows_amd64 $(GOFLAGS) -trimpath -tags '$(BUILD_TAGS) production' -ldflags '$(LDFLAGS)' ./...
 endif
 
-build-cmd-linux:
+build-cmd-linux: setup-go-work
 	@echo Build CMD Linux amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"linux_amd64")
 	env GOOS=linux GOARCH=amd64 $(GO) build -o $(GOBIN) $(GOFLAGS) -trimpath -tags '$(BUILD_TAGS) production' -ldflags '$(LDFLAGS)' ./cmd/...
@@ -107,7 +107,7 @@ else
 endif
 endif
 
-build-cmd-osx:
+build-cmd-osx: setup-go-work
 	@echo Build CMD OSX amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"darwin_amd64")
 	env GOOS=darwin GOARCH=amd64 $(GO) build -o $(GOBIN) $(GOFLAGS) -trimpath -tags '$(BUILD_TAGS) production' -ldflags '$(LDFLAGS)' ./cmd/...
@@ -123,7 +123,7 @@ else
 	env GOOS=darwin GOARCH=arm64 $(GO) build -o $(GOBIN)/darwin_arm64 $(GOFLAGS) -trimpath -tags '$(BUILD_TAGS) production' -ldflags '$(LDFLAGS)' ./cmd/...
 endif
 
-build-cmd-freebsd:
+build-cmd-freebsd: setup-go-work
 	@echo Build CMD FreeBSD amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"freebsd_amd64")
 	env GOOS=freebsd GOARCH=amd64 $(GO) build -o $(GOBIN) $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./cmd/...
@@ -139,7 +139,7 @@ else
 	env GOOS=freebsd GOARCH=arm64 $(GO) build -o $(GOBIN)/freebsd_arm64 $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./cmd/...
 endif
 
-build-cmd-windows:
+build-cmd-windows: setup-go-work
 	@echo Build CMD Windows amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"windows_amd64")
 	env GOOS=windows GOARCH=amd64 $(GO) build -o $(GOBIN) $(GOFLAGS) -trimpath -tags '$(BUILD_TAGS) production' -ldflags '$(LDFLAGS)' ./cmd/...
@@ -159,7 +159,7 @@ build-client:
 
 	cd $(BUILD_WEBAPP_DIR) && $(MAKE) dist
 
-package-prep:
+package-prep: setup-go-work
 	@ echo Packaging mattermost
 	@# Remove any old files
 	rm -Rf $(DIST_ROOT)

--- a/server/channels/app/platform/cluster.go
+++ b/server/channels/app/platform/cluster.go
@@ -28,12 +28,27 @@ func (ps *PlatformService) NewClusterDiscoveryService() *ClusterDiscoveryService
 	return ds
 }
 
+// PlatformService.IsLeader returns true if this server is the leader of its cluster. If the server isn't in a cluster
+// (because it's not supported by the server or its license), this will always return true.
 func (ps *PlatformService) IsLeader() bool {
-	if ps.License() != nil && *ps.Config().ClusterSettings.Enable && ps.clusterIFace != nil {
-		return ps.clusterIFace.IsLeader()
+	license := ps.License()
+	if license == nil || license.Features == nil || license.Features.Cluster == nil || !*license.Features.Cluster {
+		// Clustering can't be enabled without a valid license that supports it
+		return true
 	}
 
-	return true
+	if !*ps.Config().ClusterSettings.Enable {
+		// Clustering is disabled
+		return true
+	}
+
+	if ps.clusterIFace == nil {
+		// Clustering isn't supported by this server
+		return true
+	}
+
+	// Check with the clustering code
+	return ps.clusterIFace.IsLeader()
 }
 
 func (ps *PlatformService) SetCluster(impl einterfaces.ClusterInterface) { //nolint:unused

--- a/server/channels/app/platform/cluster_test.go
+++ b/server/channels/app/platform/cluster_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package platform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/v8/channels/testlib"
+)
+
+func TestIsLeader(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	t.Run("no license returns true", func(t *testing.T) {
+		th := Setup(t)
+		th.Service.SetLicense(nil)
+
+		assert.True(t, th.Service.IsLeader())
+	})
+
+	t.Run("license with cluster enabled and cluster interface returns cluster leader", func(t *testing.T) {
+		fakeCluster := &testlib.FakeClusterInterface{}
+		th := SetupWithCluster(t, fakeCluster)
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ClusterSettings.Enable = true
+		})
+
+		// This is the only case where IsLeader returns false because it's the only case where we actually call
+		// FakeClusterInterface.IsLeader() which returns false
+		assert.False(t, th.Service.IsLeader())
+	})
+
+	t.Run("license without cluster feature but cluster enabled returns true", func(t *testing.T) {
+		fakeCluster := &testlib.FakeClusterInterface{}
+		th := SetupWithCluster(t, fakeCluster)
+
+		// Set a license without the Cluster feature (like an Entry license)
+		license := model.NewTestLicenseWithFalseDefaults("cluster")
+		th.Service.SetLicense(license)
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ClusterSettings.Enable = true
+		})
+
+		// Even though ClusterSettings.Enable is true and clusterIFace is set, the license doesn't support clustering,
+		// so this node should be leader
+		assert.True(t, th.Service.IsLeader())
+	})
+
+	t.Run("cluster settings disabled returns true", func(t *testing.T) {
+		fakeCluster := &testlib.FakeClusterInterface{}
+		th := SetupWithCluster(t, fakeCluster)
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ClusterSettings.Enable = false
+		})
+
+		assert.True(t, th.Service.IsLeader())
+	})
+}

--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -3036,9 +3036,7 @@ func (s SqlChannelStore) Autocomplete(rctx request.CTX, userID, term string, inc
 			sq.Expr("c.TeamId = t.id"),
 			sq.Expr("t.id = tm.TeamId"),
 			sq.Eq{"tm.UserId": userID},
-		}).
-		OrderBy("c.DisplayName").
-		Limit(model.ChannelSearchDefaultLimit)
+		})
 
 	// Always filter out soft-deleted team memberships - users removed from
 	// a team should not see channels from that team regardless of includeDeleted
@@ -3069,6 +3067,10 @@ func (s SqlChannelStore) Autocomplete(rctx request.CTX, userID, term string, inc
 		query = query.Where(searchClause)
 	}
 
+	query = orderByDisplayNameMatch(query, term)
+
+	query = query.Limit(model.ChannelSearchDefaultLimit)
+
 	sql, args, err := query.ToSql()
 	if err != nil {
 		return nil, errors.Wrap(err, "Autocomplete_Tosql")
@@ -3086,7 +3088,6 @@ func (s SqlChannelStore) AutocompleteInTeam(rctx request.CTX, teamID, userID, te
 	query := s.getQueryBuilder().Select(channelSliceColumns(true, "c")...).
 		From("Channels c").
 		Where(sq.Eq{"c.TeamId": teamID}).
-		OrderBy("c.DisplayName").
 		Limit(model.ChannelSearchDefaultLimit)
 
 	if !includeDeleted {
@@ -3113,6 +3114,8 @@ func (s SqlChannelStore) AutocompleteInTeam(rctx request.CTX, teamID, userID, te
 	if searchClause != nil {
 		query = query.Where(searchClause)
 	}
+
+	query = orderByDisplayNameMatch(query, term)
 
 	return s.performSearch(query, term)
 }
@@ -3581,6 +3584,18 @@ func (s SqlChannelStore) searchClause(term string) sq.Sqlizer {
 		likeClause,
 		s.buildFulltextClause(term, "c.Name", "c.DisplayName", "c.Purpose"),
 	}
+}
+
+// orderByDisplayNameMatch adds an ORDER BY clause that prioritizes channels whose DisplayName matches the search term,
+// then sorts alphabetically by DisplayName.
+func orderByDisplayNameMatch(query sq.SelectBuilder, term string) sq.SelectBuilder {
+	sanitizedTerm := sanitizeSearchTerm(term, "*")
+	if sanitizedTerm == "" {
+		return query.OrderBy("c.DisplayName")
+	}
+
+	likeTerm := wildcardSearchTerm(sanitizedTerm)
+	return query.OrderByClause("CASE WHEN LOWER(c.DisplayName) LIKE LOWER(?) ESCAPE '*' THEN 0 ELSE 1 END, c.DisplayName", likeTerm)
 }
 
 func (s SqlChannelStore) searchGroupChannelsQuery(userId, term string) sq.SelectBuilder {

--- a/server/channels/store/storetest/channel_store.go
+++ b/server/channels/store/storetest/channel_store.go
@@ -120,7 +120,7 @@ func TestChannelStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore
 	t.Run("GetMemberCountsByGroup", func(t *testing.T) { testGetMemberCountsByGroup(t, rctx, ss) })
 	t.Run("GetGuestCount", func(t *testing.T) { testGetGuestCount(t, rctx, ss) })
 	t.Run("SearchMore", func(t *testing.T) { testChannelStoreSearchMore(t, rctx, ss) })
-	t.Run("SearchInTeam", func(t *testing.T) { testChannelStoreSearchInTeam(t, rctx, ss) })
+	t.Run("SearchInTeam", func(t *testing.T) { testChannelStoreSearchInTeam(t, rctx, ss, s) })
 	t.Run("Autocomplete", func(t *testing.T) { testAutocomplete(t, rctx, ss, s) })
 	t.Run("SearchForUserInTeam", func(t *testing.T) { testChannelStoreSearchForUserInTeam(t, rctx, ss) })
 	t.Run("SearchAllChannels", func(t *testing.T) { testChannelStoreSearchAllChannels(t, rctx, ss) })
@@ -5990,7 +5990,7 @@ func testChannelStoreSearchMore(t *testing.T, rctx request.CTX, ss store.Store) 
 	})
 }
 
-func testChannelStoreSearchInTeam(t *testing.T, rctx request.CTX, ss store.Store) {
+func testChannelStoreSearchInTeam(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
 	teamID := model.NewId()
 	otherTeamID := model.NewId()
 
@@ -6206,6 +6206,138 @@ func testChannelStoreSearchInTeam(t *testing.T, rctx request.CTX, ss store.Store
 			require.ElementsMatch(t, testCase.ExpectedResults, channels)
 		})
 	}
+
+	t.Run("AutoCompleteInTeam/DisplayName matches are prioritized in ordering", func(t *testing.T) {
+		s.GetMaster().Exec("TRUNCATE Channels")
+
+		sortTeam := &model.Team{
+			DisplayName: "sort-team",
+			Name:        NewTestID(),
+			Email:       MakeEmail(),
+			Type:        model.TeamOpen,
+		}
+		sortTeam, err := ss.Team().Save(sortTeam)
+		require.NoError(t, err)
+
+		sortUser := model.NewId()
+		_, err = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: sortTeam.Id, UserId: sortUser}, -1)
+		require.NoError(t, err)
+
+		// Channels where DisplayName matches "alpha":
+		chDisplayAlpha2 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Alpha Two", Name: NewTestID(), Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &chDisplayAlpha2, -1)
+		require.NoError(t, err)
+
+		chDisplayAlpha1 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Alpha One", Name: NewTestID(), Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &chDisplayAlpha1, -1)
+		require.NoError(t, err)
+
+		// Channels where only Purpose matches "alpha" (DisplayName does NOT contain "alpha"):
+		chPurposeOnly2 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Zulu Channel", Name: NewTestID(), Purpose: "alpha related work", Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &chPurposeOnly2, -1)
+		require.NoError(t, err)
+
+		chPurposeOnly1 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Bravo Channel", Name: NewTestID(), Purpose: "alpha discussions", Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &chPurposeOnly1, -1)
+		require.NoError(t, err)
+
+		channels, err := ss.Channel().AutocompleteInTeam(rctx, sortTeam.Id, sortUser, "alpha", false, false)
+		require.NoError(t, err)
+		require.Len(t, channels, 4)
+
+		// DisplayName matches come first, sorted alphabetically by DisplayName
+		assert.Equal(t, chDisplayAlpha1.Id, channels[0].Id, "first should be Alpha One (DisplayName match, alphabetically first)")
+		assert.Equal(t, chDisplayAlpha2.Id, channels[1].Id, "second should be Alpha Two (DisplayName match, alphabetically second)")
+
+		// Non-DisplayName matches come second, also sorted alphabetically by DisplayName
+		assert.Equal(t, chPurposeOnly1.Id, channels[2].Id, "third should be Bravo Channel (no DisplayName match, alphabetically first)")
+		assert.Equal(t, chPurposeOnly2.Id, channels[3].Id, "fourth should be Zulu Channel (no DisplayName match, alphabetically second)")
+	})
+
+	t.Run("AutoCompleteInTeam/no DisplayName matches still returns results sorted by DisplayName", func(t *testing.T) {
+		s.GetMaster().Exec("TRUNCATE Channels")
+
+		sortTeam := &model.Team{
+			DisplayName: "sort-team",
+			Name:        NewTestID(),
+			Email:       MakeEmail(),
+			Type:        model.TeamOpen,
+		}
+		sortTeam, err := ss.Team().Save(sortTeam)
+		require.NoError(t, err)
+
+		sortUser := model.NewId()
+		_, err = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: sortTeam.Id, UserId: sortUser}, -1)
+		require.NoError(t, err)
+
+		// All channels match on Purpose only, not DisplayName
+		ch1 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Zulu Display", Name: NewTestID(), Purpose: "searchterm stuff", Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &ch1, -1)
+		require.NoError(t, err)
+
+		ch2 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Alpha Display", Name: NewTestID(), Purpose: "searchterm things", Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &ch2, -1)
+		require.NoError(t, err)
+
+		ch3 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Mike Display", Name: NewTestID(), Purpose: "searchterm items", Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &ch3, -1)
+		require.NoError(t, err)
+
+		channels, err := ss.Channel().AutocompleteInTeam(rctx, sortTeam.Id, sortUser, "searchterm", false, false)
+		require.NoError(t, err)
+		require.Len(t, channels, 3)
+
+		// All in the same priority bucket (no DisplayName match), sorted by DisplayName
+		assert.Equal(t, ch2.Id, channels[0].Id, "Alpha Display should be first")
+		assert.Equal(t, ch3.Id, channels[1].Id, "Mike Display should be second")
+		assert.Equal(t, ch1.Id, channels[2].Id, "Zulu Display should be third")
+	})
+
+	t.Run("AutoCompleteInTeam/DisplayName match is not cut off by limit", func(t *testing.T) {
+		s.GetMaster().Exec("TRUNCATE Channels")
+
+		sortTeam := &model.Team{
+			DisplayName: "sort-team",
+			Name:        NewTestID(),
+			Email:       MakeEmail(),
+			Type:        model.TeamOpen,
+		}
+		sortTeam, err := ss.Team().Save(sortTeam)
+		require.NoError(t, err)
+
+		sortUser := model.NewId()
+		_, err = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: sortTeam.Id, UserId: sortUser}, -1)
+		require.NoError(t, err)
+
+		// Create 50 channels that match only on Purpose (not DisplayName).
+		for i := range model.ChannelSearchDefaultLimit {
+			_, err = ss.Channel().Save(rctx, &model.Channel{
+				TeamId:      sortTeam.Id,
+				DisplayName: fmt.Sprintf("AAA Channel %03d", i),
+				Name:        NewTestID(),
+				Purpose:     "findme in purpose",
+				Type:        model.ChannelTypeOpen,
+			}, -1)
+			require.NoError(t, err)
+		}
+
+		// Create 1 channel whose DisplayName matches the term but sorts last alphabetically.
+		chDisplayMatch := model.Channel{
+			TeamId:      sortTeam.Id,
+			DisplayName: "ZZZ findme channel",
+			Name:        NewTestID(),
+			Type:        model.ChannelTypeOpen,
+		}
+		_, err = ss.Channel().Save(rctx, &chDisplayMatch, -1)
+		require.NoError(t, err)
+
+		channels, err := ss.Channel().AutocompleteInTeam(rctx, sortTeam.Id, sortUser, "findme", false, false)
+		require.NoError(t, err)
+		require.Len(t, channels, model.ChannelSearchDefaultLimit)
+
+		// The DisplayName-matching channel must be first despite sorting last alphabetically.
+		assert.Equal(t, chDisplayMatch.Id, channels[0].Id, "DisplayName match should be returned first, not cut off by limit")
+	})
 }
 
 func testAutocomplete(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
@@ -6417,6 +6549,101 @@ func testAutocomplete(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore
 				require.NotEqual(t, o5.Id, ch.Id, "includeDeleted=%v: channel from left team should not be returned", includeDeleted)
 			}
 		}
+	})
+
+	t.Run("channels with a matching DisplayName are sorted before those matching other fields", func(t *testing.T) {
+		// Clean slate for ordering tests
+		s.GetMaster().Exec("TRUNCATE Channels")
+
+		sortTeam := &model.Team{
+			DisplayName: "sort-team",
+			Name:        NewTestID(),
+			Email:       MakeEmail(),
+			Type:        model.TeamOpen,
+		}
+		sortTeam, err2 := ss.Team().Save(sortTeam)
+		require.NoError(t, err2)
+
+		sortUser := model.NewId()
+		_, err2 = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: sortTeam.Id, UserId: sortUser}, -1)
+		require.NoError(t, err2)
+
+		// Channels where DisplayName matches "alpha":
+		chDisplayAlpha2 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Alpha Two", Name: NewTestID(), Type: model.ChannelTypeOpen}
+		_, err2 = ss.Channel().Save(rctx, &chDisplayAlpha2, -1)
+		require.NoError(t, err2)
+
+		chDisplayAlpha1 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Alpha One", Name: NewTestID(), Type: model.ChannelTypeOpen}
+		_, err2 = ss.Channel().Save(rctx, &chDisplayAlpha1, -1)
+		require.NoError(t, err2)
+
+		// Channels where only Purpose matches "alpha" (DisplayName does NOT contain "alpha"):
+		chPurposeOnly2 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Zulu Channel", Name: NewTestID(), Purpose: "alpha related work", Type: model.ChannelTypeOpen}
+		_, err2 = ss.Channel().Save(rctx, &chPurposeOnly2, -1)
+		require.NoError(t, err2)
+
+		chPurposeOnly1 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Bravo Channel", Name: NewTestID(), Purpose: "alpha discussions", Type: model.ChannelTypeOpen}
+		_, err2 = ss.Channel().Save(rctx, &chPurposeOnly1, -1)
+		require.NoError(t, err2)
+
+		channels, err2 := ss.Channel().Autocomplete(rctx, sortUser, "alpha", false, false)
+		require.NoError(t, err2)
+		require.Len(t, channels, 4)
+
+		// DisplayName matches come first, sorted alphabetically by DisplayName
+		assert.Equal(t, chDisplayAlpha1.Id, channels[0].Id, "first should be Alpha One (DisplayName match, alphabetically first)")
+		assert.Equal(t, chDisplayAlpha2.Id, channels[1].Id, "second should be Alpha Two (DisplayName match, alphabetically second)")
+
+		// Non-DisplayName matches come second, also sorted alphabetically by DisplayName
+		assert.Equal(t, chPurposeOnly1.Id, channels[2].Id, "third should be Bravo Channel (no DisplayName match, alphabetically first)")
+		assert.Equal(t, chPurposeOnly2.Id, channels[3].Id, "fourth should be Zulu Channel (no DisplayName match, alphabetically second)")
+	})
+
+	t.Run("channels with a matching DisplayName are sorted before those matching other fields, even when the results are cut off", func(t *testing.T) {
+		s.GetMaster().Exec("TRUNCATE Channels")
+
+		sortTeam := &model.Team{
+			DisplayName: "sort-team",
+			Name:        NewTestID(),
+			Email:       MakeEmail(),
+			Type:        model.TeamOpen,
+		}
+		sortTeam, err2 := ss.Team().Save(sortTeam)
+		require.NoError(t, err2)
+
+		sortUser := model.NewId()
+		_, err2 = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: sortTeam.Id, UserId: sortUser}, -1)
+		require.NoError(t, err2)
+
+		// Create 50 channels that match only on Purpose (not DisplayName).
+		// Give them DisplayNames that sort before the DisplayName-matching channel.
+		for i := range model.ChannelSearchDefaultLimit {
+			_, err2 = ss.Channel().Save(rctx, &model.Channel{
+				TeamId:      sortTeam.Id,
+				DisplayName: fmt.Sprintf("AAA Channel %03d", i),
+				Name:        NewTestID(),
+				Purpose:     "findme in purpose",
+				Type:        model.ChannelTypeOpen,
+			}, -1)
+			require.NoError(t, err2)
+		}
+
+		// Create 1 channel whose DisplayName matches the term but sorts last alphabetically.
+		chDisplayMatch := model.Channel{
+			TeamId:      sortTeam.Id,
+			DisplayName: "ZZZ findme channel",
+			Name:        NewTestID(),
+			Type:        model.ChannelTypeOpen,
+		}
+		_, err2 = ss.Channel().Save(rctx, &chDisplayMatch, -1)
+		require.NoError(t, err2)
+
+		channels, err2 := ss.Channel().Autocomplete(rctx, sortUser, "findme", false, false)
+		require.NoError(t, err2)
+		require.Len(t, channels, model.ChannelSearchDefaultLimit)
+
+		// The DisplayName-matching channel must be first despite sorting last alphabetically.
+		assert.Equal(t, chDisplayMatch.Id, channels[0].Id, "DisplayName match should be returned first, not cut off by limit")
 	})
 
 	t.Run("Limit", func(t *testing.T) {

--- a/server/cmd/mmctl/commands/version.go
+++ b/server/cmd/mmctl/commands/version.go
@@ -5,19 +5,23 @@ package commands
 
 import (
 	"fmt"
-	"runtime/debug"
+	"runtime"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/printer"
-	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
 )
 
+// Version defaults to model.CurrentVersion. buildDate, gitCommit,
+// gitTreeState, and commitDate are set via -X ldflags at build time.
+// See MMCTL_LDFLAGS in the Makefile.
 var (
-	Version = model.CurrentVersion
-	// Build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
-	buildDate = "dev"
+	Version      = model.CurrentVersion
+	buildDate    = "dev"
+	gitCommit    = "dev"
+	gitTreeState = "dev"
+	commitDate   = "dev"
 )
 
 var VersionCmd = &cobra.Command{
@@ -31,14 +35,9 @@ func init() {
 }
 
 func versionCmdF(cmd *cobra.Command, args []string) error {
-	v, err := getVersionInfo()
-	if err != nil {
-		return err
-	}
-
 	printer.PrintT("mmctl:\nVersion:\t{{.Version}}\nBuiltDate:\t{{.BuildDate}}\nCommitDate:\t{{.CommitDate}}\nGitCommit:\t{{.GitCommit}}"+
 		"\nGitTreeState:\t{{.GitTreeState}}\nGoVersion:\t{{.GoVersion}}"+
-		"\nCompiler:\t{{.Compiler}}\nPlatform:\t{{.Platform}}", v)
+		"\nCompiler:\t{{.Compiler}}\nPlatform:\t{{.Platform}}", getVersionInfo())
 	return nil
 }
 
@@ -53,51 +52,15 @@ type Info struct {
 	Platform     string
 }
 
-func getVersionInfo() (*Info, error) {
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return nil, errors.New("failed to get build info")
-	}
-
-	var (
-		revision     = "dev"
-		gitTreeState = "dev"
-		commitDate   = "dev"
-
-		os       string
-		arch     string
-		compiler string
-	)
-
-	for _, s := range info.Settings {
-		switch s.Key {
-		case "vcs.revision":
-			revision = s.Value
-		case "vcs.time":
-			commitDate = s.Value
-		case "vcs.modified":
-			if s.Value == "true" {
-				gitTreeState = "dirty"
-			} else {
-				gitTreeState = "clean"
-			}
-		case "GOOS":
-			os = s.Value
-		case "GOARCH":
-			arch = s.Value
-		case "-compiler":
-			compiler = s.Value
-		}
-	}
-
+func getVersionInfo() *Info {
 	return &Info{
 		Version:      Version,
 		BuildDate:    buildDate,
 		CommitDate:   commitDate,
-		GitCommit:    revision,
+		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,
-		GoVersion:    info.GoVersion,
-		Compiler:     compiler,
-		Platform:     fmt.Sprintf("%s/%s", arch, os),
-	}, nil
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
 }

--- a/server/config.mk
+++ b/server/config.mk
@@ -26,3 +26,10 @@ LDAP_DATA ?= test
 
 # Mock the CWS.
 MM_ENABLE_CWS_MOCK ?= false
+
+# Skip running setup-go-work automatically.
+# IGNORE_GO_WORK_IF_EXISTS is supported for backwards compatibility.
+ifdef IGNORE_GO_WORK_IF_EXISTS
+SKIP_SETUP_GO_WORK ?= $(IGNORE_GO_WORK_IF_EXISTS)
+endif
+SKIP_SETUP_GO_WORK ?= false


### PR DESCRIPTION
- [MM-67744] Add -buildvcs=false to default GOFLAGS (#35587)
- MM-66944 Change PlatformService.IsLeader to always be true when license doesn't support clustering (#35577)
- ci: skip server CI for docs-only changes (#35719)
- Automate setup-go-work as a dependency for Make targets (#35476)
- MM-67953 Changed sorting of channels in some places to prioritize display name matches (#35679)
- docs: upstream sync 진행 (picked 5)

## 검증

- `make mmctl-build` + `bin/mmctl version` 실주행 — ldflags 주입 동작 확인 (GitCommit이 실제 해시)
- `make setup-go-work` 2회 실행 — 내용 동일 시 go.work mtime 보존, go.work.bak 잔여물 없음, SKIP_SETUP_GO_WORK 스위치 동작
- `make -n golangci-lint` — 새 setup-go-work 의존성 배선 확인
- server-ci.yml YAML 파싱 및 paths 제외 패턴 3개 확인
- `go build ./channels/...`, `go vet` (platform, sqlstore, storetest, mmctl) 통과
- playwright `tsc -b` 0건 (lib 워크스페이스 재빌드 후)

## 실행하지 못한 검증

- `cluster_test.go`, `storetest/channel_store.go`: PostgreSQL 필요
- Playwright E2E 3종: 실서버 필요
- 채널 정렬(ORDER BY CASE) 동작은 DB 있는 환경에서 확인 필요

## 알려진 기존 실패 (우리 변경과 무관)

- `make check-style` vet 7건 — `storetest.Store`에 `NotificationHistory` 누락, master 재현 확인 완료
- `check-lint` — master 기존 부채 46개 파일