### PR TITLE
upstream sync 2026-03-22 (picked 1, excluded 1)

### DIFF
--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -54,11 +54,6 @@ jobs:
         run: |
           echo "${{ inputs.name }}" > server/test-name
           echo "${{ github.event.pull_request.number }}" > server/pr-number
-      - name: Setup needed prepackaged plugins
-        run: |
-          cd server
-          make prepackaged-plugins PLUGIN_PACKAGES=mattermost-plugin-jira-v3.2.5
-
       - name: Run docker compose
         run: |
           cd server/build

--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,16 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-12 16:32
+- 갱신일: 2026-08-12 16:48
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 915개
+- 남은 커밋: 914개
 
-**마지막 반영 커밋:** `5f8c77a3` | [MM-67953 Changed sorting of channels in some places to prioritize display name matches (#35679)](https://github.com/mattermost/mattermost/commit/5f8c77a3efcc31260cde2d8e800577a2c4a18d68) | 2026-03-20
+**마지막 반영 커밋:** `b4163449` | [ci: cache prepackaged plugins in mmctl tests (#35720)](https://github.com/mattermost/mattermost/commit/b4163449319c422f462a845294808084d0c6b332) | 2026-03-22
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| e6b8e12f | [SEC-9862: Add CI check for test analysis (#35555)](https://github.com/mattermost/mattermost/commit/e6b8e12fb94e8d4ef45b3f0d765c00f8f7087fe7) | 2026-03-22 |
-| b4163449 | [ci: cache prepackaged plugins in mmctl tests (#35720)](https://github.com/mattermost/mattermost/commit/b4163449319c422f462a845294808084d0c6b332) | 2026-03-22 |
 | ae1691a3 | [fix(pr-analysis): on large diff and reduce gh pr calls (#35734)](https://github.com/mattermost/mattermost/commit/ae1691a3685d7ff4817593adab7741b4ce884784) | 2026-03-23 |
 | 156bdc5f | [MM-67742 Fixing text color in marketplace banner (#35674)](https://github.com/mattermost/mattermost/commit/156bdc5fa64330b0e1b730b441941f1c07183e10) | 2026-03-23 |
 | f0b2a36d | [MM-67616: Refactor shared channel membership sync to use ChannelMemberHistory (#35619)](https://github.com/mattermost/mattermost/commit/f0b2a36dbc4a9e8a5e5f6232ba51a1940e90fddf) | 2026-03-23 |
@@ -926,6 +924,7 @@
 | 1f08ac5b | [MM-69886: Refresh Channel Members RHS on websocket add and reconnect (#37584)](https://github.com/mattermost/mattermost/commit/1f08ac5bb04372421315c0ebe0e951fbecf3ebb6) | 2026-08-11 |
 | 265f1509 | [\[MM-70223\] Migrate GetAllProfilesInChannel to request context (#37637)](https://github.com/mattermost/mattermost/commit/265f1509fa0ea08464a007995c943b21d0530f9a) | 2026-08-12 |
 | 270a5030 | [\[MM-70225\] Migrate Store.GetDiagnostics to request.CTX (#37635)](https://github.com/mattermost/mattermost/commit/270a5030542305e1a9921f6df71bc7793245442c) | 2026-08-12 |
+| 9f0ae6a2 | [\[MM-70222\] Migrate UserStore Get to request context (#37646)](https://github.com/mattermost/mattermost/commit/9f0ae6a220f5da8f4303ee80f2237f395ff9bed4) | 2026-08-12 |
 
 ## 제외된 커밋
 
@@ -963,6 +962,8 @@
 | 9e73b9bb | [Update docs-impact-review.yml (#35589)](https://github.com/mattermost/mattermost/commit/9e73b9bb0cb998c5c88b664cc087776d848fd14f) | 부모 워크플로 45f54a0e(Documentation Impact Review Workflow)와 동일 사유로 제외 — okrbest에 docs-impact-review.yml 자체가 없어(Mattermost 공식 docs 저장소 전용, adapt 대상 없음) 프롬프트 문구 수정(feature flag/audit event/support packet/플러그인 버전 판정 기준 추가)도 반영할 대상이 없음. |
 
 | fee649d0 | [Run docs-impact-review as regular CI instead of slash command (#35620)](https://github.com/mattermost/mattermost/commit/fee649d06353948763d4fb09c6664fa942a82428) | 부모 워크플로 45f54a0e(Documentation Impact Review Workflow)와 동일 사유로 제외 — okrbest에 docs-impact-review.yml 자체가 없어(Mattermost 공식 docs 저장소 전용, adapt 대상 없음) 슬래시 커맨드에서 일반 CI 실행으로 바꾸는 이번 수정(+43/-13)도 반영할 대상이 없음. 반영 시 mattermost/docs를 체크아웃하고 ANTHROPIC_API_KEY를 소모하는 무관한 워크플로가 PR마다 자동 실행됨. 0fa5e235·7ccafd79와 같은 계열. |
+
+| e6b8e12f | [SEC-9862: Add CI check for test analysis (#35555)](https://github.com/mattermost/mattermost/commit/e6b8e12fb94e8d4ef45b3f0d765c00f8f7087fe7) | Mattermost 조직 전용 CI 워크플로 2개(pr-test-analysis.yml +464, pr-test-analysis-override.yml +117) 신설. 실행 가드가 head.repo.full_name == 'mattermost/mattermost'로 하드코딩돼 okrbest에 넣어도 job이 항상 skip되어 죽은 파일만 남음. adapt로 가드를 바꾸면 PR마다 secrets.ANTHROPIC_API_KEY로 Claude 호출 비용이 발생하고, 보고 대상 secrets.WEBHOOK_URL_TEST_PR_ANALYSIS_HUB는 Mattermost 내부 허브라 우리에게 대상이 없음. 도입 여부는 sync가 아닌 별도 의사결정 사안. 45f54a0e·fee649d0(docs-impact-review) 계열과 동일 사유. |
 
 ## spec 전환 커밋
 

--- a/server/cmd/mmctl/commands/mmctl_test.go
+++ b/server/cmd/mmctl/commands/mmctl_test.go
@@ -59,6 +59,11 @@ func (s *MmctlE2ETestSuite) SetupTestHelper() *api4.TestHelper {
 	return s.th
 }
 
+func (s *MmctlE2ETestSuite) SetupTestHelperWithConfig(updateConfig func(cfg *model.Config)) *api4.TestHelper {
+	s.th = api4.SetupConfig(s.T(), updateConfig)
+	return s.th
+}
+
 func (s *MmctlE2ETestSuite) SetupEnterpriseTestHelper() *api4.TestHelper {
 	if EnableEnterpriseTests != "true" {
 		s.T().SkipNow()

--- a/server/cmd/mmctl/commands/plugin_marketplace_e2e_test.go
+++ b/server/cmd/mmctl/commands/plugin_marketplace_e2e_test.go
@@ -4,15 +4,42 @@
 package commands
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/spf13/cobra"
 
+	"github.com/mattermost/mattermost/server/v8/channels/testlib"
+	"github.com/mattermost/mattermost/server/v8/channels/utils/fileutils"
 	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/client"
 	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/printer"
 )
 
 func (s *MmctlE2ETestSuite) TestPluginMarketplaceInstallCmd() {
-	s.SetupTestHelper().InitBasic(s.T())
+	testsPath, found := fileutils.FindDir("tests")
+	s.Require().True(found, "failed to find tests directory")
+
+	prepackagedPluginsDir := "prepackaged_plugins"
+	os.RemoveAll(prepackagedPluginsDir)
+	err := os.Mkdir(prepackagedPluginsDir, os.ModePerm)
+	s.Require().NoError(err)
+	s.T().Cleanup(func() { os.RemoveAll(prepackagedPluginsDir) })
+
+	ppDir, found := fileutils.FindDir(prepackagedPluginsDir)
+	s.Require().True(found, "failed to find prepackaged plugins directory")
+
+	err = testlib.CopyFile(filepath.Join(testsPath, "testplugin.tar.gz"), filepath.Join(ppDir, "testplugin.tar.gz"))
+	s.Require().NoError(err)
+	err = testlib.CopyFile(filepath.Join(testsPath, "testplugin.tar.gz.asc"), filepath.Join(ppDir, "testplugin.tar.gz.sig"))
+	s.Require().NoError(err)
+
+	s.SetupTestHelperWithConfig(func(cfg *model.Config) {
+		*cfg.PluginSettings.AutomaticPrepackagedPlugins = false
+		cfg.PluginSettings.SignaturePublicKeyFiles = []string{
+			filepath.Join(testsPath, "development-public-key.asc"),
+		}
+	}).InitBasic(s.T())
 
 	s.RunForSystemAdminAndLocal("install a plugin", func(c client.Client) {
 		printer.Clean()
@@ -20,7 +47,7 @@ func (s *MmctlE2ETestSuite) TestPluginMarketplaceInstallCmd() {
 		marketPlacePlugins, appErr := s.th.App.GetMarketplacePlugins(s.th.Context, &model.MarketplacePluginFilter{
 			Page:    0,
 			PerPage: 100,
-			Filter:  "jira",
+			Filter:  "testplugin",
 		})
 		s.Require().Nil(appErr)
 		s.Require().NotEmpty(marketPlacePlugins)
@@ -52,7 +79,7 @@ func (s *MmctlE2ETestSuite) TestPluginMarketplaceInstallCmd() {
 		printer.Clean()
 
 		const (
-			pluginID = "jira"
+			pluginID = "testplugin"
 		)
 
 		defer removePluginIfInstalled(s.th.Client, s, pluginID)


### PR DESCRIPTION
- ci: cache prepackaged plugins in mmctl tests (#35720)
- docs: upstream sync 진행 (picked 1, excluded 1)

## 제외 1건

`e6b8e12f` SEC-9862 테스트 분석 CI — Mattermost 조직 전용. 실행 가드가 `head.repo.full_name == 'mattermost/mattermost'`로 하드코딩돼 okrbest에서는 항상 skip되고, adapt하면 PR마다 ANTHROPIC_API_KEY 비용이 발생하며 보고 웹훅 대상이 없음. 45f54a0e·fee649d0(docs-impact-review) 계열과 동일 사유.

## 반영 1건의 효과

mmctl E2E가 매 실행마다 외부에서 Jira 플러그인 v3.2.5를 내려받던 스텝을 제거하고, 저장소에 이미 있는 `tests/testplugin.tar.gz`를 쓰도록 전환. 우리 프리패키지 Jira는 v4.6.0(3b256b7645)이라 테스트용으로만 낡은 3.2.5를 받던 불일치도 함께 해소.

## 검증

- `go vet ./cmd/mmctl/commands/` exit 0
- `go test -c` 테스트 바이너리 컴파일 exit 0
- mmctl-test-template.yml YAML 파싱 유효, 삭제 스텝 제거 확인
- 전제 파일 확인: tests/testplugin.tar.gz, .asc, development-public-key.asc 존재 / api4.SetupConfig, testlib.CopyFile 존재

## 실행하지 못한 검증

mmctl E2E는 DB·서버 기동 필요로 로컬 실행 불가 (CI에서 확인)

## 알려진 기존 실패 (우리 변경과 무관)

`make check-style` vet 7건 — `storetest.Store`에 `NotificationHistory` 누락, master 재현 확인 완료