### PR TITLE
upstream sync 2026-03-24 (picked 5)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,19 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-12 17:15
+- 갱신일: 2026-08-12 22:42
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 908개
+- 남은 커밋: 906개
 
-**마지막 반영 커밋:** `a3cdef8b` | [Fix docs-impact-review CI hitting max turns limit (#35744)](https://github.com/mattermost/mattermost/commit/a3cdef8b0f1b31c931895fbd5011a17fa6869afa) | 2026-03-23
+**마지막 반영 커밋:** `cc66081f` | [Fix flaky test for makeGetProfilesInChannel (#35765)](https://github.com/mattermost/mattermost/commit/cc66081f6b6812a77158847d5270072313553287) | 2026-03-24
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 7d26b7f3 | [Fix datepicker calendar overflow in AppsForm modal (#35437)](https://github.com/mattermost/mattermost/commit/7d26b7f3174649868b05569505dd5eaf02f93415) | 2026-03-24 |
-| 43130d80 | [MM-67158 - fix overlap in post actions menu (#35415)](https://github.com/mattermost/mattermost/commit/43130d8085cdbb7ae098027b46b764ee22ae33e6) | 2026-03-24 |
-| 4b1b3cee | [refactor(pdf_preview): migrate PDFPreview to function component (#33648)](https://github.com/mattermost/mattermost/commit/4b1b3cee69cc7db260352450eb57da310651f7a9) | 2026-03-24 |
-| 8bfa1ff0 | [fix: allow substring matching when searching channel members (#35017)](https://github.com/mattermost/mattermost/commit/8bfa1ff09ff3d593cb7c98786d719d2bc42d3851) | 2026-03-25 |
-| cc66081f | [Fix flaky test for makeGetProfilesInChannel (#35765)](https://github.com/mattermost/mattermost/commit/cc66081f6b6812a77158847d5270072313553287) | 2026-03-24 |
 | 95e33dbc | [MM-63848: Enforce unique names for parent access control policies (#35676)](https://github.com/mattermost/mattermost/commit/95e33dbc7229a28d768ce1f5c4a14a673d0303a4) | 2026-03-25 |
 | 7d6d834f | [MM-68016, MM-68017, MM-68018 Add plugin pre-hooks for membership and channel archive (#35731)](https://github.com/mattermost/mattermost/commit/7d6d834f1f4feea8ecbf2eedf505cc76cbe62998) | 2026-03-25 |
 | 4f16a29c | [MM-67793: Remove dependency on blang/semver/v4 (#35742)](https://github.com/mattermost/mattermost/commit/4f16a29cb5e8bf4978763581602caa6012865091) | 2026-03-25 |
@@ -919,6 +914,9 @@
 | 265f1509 | [\[MM-70223\] Migrate GetAllProfilesInChannel to request context (#37637)](https://github.com/mattermost/mattermost/commit/265f1509fa0ea08464a007995c943b21d0530f9a) | 2026-08-12 |
 | 270a5030 | [\[MM-70225\] Migrate Store.GetDiagnostics to request.CTX (#37635)](https://github.com/mattermost/mattermost/commit/270a5030542305e1a9921f6df71bc7793245442c) | 2026-08-12 |
 | 9f0ae6a2 | [\[MM-70222\] Migrate UserStore Get to request context (#37646)](https://github.com/mattermost/mattermost/commit/9f0ae6a220f5da8f4303ee80f2237f395ff9bed4) | 2026-08-12 |
+| 523292f0 | [Remove unused context import left behind by UserStore.Get migration (#37921)](https://github.com/mattermost/mattermost/commit/523292f0816a3a5ebc5f836d323a4d9beecc5860) | 2026-08-12 |
+| 46102626 | [MM-70151/MM-70152: fix slash commands in the WYSIWYG composer (#37880)](https://github.com/mattermost/mattermost/commit/46102626dbad7473f461307b7be4c98cd387bf4f) | 2026-08-12 |
+| 0fc1ff17 | [\[MM-69557\] Fix post actions menu not closing on outside click in mobile view (#37394)](https://github.com/mattermost/mattermost/commit/0fc1ff17c8a92a00c2694a059214d0b823db2a83) | 2026-08-12 |
 
 ## 제외된 커밋
 

--- a/e2e-tests/cypress/tests/integration/channels/enterprise/accessibility/accessibility_input_fields_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/enterprise/accessibility/accessibility_input_fields_spec.ts
@@ -202,7 +202,10 @@ describe('Verify Accessibility Support in different input fields', () => {
             cy.get('#FormattingControl_ul').should('be.focused').and('have.attr', 'aria-label', 'bulleted list').tab();
 
             // * Verify if the focus is on the numbered list button
-            cy.get('#FormattingControl_ol').should('be.focused').and('have.attr', 'aria-label', 'numbered list').tab().tab().tab();
+            cy.get('#FormattingControl_ol').should('be.focused').and('have.attr', 'aria-label', 'numbered list');
+
+            // # Skip any additional controls (priority, AI rewrite, BOR) which vary by enterprise config
+            cy.get('#toggleFormattingBarButton').focus();
 
             // * Verify if the focus is on the formatting options button
             cy.get('#toggleFormattingBarButton').should('be.focused').and('have.attr', 'aria-label', 'formatting').tab();
@@ -240,32 +243,23 @@ describe('Verify Accessibility Support in different input fields', () => {
             // * Verify if the focus is on the bold button
             cy.get('#FormattingControl_bold').should('be.focused').and('have.attr', 'aria-label', 'bold').tab();
 
-            // * Verify if the focus is on the italic button
-            cy.get('#FormattingControl_italic').should('be.focused').and('have.attr', 'aria-label', 'italic').tab();
+            // # Tab through any remaining visible formatting controls before the overflow button.
+            // # The number of visible controls depends on the RHS width and additional controls present.
+            cy.get('#HiddenControlsButtonRHS_COMMENT').focus().click().tab();
 
-            // * Verify if the focus is on the strike through button
-            cy.get('#FormattingControl_strike').should('be.focused').and('have.attr', 'aria-label', 'strike through').tab();
+            // * Verify hidden controls are accessible via the overflow menu
+            cy.get('#FormattingControl_italic').should('exist').and('have.attr', 'aria-label', 'italic');
+            cy.get('#FormattingControl_strike').should('exist').and('have.attr', 'aria-label', 'strike through');
+            cy.get('#FormattingControl_heading').should('exist').and('have.attr', 'aria-label', 'heading');
+            cy.get('#FormattingControl_link').should('exist').and('have.attr', 'aria-label', 'link');
+            cy.get('#FormattingControl_code').should('exist').and('have.attr', 'aria-label', 'code');
+            cy.get('#FormattingControl_quote').should('exist').and('have.attr', 'aria-label', 'quote');
+            cy.get('#FormattingControl_ul').should('exist').and('have.attr', 'aria-label', 'bulleted list');
+            cy.get('#FormattingControl_ol').should('exist').and('have.attr', 'aria-label', 'numbered list');
 
-            // * Verify if the focus is on the hidden controls button
-            cy.get('#HiddenControlsButtonRHS_COMMENT').should('be.focused').and('have.attr', 'aria-label', 'show hidden formatting options').click().tab();
-
-            // * Verify if the focus is on the hidden heading button
-            cy.get('#FormattingControl_heading').should('be.focused').and('have.attr', 'aria-label', 'heading').tab();
-
-            // * Verify if the focus is on the hidden link button
-            cy.get('#FormattingControl_link').should('be.focused').and('have.attr', 'aria-label', 'link').tab();
-
-            // * Verify if the focus is on the hidden code button
-            cy.get('#FormattingControl_code').should('be.focused').and('have.attr', 'aria-label', 'code').tab();
-
-            // * Verify if the focus is on the hidden quote button
-            cy.get('#FormattingControl_quote').should('be.focused').and('have.attr', 'aria-label', 'quote').tab();
-
-            // * Verify if the focus is on the hidden bulleted list button
-            cy.get('#FormattingControl_ul').should('be.focused').and('have.attr', 'aria-label', 'bulleted list').tab();
-
-            // * Verify if the focus is on the hidden numbered list button
-            cy.get('#FormattingControl_ol').should('be.focused').and('have.attr', 'aria-label', 'numbered list').tab();
+            // # Close the overflow popover, skip additional controls (priority, BOR) which vary by enterprise config
+            cy.get('#HiddenControlsButtonRHS_COMMENT').focus().type('{esc}');
+            cy.get('#toggleFormattingBarButton').focus();
 
             // * Verify if the focus is on the formatting options button
             cy.get('#toggleFormattingBarButton').should('be.focused').and('have.attr', 'aria-label', 'formatting').tab();

--- a/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.test.tsx
@@ -12,7 +12,7 @@ import * as Hooks from './hooks';
 
 jest.mock('./hooks');
 
-const {splitFormattingBarControls} = jest.requireActual('./hooks');
+const {LayoutModes, splitFormattingBarControls} = jest.requireActual('./hooks');
 
 describe('FormattingBar', () => {
     const baseProps = {
@@ -24,7 +24,7 @@ describe('FormattingBar', () => {
     };
 
     test('should render hidden formatting button when screen size is min', () => {
-        jest.spyOn(Hooks, 'useFormattingBarControls').mockReturnValue({wideMode: 'min', ...splitFormattingBarControls('min')});
+        jest.spyOn(Hooks, 'useFormattingBarControls').mockReturnValue({layoutMode: LayoutModes.Min, ...splitFormattingBarControls('min')});
 
         renderWithContext(
             <FormattingBar {...baseProps}/>,
@@ -34,7 +34,7 @@ describe('FormattingBar', () => {
     });
 
     test('should render hidden formatting button when screen size is narrow', () => {
-        jest.spyOn(Hooks, 'useFormattingBarControls').mockReturnValue({wideMode: 'narrow', ...splitFormattingBarControls('narrow')});
+        jest.spyOn(Hooks, 'useFormattingBarControls').mockReturnValue({layoutMode: LayoutModes.Narrow, ...splitFormattingBarControls('narrow')});
 
         renderWithContext(
             <FormattingBar {...baseProps}/>,
@@ -44,7 +44,7 @@ describe('FormattingBar', () => {
     });
 
     test('should render hidden formatting button when screen size is normal', () => {
-        jest.spyOn(Hooks, 'useFormattingBarControls').mockReturnValue({wideMode: 'normal', ...splitFormattingBarControls('normal')});
+        jest.spyOn(Hooks, 'useFormattingBarControls').mockReturnValue({layoutMode: LayoutModes.Normal, ...splitFormattingBarControls('normal')});
 
         renderWithContext(
             <FormattingBar {...baseProps}/>,
@@ -54,7 +54,7 @@ describe('FormattingBar', () => {
     });
 
     test('should not render hidden formatting button when screen size is wide', () => {
-        jest.spyOn(Hooks, 'useFormattingBarControls').mockReturnValue({wideMode: 'wide', ...splitFormattingBarControls('wide')});
+        jest.spyOn(Hooks, 'useFormattingBarControls').mockReturnValue({layoutMode: LayoutModes.Wide, ...splitFormattingBarControls('wide')});
 
         renderWithContext(
             <FormattingBar {...baseProps}/>,
@@ -64,7 +64,7 @@ describe('FormattingBar', () => {
     });
 
     test('MM-56705 should not submit form when clicking on hidden formatting button', async () => {
-        jest.spyOn(Hooks, 'useFormattingBarControls').mockReturnValue({wideMode: 'narrow', ...splitFormattingBarControls('narrow')});
+        jest.spyOn(Hooks, 'useFormattingBarControls').mockReturnValue({layoutMode: LayoutModes.Narrow, ...splitFormattingBarControls('narrow')});
 
         const onSubmit = jest.fn();
 
@@ -83,7 +83,7 @@ describe('FormattingBar', () => {
     });
 
     test('should disable tooltip when hidden controls are shown', async () => {
-        jest.spyOn(Hooks, 'useFormattingBarControls').mockReturnValue({wideMode: 'narrow', ...splitFormattingBarControls('narrow')});
+        jest.spyOn(Hooks, 'useFormattingBarControls').mockReturnValue({layoutMode: LayoutModes.Narrow, ...splitFormattingBarControls('narrow')});
 
         const {container} = renderWithContext(
             <FormattingBar {...baseProps}/>,

--- a/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
@@ -3,7 +3,7 @@
 
 import {useFloating, offset, useClick, useDismiss, useInteractions} from '@floating-ui/react';
 import classNames from 'classnames';
-import React, {memo, useCallback, useEffect, useRef, useState} from 'react';
+import React, {memo, useCallback, useEffect, useMemo, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {CSSTransition} from 'react-transition-group';
 import styled from 'styled-components';
@@ -15,7 +15,7 @@ import WithTooltip from 'components/with_tooltip';
 import type {ApplyMarkdownOptions, MarkdownMode} from 'utils/markdown/apply_markdown';
 
 import FormattingIcon, {IconContainer} from './formatting_icon';
-import {useFormattingBarControls} from './hooks';
+import {LayoutModes, useFormattingBarControls} from './hooks';
 
 export const Separator = styled.div`
     display: block;
@@ -144,8 +144,12 @@ const FormattingBar = (props: FormattingBarProps): JSX.Element => {
         additionalControls,
     } = props;
     const [showHiddenControls, setShowHiddenControls] = useState(false);
-    const formattingBarRef = useRef<HTMLDivElement>(null);
-    const {controls, hiddenControls, wideMode} = useFormattingBarControls(formattingBarRef);
+
+    const additionalControlsCount = useMemo(() => {
+        return Array.isArray(additionalControls) ? additionalControls.filter(Boolean).length : 0;
+    }, [additionalControls]);
+
+    const {formattingBarRef, controls, hiddenControls, layoutMode} = useFormattingBarControls(additionalControlsCount, location);
 
     const {formatMessage} = useIntl();
     const HiddenControlsButtonAriaLabel = formatMessage({id: 'accessibility.button.hidden_controls_button', defaultMessage: 'show hidden formatting options'});
@@ -169,9 +173,9 @@ const FormattingBar = (props: FormattingBarProps): JSX.Element => {
 
     useEffect(() => {
         update?.();
-    }, [wideMode, update, showHiddenControls]);
+    }, [layoutMode, update, showHiddenControls]);
 
-    const hasHiddenControls = wideMode !== 'wide';
+    const hasHiddenControls = layoutMode !== LayoutModes.Wide;
 
     /**
      * wrapping this factory in useCallback prevents it from constantly getting a new
@@ -206,7 +210,7 @@ const FormattingBar = (props: FormattingBarProps): JSX.Element => {
         }
     }, [getCurrentSelection, getCurrentMessage, applyMarkdown, showHiddenControls, disableControls]);
 
-    const leftPosition = wideMode === 'min' ? (x ?? 0) + DEFAULT_MIN_MODE_X_COORD : x ?? 0;
+    const leftPosition = layoutMode === LayoutModes.Min ? (x ?? 0) + DEFAULT_MIN_MODE_X_COORD : x ?? 0;
 
     const hiddenControlsContainerStyles: React.CSSProperties = {
         position: strategy,
@@ -214,7 +218,7 @@ const FormattingBar = (props: FormattingBarProps): JSX.Element => {
         left: leftPosition,
     };
 
-    const showSeparators = wideMode === 'wide';
+    const showSeparators = layoutMode === LayoutModes.Wide;
 
     return (
         <FormattingBarContainer

--- a/webapp/channels/src/components/advanced_text_editor/formatting_bar/hooks.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/formatting_bar/hooks.test.tsx
@@ -1,0 +1,149 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {LayoutModes, splitFormattingBarControls} from './hooks';
+
+describe('splitFormattingBarControls', () => {
+    describe('wide mode — always shows all 9 icons regardless of additional controls', () => {
+        test('shows all 9 with no additional controls', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Wide, 0, false);
+            expect(controls).toHaveLength(9);
+            expect(controls).toEqual(['bold', 'italic', 'strike', 'heading', 'link', 'code', 'quote', 'ul', 'ol']);
+            expect(hiddenControls).toHaveLength(0);
+        });
+
+        test('shows all 9 with 1 additional control', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Wide, 1, false);
+            expect(controls).toHaveLength(9);
+            expect(hiddenControls).toHaveLength(0);
+        });
+
+        test('shows all 9 with 3 additional controls', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Wide, 3, false);
+            expect(controls).toHaveLength(9);
+            expect(hiddenControls).toHaveLength(0);
+        });
+    });
+
+    describe('normal mode (base 5) — first additional control is free, each one after reduces by 1', () => {
+        test('shows 5 with no additional controls', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Normal, 0, false);
+            expect(controls).toHaveLength(5);
+            expect(controls).toEqual(['bold', 'italic', 'strike', 'heading', 'link']);
+            expect(hiddenControls).toHaveLength(4);
+        });
+
+        test('shows 5 with 1 additional control', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Normal, 1, false);
+            expect(controls).toHaveLength(5);
+            expect(hiddenControls).toHaveLength(4);
+        });
+
+        test('shows 4 with 2 additional controls', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Normal, 2, false);
+            expect(controls).toHaveLength(4);
+            expect(controls).toEqual(['bold', 'italic', 'strike', 'heading']);
+            expect(hiddenControls).toHaveLength(5);
+        });
+
+        test('shows 3 with 3 additional controls', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Normal, 3, false);
+            expect(controls).toHaveLength(3);
+            expect(controls).toEqual(['bold', 'italic', 'strike']);
+            expect(hiddenControls).toHaveLength(6);
+        });
+
+        test('shows 2 with 4 additional controls', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Normal, 4, false);
+            expect(controls).toHaveLength(2);
+            expect(hiddenControls).toHaveLength(7);
+        });
+    });
+
+    describe('narrow mode (base 2) — first additional control is free, each one after reduces by 1', () => {
+        test('shows 2 with no additional controls', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Narrow, 0, false);
+            expect(controls).toHaveLength(2);
+            expect(controls).toEqual(['bold', 'italic']);
+            expect(hiddenControls).toHaveLength(7);
+        });
+
+        test('shows 2 with 1 additional control', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Narrow, 1, false);
+            expect(controls).toHaveLength(2);
+            expect(hiddenControls).toHaveLength(7);
+        });
+
+        test('shows 1 with 2 additional controls', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Narrow, 2, false);
+            expect(controls).toHaveLength(1);
+            expect(controls).toEqual(['bold']);
+            expect(hiddenControls).toHaveLength(8);
+        });
+
+        test('shows 0 with 3 additional controls', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Narrow, 3, false);
+            expect(controls).toHaveLength(0);
+            expect(hiddenControls).toHaveLength(9);
+        });
+    });
+
+    describe('min mode (base 1) — first additional control is free, each one after reduces by 1', () => {
+        test('shows 1 with no additional controls', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Min, 0, false);
+            expect(controls).toHaveLength(1);
+            expect(controls).toEqual(['bold']);
+            expect(hiddenControls).toHaveLength(8);
+        });
+
+        test('shows 0 with 2 additional controls', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Min, 2, false);
+            expect(controls).toHaveLength(0);
+            expect(hiddenControls).toHaveLength(9);
+        });
+    });
+
+    describe('RHS — each additional control reduces by 1 (tighter space, no free slot)', () => {
+        test('wide mode keeps all 9 regardless of additional controls', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Wide, 3, true);
+            expect(controls).toHaveLength(9);
+            expect(hiddenControls).toHaveLength(0);
+        });
+
+        test('normal with 1 additional shows 4', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Normal, 1, true);
+            expect(controls).toHaveLength(4);
+            expect(hiddenControls).toHaveLength(5);
+        });
+
+        test('normal with 2 additional shows 3', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Normal, 2, true);
+            expect(controls).toHaveLength(3);
+            expect(hiddenControls).toHaveLength(6);
+        });
+
+        test('normal with 3 additional shows 2', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Normal, 3, true);
+            expect(controls).toHaveLength(2);
+            expect(hiddenControls).toHaveLength(7);
+        });
+
+        test('narrow with 1 additional shows 1', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Narrow, 1, true);
+            expect(controls).toHaveLength(1);
+            expect(hiddenControls).toHaveLength(8);
+        });
+
+        test('narrow with 2 additional shows 0', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Narrow, 2, true);
+            expect(controls).toHaveLength(0);
+            expect(hiddenControls).toHaveLength(9);
+        });
+
+        test('min with 1 additional shows 0', () => {
+            const {controls, hiddenControls} = splitFormattingBarControls(LayoutModes.Min, 1, true);
+            expect(controls).toHaveLength(0);
+            expect(hiddenControls).toHaveLength(9);
+        });
+    });
+});

--- a/webapp/channels/src/components/advanced_text_editor/formatting_bar/hooks.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/formatting_bar/hooks.tsx
@@ -3,66 +3,105 @@
 
 import type {Instance} from '@popperjs/core';
 import debounce from 'lodash/debounce';
-import type React from 'react';
 import {useEffect, useLayoutEffect, useMemo, useState} from 'react';
 
 import type {MarkdownMode} from 'utils/markdown/apply_markdown';
 
-type WideMode = 'wide' | 'normal' | 'narrow' | 'min';
+export const LayoutModes = {
+    Wide: 'wide',
+    Normal: 'normal',
+    Narrow: 'narrow',
+    Min: 'min',
+} as const;
 
-const useResponsiveFormattingBar = (ref: React.RefObject<HTMLDivElement>): WideMode => {
-    const [wideMode, setWideMode] = useState<WideMode>('wide');
+type LayoutMode = typeof LayoutModes[keyof typeof LayoutModes];
+
+type Threshold = [minWidth: number, mode: LayoutMode];
+
+// Ordered descending — first match (width >= threshold) wins, fallback is 'min'.
+const THRESHOLDS_CENTER: Threshold[] = [
+    [641, LayoutModes.Wide],
+    [424, LayoutModes.Normal],
+    [310, LayoutModes.Narrow],
+];
+
+const THRESHOLDS_RHS: Threshold[] = [
+    [521, LayoutModes.Wide],
+    [380, LayoutModes.Normal],
+    [280, LayoutModes.Narrow],
+];
+
+const DEBOUNCE_DELAY = 10;
+
+function resolveLayoutMode(width: number, thresholds: Threshold[]): LayoutMode {
+    for (const [minWidth, mode] of thresholds) {
+        if (width >= minWidth) {
+            return mode;
+        }
+    }
+    return LayoutModes.Min;
+}
+
+function isRHSLocation(location: string): boolean {
+    return location.toLowerCase().includes('rhs');
+}
+
+const useResponsiveFormattingBar = (element: HTMLDivElement | null, isRHS: boolean): LayoutMode => {
+    const [layoutMode, setLayoutMode] = useState<LayoutMode>(LayoutModes.Wide);
+
     const handleResize = useMemo(() => debounce(() => {
-        if (ref.current?.clientWidth == null) {
+        if (!element) {
             return;
         }
-        if (ref.current.clientWidth > 640) {
-            setWideMode('wide');
-        }
-        if (ref.current.clientWidth >= 424 && ref.current.clientWidth <= 640) {
-            setWideMode('normal');
-        }
-        if (ref.current.clientWidth < 424) {
-            setWideMode('narrow');
-        }
-
-        if (ref.current.clientWidth < 310) {
-            setWideMode('min');
-        }
-    }, 10), [ref]);
+        const thresholds = isRHS ? THRESHOLDS_RHS : THRESHOLDS_CENTER;
+        setLayoutMode(resolveLayoutMode(element.clientWidth, thresholds));
+    }, DEBOUNCE_DELAY), [element, isRHS]);
 
     useLayoutEffect(() => {
-        if (!ref.current) {
+        if (!element) {
             return () => {};
         }
 
-        let sizeObserver: ResizeObserver | null = new ResizeObserver(handleResize);
-
-        sizeObserver.observe(ref.current);
+        const sizeObserver = new ResizeObserver(handleResize);
+        sizeObserver.observe(element);
 
         return () => {
-            sizeObserver!.disconnect();
-            sizeObserver = null;
+            handleResize.cancel();
+            sizeObserver.disconnect();
         };
-    }, [handleResize, ref]);
+    }, [handleResize, element]);
 
-    return wideMode;
+    return layoutMode;
 };
 
-const MAP_WIDE_MODE_TO_CONTROLS_QUANTITY: {[key in WideMode]: number} = {
-    wide: 9,
-    normal: 5,
-    narrow: 3,
-    min: 1,
+// Base icon counts for each mode (no additional controls)
+const CONTROLS_COUNT_BASE: Record<LayoutMode, number> = {
+    [LayoutModes.Wide]: 9,
+    [LayoutModes.Normal]: 5,
+    [LayoutModes.Narrow]: 2,
+    [LayoutModes.Min]: 1,
 };
 
-export function splitFormattingBarControls(wideMode: WideMode) {
-    const allControls: MarkdownMode[] = ['bold', 'italic', 'strike', 'heading', 'link', 'code', 'quote', 'ul', 'ol'];
+// All available formatting controls in priority order
+const ALL_CONTROLS: MarkdownMode[] = ['bold', 'italic', 'strike', 'heading', 'link', 'code', 'quote', 'ul', 'ol'];
 
-    const controlsLength = MAP_WIDE_MODE_TO_CONTROLS_QUANTITY[wideMode];
+// Wide layout always shows all icons — there is enough room regardless of additional controls.
+// Center channel: reduction starts from the 2nd additional control (1 extra always fits).
+// RHS: reduction starts from the 1st additional control (tighter space).
+function getVisibleControlsCount(layoutMode: LayoutMode, additionalControlsCount: number, isRHS: boolean): number {
+    const base = CONTROLS_COUNT_BASE[layoutMode];
+    if (layoutMode === LayoutModes.Wide) {
+        return base;
+    }
+    const reduction = isRHS ? additionalControlsCount : Math.max(0, additionalControlsCount - 1);
+    return Math.max(0, base - reduction);
+}
 
-    const controls = allControls.slice(0, controlsLength);
-    const hiddenControls = allControls.slice(controlsLength);
+export function splitFormattingBarControls(layoutMode: LayoutMode, additionalControlsCount: number = 0, isRHS: boolean = false) {
+    const visibleControlsCount = getVisibleControlsCount(layoutMode, additionalControlsCount, isRHS);
+
+    const controls = ALL_CONTROLS.slice(0, visibleControlsCount);
+    const hiddenControls = ALL_CONTROLS.slice(visibleControlsCount);
 
     return {
         controls,
@@ -71,35 +110,36 @@ export function splitFormattingBarControls(wideMode: WideMode) {
 }
 
 export const useFormattingBarControls = (
-    formattingBarRef: React.RefObject<HTMLDivElement>,
+    additionalControlsCount: number = 0,
+    location: string = '',
 ): {
-    controls: MarkdownMode[];
-    hiddenControls: MarkdownMode[];
-    wideMode: WideMode;
-} => {
-    const wideMode = useResponsiveFormattingBar(formattingBarRef);
+        formattingBarRef: (node: HTMLDivElement | null) => void;
+        controls: MarkdownMode[];
+        hiddenControls: MarkdownMode[];
+        layoutMode: LayoutMode;
+    } => {
+    const [element, setElement] = useState<HTMLDivElement | null>(null);
 
-    const {controls, hiddenControls} = splitFormattingBarControls(wideMode);
+    const isRHS = useMemo(() => isRHSLocation(location), [location]);
+    const layoutMode = useResponsiveFormattingBar(element, isRHS);
+
+    const {controls, hiddenControls} = useMemo(() => {
+        return splitFormattingBarControls(layoutMode, additionalControlsCount, isRHS);
+    }, [layoutMode, additionalControlsCount, isRHS]);
 
     return {
+        formattingBarRef: setElement,
         controls,
         hiddenControls,
-        wideMode,
+        layoutMode,
     };
 };
 
 export const useUpdateOnVisibilityChange = (update: Instance['update'] | null, isVisible: boolean) => {
-    const updateComponent = async () => {
-        if (!update) {
-            return;
-        }
-        await update();
-    };
-
     useEffect(() => {
-        if (!isVisible) {
+        if (!isVisible || !update) {
             return;
         }
-        updateComponent();
-    }, [isVisible]);
+        update();
+    }, [isVisible, update]);
 };

--- a/webapp/channels/src/components/apps_form/apps_form_component.tsx
+++ b/webapp/channels/src/components/apps_form/apps_form_component.tsx
@@ -536,9 +536,7 @@ export class AppsForm extends React.PureComponent<Props, State> {
         const bodyClass = loading ? 'apps-form-modal-body-loading' : 'apps-form-modal-body-loaded';
         const bodyClassNames = 'apps-form-modal-body-common ' + bodyClass;
 
-        // Apply modal-overflow only when date/time picker is open to allow calendar to escape modal bounds
-        // while preserving scroll containment when picker is closed
-        const dialogClassName = this.state.isInteracting ? 'a11y__modal about-modal modal-overflow' : 'a11y__modal about-modal';
+        const dialogClassName = 'a11y__modal about-modal';
         const hasDateTimeFields = this.hasDateTimeFields();
 
         return (

--- a/webapp/channels/src/components/date_picker/date_picker.tsx
+++ b/webapp/channels/src/components/date_picker/date_picker.tsx
@@ -37,6 +37,7 @@ const DatePicker = ({children, datePickerProps, isPopperOpen, handlePopperOpenSt
     const {x, y, strategy, context, refs: {setReference, setFloating}} = useFloating({
         open: isPopperOpen,
         onOpenChange: () => handlePopperOpenState(false),
+        strategy: 'fixed',
         placement: 'bottom-start',
         whileElementsMounted: autoUpdate,
         middleware: [

--- a/webapp/channels/src/components/pdf_preview.tsx
+++ b/webapp/channels/src/components/pdf_preview.tsx
@@ -6,11 +6,9 @@ import type {PDFDocumentProxy, PDFPageProxy} from 'pdfjs-dist';
 import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
 import 'pdfjs-dist/build/pdf.worker.min.mjs';
 import type {RenderParameters} from 'pdfjs-dist/types/src/display/api';
-import React from 'react';
+import React, {useRef, useState, memo, useEffect, useCallback} from 'react';
 
 import type {FileInfo} from '@mattermost/types/files';
-
-import {getFileDownloadUrl} from 'mattermost-redux/utils/file_utils';
 
 import FileInfoPreview from 'components/file_info_preview';
 import LoadingSpinner from 'components/widgets/loading/loading_spinner';
@@ -34,99 +32,115 @@ export type Props = {
     handleBgClose: (e: React.MouseEvent<Element, MouseEvent>) => void;
 }
 
-type State = {
-    pdf: PDFDocumentProxy | null;
-    pdfPages: Record<number, PDFPageProxy>;
-    pdfPagesLoaded: Record<number, boolean>;
-    numPages: number;
-    loading: boolean;
-    success: boolean;
-    prevFileUrl: string;
-}
+type Status = 'success' | 'loading' | 'fail';
 
-export default class PDFPreview extends React.PureComponent<Props, State> {
-    public pdfPagesRendered: Record<number, boolean>;
-    public container: React.RefObject<HTMLDivElement>;
-    public parentNode: HTMLElement|null = null;
-    public pdfCanvasRef: {[key: string]: React.RefObject<HTMLCanvasElement>} = {};
+const PDFPreview = memo(({
+    fileInfo,
+    fileUrl,
+    scale,
+    handleBgClose,
+}: Props) => {
+    const pdfPagesRendered = useRef<Record<number, boolean>>({});
+    const container = useRef<HTMLDivElement>(null);
+    const parentNode = useRef<HTMLElement | null>(null);
+    const pdfCanvasRef = useRef<{[key: string]: React.RefObject<HTMLCanvasElement>}>({});
 
-    constructor(props: Props) {
-        super(props);
+    const [pdfFromState, setPdfFromState] = useState<{
+        pdf: PDFDocumentProxy | null;
+        pages: Record<number, PDFPageProxy>;
+        pagesLoaded: Record<number, boolean>;
+        numPages: number;
+    }>({
+        pdf: null,
+        pages: {},
+        pagesLoaded: {},
+        numPages: 0,
+    });
 
-        this.pdfPagesRendered = {};
-        this.container = React.createRef();
+    const [status, setStatus] = useState<Status>('loading');
 
-        this.state = {
+    useEffect(() => {
+        setPdfFromState({
             pdf: null,
-            pdfPages: [],
-            pdfPagesLoaded: {},
+            pages: {},
+            pagesLoaded: {},
             numPages: 0,
-            loading: true,
-            success: false,
-            prevFileUrl: '',
+        });
+
+        setStatus('loading');
+
+        const onDocumentLoad = (pdf: PDFDocumentProxy) => {
+            setPdfFromState((prev) => {
+                return {
+                    ...prev,
+                    pdf,
+                    numPages: pdf.numPages,
+                };
+            });
+
+            for (let i = 0; i < pdf.numPages; i++) {
+                pdfCanvasRef.current[`pdfCanvasRef-${i}`] = React.createRef();
+            }
+
+            setStatus('success');
         };
-    }
 
-    componentDidMount() {
-        this.getPdfDocument();
-        if (this.container.current) {
-            this.parentNode = this.container.current.parentElement;
-            this.parentNode?.addEventListener('scroll', this.handleScroll);
+        const onDocumentLoadError = (reason: string) => {
+            console.log('Unable to load PDF preview: ' + reason); //eslint-disable-line no-console
+
+            setStatus('fail');
+        };
+
+        const getPdfDocument = async () => {
+            try {
+                const pdf = await pdfjsLib.getDocument({
+                    url: fileUrl,
+                    cMapUrl: getSiteURL() + '/static/cmaps/',
+                    cMapPacked: true,
+                }).promise;
+                onDocumentLoad(pdf);
+            } catch (err) {
+                onDocumentLoadError(String(err));
+            }
+        };
+
+        getPdfDocument();
+
+        /**
+         * This is already initialized to an empty object above, so on mount, it's set to the same
+         * initial empty object. Same for every update.
+         */
+        pdfPagesRendered.current = {};
+    }, [fileUrl]);
+
+    const loadPage = useCallback(async (pdf: PDFDocumentProxy, pageIndex: number) => {
+        if (pdfFromState.pagesLoaded[pageIndex]) {
+            return pdfFromState.pages[pageIndex];
         }
-    }
 
-    componentWillUnmount() {
-        if (this.parentNode) {
-            this.parentNode.removeEventListener('scroll', this.handleScroll);
-        }
-    }
+        const page = await pdf.getPage(pageIndex + 1);
 
-    static getDerivedStateFromProps(props: Props, state: State) {
-        if (props.fileUrl !== state.prevFileUrl) {
+        setPdfFromState((prev) => {
             return {
-                pdf: null,
-                pdfPages: {},
-                pdfPagesLoaded: {},
-                numPages: 0,
-                loading: true,
-                success: false,
-                prevFileUrl: props.fileUrl,
+                ...prev,
+                pages: {
+                    ...prev.pages,
+                    [pageIndex]: page,
+                },
+                pagesLoaded: {
+                    ...prev.pagesLoaded,
+                    [pageIndex]: true,
+                },
             };
-        }
-        return null;
-    }
+        });
 
-    componentDidUpdate(prevProps: Props, prevState: State) {
-        if (this.props.fileUrl !== prevProps.fileUrl) {
-            this.getPdfDocument();
-            this.pdfPagesRendered = {};
-        }
-        if (this.props.scale !== prevProps.scale) {
-            this.pdfPagesRendered = {};
-            if (this.state.success) {
-                for (let i = 0; i < this.state.numPages; i++) {
-                    this.renderPDFPage(i);
-                }
-            }
-        }
+        return page;
+    }, [pdfFromState.pages, pdfFromState.pagesLoaded]);
 
-        if (!prevState.success && this.state.success) {
-            for (let i = 0; i < this.state.numPages; i++) {
-                this.renderPDFPage(i);
-            }
-        }
-    }
-
-    downloadFile = (e: React.FormEvent) => {
-        const fileDownloadUrl = this.props.fileInfo.link || getFileDownloadUrl(this.props.fileInfo.id);
-        e.preventDefault();
-        window.location.href = fileDownloadUrl;
-    };
-
-    isInViewport = (page: Element) => {
+    const isInViewport = (page: Element) => {
         const bounding = page.getBoundingClientRect();
-        const viewportTop = this.container.current?.scrollTop ?? 0;
-        const viewportBottom = viewportTop + (this.parentNode?.clientHeight ?? 0);
+        const viewportTop = container.current?.scrollTop ?? 0;
+        const viewportBottom = viewportTop + (parentNode.current?.clientHeight ?? 0);
         return (
             (bounding.top >= viewportTop && bounding.top <= viewportBottom) ||
             (bounding.bottom >= viewportTop && bounding.bottom <= viewportBottom) ||
@@ -134,8 +148,8 @@ export default class PDFPreview extends React.PureComponent<Props, State> {
         );
     };
 
-    renderPDFPage = async (pageIndex: number) => {
-        const canvas = this.pdfCanvasRef[`pdfCanvasRef-${pageIndex}`].current;
+    const renderPDFPage = useCallback(async (pageIndex: number) => {
+        const canvas = pdfCanvasRef.current[`pdfCanvasRef-${pageIndex}`].current;
         if (!canvas) {
             // Refs are undefined when testing
             return;
@@ -143,17 +157,17 @@ export default class PDFPreview extends React.PureComponent<Props, State> {
 
         // Always render the first INITIAL_RENDERED_PAGES pages to avoid
         // problems detecting isInViewport during the open animation
-        if (pageIndex >= INITIAL_RENDERED_PAGES && !this.isInViewport(canvas)) {
+        if (pageIndex >= INITIAL_RENDERED_PAGES && !isInViewport(canvas)) {
             return;
         }
 
-        if (this.pdfPagesRendered[pageIndex]) {
+        if (pdfPagesRendered.current[pageIndex]) {
             return;
         }
 
-        const page = await this.loadPage(this.state.pdf!, pageIndex);
+        const page = await loadPage(pdfFromState.pdf!, pageIndex);
         const context = canvas.getContext('2d');
-        const viewport = page.getViewport({scale: this.props.scale});
+        const viewport = page.getViewport({scale});
         canvas.height = viewport.height;
         canvas.width = viewport.width;
 
@@ -163,108 +177,110 @@ export default class PDFPreview extends React.PureComponent<Props, State> {
         } as RenderParameters;
 
         await page.render(renderContext).promise;
-        this.pdfPagesRendered[pageIndex] = true;
-    };
+        pdfPagesRendered.current[pageIndex] = true;
+    }, [loadPage, pdfFromState.pdf, scale]);
 
-    getPdfDocument = async () => {
-        try {
-            const pdf = await pdfjsLib.getDocument({
-                url: this.props.fileUrl,
-                cMapUrl: getSiteURL() + '/static/cmaps/',
-                cMapPacked: true,
-            }).promise;
-            this.onDocumentLoad(pdf);
-        } catch (err) {
-            this.onDocumentLoadError(err);
-        }
-    };
+    useEffect(() => {
+        const handleScroll = debounce(() => {
+            if (status === 'success') {
+                for (let i = 0; i < pdfFromState.numPages; i++) {
+                    renderPDFPage(i);
+                }
+            }
+        }, 100);
 
-    onDocumentLoad = (pdf: PDFDocumentProxy) => {
-        this.setState({pdf, numPages: pdf.numPages});
-        for (let i = 0; i < pdf.numPages; i++) {
-            this.pdfCanvasRef[`pdfCanvasRef-${i}`] = React.createRef();
-        }
-        this.setState({loading: false, success: true});
-    };
-
-    onDocumentLoadError = (reason: string) => {
-        console.log('Unable to load PDF preview: ' + reason); //eslint-disable-line no-console
-        this.setState({loading: false, success: false});
-    };
-
-    loadPage = async (pdf: PDFDocumentProxy, pageIndex: number) => {
-        if (this.state.pdfPagesLoaded[pageIndex]) {
-            return this.state.pdfPages[pageIndex];
+        if (container.current) {
+            parentNode.current = container.current.parentElement;
+            parentNode.current?.addEventListener('scroll', handleScroll);
         }
 
-        const page = await pdf.getPage(pageIndex + 1);
+        return () => {
+            handleScroll.cancel();
 
-        const pdfPages = Object.assign({}, this.state.pdfPages);
-        pdfPages[pageIndex] = page;
+            if (parentNode.current) {
+                parentNode.current.removeEventListener('scroll', handleScroll);
+            }
+        };
+    }, [pdfFromState.numPages, renderPDFPage, status]);
 
-        const pdfPagesLoaded = Object.assign({}, this.state.pdfPagesLoaded);
-        pdfPagesLoaded[pageIndex] = true;
-        this.setState({pdfPages, pdfPagesLoaded});
+    const prevScale = useRef(scale);
+    useEffect(() => {
+        // Only re-render the pages when the user zooms in or out
+        if (scale === prevScale.current) {
+            return;
+        }
 
-        return page;
-    };
+        prevScale.current = scale;
 
-    handleScroll = debounce(() => {
-        if (this.state.success) {
-            for (let i = 0; i < this.state.numPages; i++) {
-                this.renderPDFPage(i);
+        pdfPagesRendered.current = {};
+
+        if (status === 'success') {
+            for (let i = 0; i < pdfFromState.numPages; i++) {
+                renderPDFPage(i);
             }
         }
-    }, 100);
+    }, [pdfFromState.numPages, renderPDFPage, scale, status]);
 
-    render() {
-        if (this.state.loading) {
-            return (
-                <div
-                    ref={this.container}
-                    className='view-image__loading'
-                >
-                    <LoadingSpinner/>
-                </div>
-            );
-        }
-
-        if (!this.state.success) {
-            return (
-                <FileInfoPreview
-                    fileInfo={this.props.fileInfo}
-                    fileUrl={this.props.fileUrl}
-                />
-            );
-        }
-
-        const pdfCanvases = [];
-        for (let i = 0; i < this.state.numPages; i++) {
-            pdfCanvases.push(
-                <canvas
-                    ref={this.pdfCanvasRef[`pdfCanvasRef-${i}`]}
-                    key={'previewpdfcanvas' + i}
-                />,
-            );
-
-            if (i < this.state.numPages - 1 && this.state.numPages > 1) {
-                pdfCanvases.push(
-                    <div
-                        key={'previewpdfspacer' + i}
-                        className='pdf-preview-spacer'
-                    />,
-                );
+    const prevStatus = useRef<Status>(status);
+    useEffect(() => {
+        if (prevStatus.current !== status && status === 'success') {
+            for (let i = 0; i < pdfFromState.numPages; i++) {
+                renderPDFPage(i);
             }
         }
 
+        prevStatus.current = status;
+    }, [pdfFromState.numPages, renderPDFPage, status]);
+
+    if (status === 'loading') {
         return (
             <div
-                ref={this.container}
-                className='post-code'
-                onClick={this.props.handleBgClose}
+                ref={container}
+                className='view-image__loading'
             >
-                {pdfCanvases}
+                <LoadingSpinner/>
             </div>
         );
     }
-}
+
+    if (status === 'fail') {
+        return (
+            <FileInfoPreview
+                fileInfo={fileInfo}
+                fileUrl={fileUrl}
+            />
+        );
+    }
+
+    const pdfCanvases = [];
+    for (let i = 0; i < pdfFromState.numPages; i++) {
+        pdfCanvases.push(
+            <canvas
+                ref={pdfCanvasRef.current[`pdfCanvasRef-${i}`]}
+                key={'previewpdfcanvas' + i}
+            />,
+        );
+
+        if (i < pdfFromState.numPages - 1 && pdfFromState.numPages > 1) {
+            pdfCanvases.push(
+                <div
+                    key={'previewpdfspacer' + i}
+                    className='pdf-preview-spacer'
+                />,
+            );
+        }
+    }
+
+    return (
+        <div
+            ref={container}
+            className='post-code'
+            data-testid='pdf-container'
+            onClick={handleBgClose}
+        >
+            {pdfCanvases}
+        </div>
+    );
+});
+
+export default PDFPreview;

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/users.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/users.test.ts
@@ -41,6 +41,8 @@ describe('Selectors.Users', () => {
     const user7 = TestHelper.fakeUserWithId();
     user7.delete_at = 1;
     user7.roles = 'system_admin system_user';
+    const user8 = TestHelper.fakeUserWithId();
+    user8.nickname = 'vertex_to_edge';
     const profiles: Record<string, UserProfile> = {};
     profiles[user1.id] = user1;
     profiles[user2.id] = user2;
@@ -49,6 +51,7 @@ describe('Selectors.Users', () => {
     profiles[user5.id] = user5;
     profiles[user6.id] = user6;
     profiles[user7.id] = user7;
+    profiles[user8.id] = user8;
 
     const profilesInTeam: Record<Team['id'], Set<UserProfile['id']>> = {};
     profilesInTeam[team1.id] = new Set([user1.id, user2.id, user7.id]);
@@ -75,7 +78,7 @@ describe('Selectors.Users', () => {
     profilesNotInTeam[team1.id] = new Set([user3.id, user4.id]);
 
     const profilesInChannel: Record<Channel['id'], Set<UserProfile['id']>> = {};
-    profilesInChannel[channel1.id] = new Set([user1.id]);
+    profilesInChannel[channel1.id] = new Set([user1.id, user8.id]);
     profilesInChannel[channel2.id] = new Set([user1.id, user2.id]);
 
     const membersInChannel: Record<Channel['id'], Record<UserProfile['id'], ChannelMembership>> = {};
@@ -84,6 +87,10 @@ describe('Selectors.Users', () => {
         ...TestHelper.fakeChannelMember(user1.id, channel1.id),
         scheme_user: true,
         scheme_admin: true,
+    };
+    membersInChannel[channel1.id][user8.id] = {
+        ...TestHelper.fakeChannelMember(user8.id, channel1.id),
+        scheme_user: true,
     };
     membersInChannel[channel2.id] = {};
     membersInChannel[channel2.id][user1.id] = {
@@ -264,7 +271,7 @@ describe('Selectors.Users', () => {
 
     describe('getProfiles', () => {
         it('getProfiles without filter', () => {
-            const users = [user1, user2, user3, user4, user5, user6, user7].sort(sortByUsername);
+            const users = [user1, user2, user3, user4, user5, user6, user7, user8].sort(sortByUsername);
             expect(Selectors.getProfiles(testState)).toEqual(users);
         });
 
@@ -277,7 +284,7 @@ describe('Selectors.Users', () => {
             expect(Selectors.getProfiles(testState, {inactive: true})).toEqual(users);
         });
         it('getProfiles with active', () => {
-            const users = [user1, user3, user4, user5, user6].sort(sortByUsername);
+            const users = [user1, user3, user4, user5, user6, user8].sort(sortByUsername);
             expect(Selectors.getProfiles(testState, {active: true})).toEqual(users);
         });
         it('getProfiles with multiple filters', () => {
@@ -465,6 +472,7 @@ describe('Selectors.Users', () => {
         expect(Selectors.searchProfilesInCurrentChannel(testState, user1.username)).toEqual([user1]);
         expect(Selectors.searchProfilesInCurrentChannel(testState, 'engineer at mattermost')).toEqual([user1]);
         expect(Selectors.searchProfilesInCurrentChannel(testState, user1.username, true)).toEqual([]);
+        expect(Selectors.searchProfilesInCurrentChannel(testState, 'to_edge', true)).toEqual([user8]);
     });
 
     it('searchProfilesNotInCurrentChannel', () => {
@@ -525,7 +533,7 @@ describe('Selectors.Users', () => {
 
     it('makeGetProfilesInChannel', () => {
         const getProfilesInChannel = Selectors.makeGetProfilesInChannel();
-        expect(getProfilesInChannel(testState, channel1.id)).toEqual([user1]);
+        expect(getProfilesInChannel(testState, channel1.id)).toEqual([user1, user8]);
 
         const users = [user1, user2].sort(sortByUsername);
         expect(getProfilesInChannel(testState, channel2.id)).toEqual(users);
@@ -555,8 +563,8 @@ describe('Selectors.Users', () => {
         };
 
         const getProfilesInChannel = Selectors.makeGetProfilesInChannel();
-        expect(getProfilesInChannel(state, channel1.id)).toEqual([user1]);
-        expect(getProfilesInChannel(state, channel1.id, {})).toEqual([user1]);
+        expect(getProfilesInChannel(state, channel1.id)).toEqual([user1, user8]);
+        expect(getProfilesInChannel(state, channel1.id, {})).toEqual([user1, user8]);
     });
 
     it('makeGetProfilesNotInChannel', () => {
@@ -874,7 +882,7 @@ describe('Selectors.Users', () => {
 
     describe('filterProfiles', () => {
         it('no filter, return all users', () => {
-            expect(Object.keys(Selectors.filterProfiles(profiles)).length).toEqual(7);
+            expect(Object.keys(Selectors.filterProfiles(profiles)).length).toEqual(8);
         });
 
         it('filter role', () => {
@@ -901,7 +909,7 @@ describe('Selectors.Users', () => {
             const filter = {
                 exclude_roles: ['system_admin'],
             };
-            expect(Object.keys(Selectors.filterProfiles(profiles, filter)).length).toEqual(4);
+            expect(Object.keys(Selectors.filterProfiles(profiles, filter)).length).toEqual(5);
         });
 
         it('exclude bots', () => {
@@ -920,7 +928,7 @@ describe('Selectors.Users', () => {
                 ...profiles,
                 [botUser.id]: botUser,
             };
-            expect(Object.keys(Selectors.filterProfiles(newProfiles, filter)).length).toEqual(7);
+            expect(Object.keys(Selectors.filterProfiles(newProfiles, filter)).length).toEqual(8);
         });
 
         it('filter inactive', () => {
@@ -934,7 +942,7 @@ describe('Selectors.Users', () => {
             const filter = {
                 active: true,
             };
-            expect(Object.keys(Selectors.filterProfiles(profiles, filter)).length).toEqual(5);
+            expect(Object.keys(Selectors.filterProfiles(profiles, filter)).length).toEqual(6);
         });
     });
 });

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/users.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/users.test.ts
@@ -28,21 +28,29 @@ describe('Selectors.Users', () => {
     const group2 = TestHelper.fakeGroupWithId('');
 
     const user1 = TestHelper.fakeUserWithId('');
+    user1.username = 'user1';
     user1.position = 'Software Engineer at Mattermost';
     user1.notify_props = {mention_keys: 'testkey1,testkey2'} as UserProfile['notify_props'];
     user1.roles = 'system_admin system_user';
     const user2 = TestHelper.fakeUserWithId();
+    user2.username = 'user2';
     user2.delete_at = 1;
     const user3 = TestHelper.fakeUserWithId();
+    user3.username = 'user3';
     const user4 = TestHelper.fakeUserWithId();
+    user4.username = 'user4';
     const user5 = TestHelper.fakeUserWithId();
+    user5.username = 'user5';
     const user6 = TestHelper.fakeUserWithId();
+    user6.username = 'user6';
     user6.roles = 'system_admin system_user';
     const user7 = TestHelper.fakeUserWithId();
+    user7.username = 'user7';
     user7.delete_at = 1;
     user7.roles = 'system_admin system_user';
     const user8 = TestHelper.fakeUserWithId();
-    user8.nickname = 'vertex_to_edge';
+    user8.username = 'user8';
+    user8.nickname = 'some.body';
     const profiles: Record<string, UserProfile> = {};
     profiles[user1.id] = user1;
     profiles[user2.id] = user2;
@@ -472,7 +480,7 @@ describe('Selectors.Users', () => {
         expect(Selectors.searchProfilesInCurrentChannel(testState, user1.username)).toEqual([user1]);
         expect(Selectors.searchProfilesInCurrentChannel(testState, 'engineer at mattermost')).toEqual([user1]);
         expect(Selectors.searchProfilesInCurrentChannel(testState, user1.username, true)).toEqual([]);
-        expect(Selectors.searchProfilesInCurrentChannel(testState, 'to_edge', true)).toEqual([user8]);
+        expect(Selectors.searchProfilesInCurrentChannel(testState, 'body', true)).toEqual([user8]);
     });
 
     it('searchProfilesNotInCurrentChannel', () => {

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/users.ts
@@ -510,7 +510,7 @@ export function makeSearchProfilesInChannel() {
 }
 
 export function searchProfilesInCurrentChannel(state: GlobalState, term: string, skipCurrent = false): UserProfile[] {
-    const profiles = filterProfilesStartingWithTerm(getProfilesInCurrentChannel(state), term);
+    const profiles = filterProfilesMatchingWithTerm(getProfilesInCurrentChannel(state), term);
 
     if (skipCurrent) {
         removeCurrentUserFromList(profiles, getCurrentUserId(state));

--- a/webapp/channels/src/sass/components/_apps-modal.scss
+++ b/webapp/channels/src/sass/components/_apps-modal.scss
@@ -5,21 +5,3 @@
         }
     }
 }
-
-// Apply modal-overflow behavior for date/datetime fields - same as DND modal
-// This needs to be global like the existing modal-overflow class
-.modal-overflow {
-    overflow: visible !important;
-
-    .modal-dialog {
-        overflow: visible !important;
-    }
-
-    .modal-content {
-        overflow: visible !important;
-    }
-
-    .modal-body {
-        overflow: visible !important;
-    }
-}


### PR DESCRIPTION
- Fix datepicker calendar overflow in AppsForm modal (#35437)
- MM-67158 - fix overlap in post actions menu (#35415)
- refactor(pdf_preview): migrate PDFPreview to function component (#33648)
- fix: allow substring matching when searching channel members (#35017)
- Fix flaky test for makeGetProfilesInChannel (#35765)
- docs: upstream sync 진행 (picked 5)

## 짚어둘 점 — flaky 테스트를 다음 커밋이 해소

`2dbaeb2ce8`(부분 문자열 검색)이 테스트 픽스처에 user8을 추가하면서 `makeGetProfilesInChannel` 2건이 정렬 불안정으로 실패했다. upstream도 같은 문제를 겪고 바로 다음 커밋 `dcb81f91df`에서 고정 username 부여로 해결했다. 오래된 순서를 지켜 둘 다 반영했고, 최종 상태는 기준선과 동일(실패 1건 = master 기존 부채)로 복귀했다.

## 날짜 표기 참고

`2dbaeb2ce8`(8bfa1ff09)은 ledger에 2026-03-25로 표기되지만 commit date 기준 2026-03-24 19:45 UTC로, 이번 배치의 정당한 구성원이다.

## 검증

- `users.test.ts` 66 통과 / 1 실패 = **master 기준선과 동일** (LockTeammateNameDisplay는 기존 부채)
- apps_form·date_picker·datetime_input·dnd 모달 144건 + 스냅샷 4건 통과
- advanced_text_editor 12 스위트 128건 통과 (신규 hooks.test.tsx 포함). advanced_text_editor.test.tsx 10건 실패는 master와 동일한 기존 부채(Lexical 에디터 divergence)
- pdf_preview + file_preview_modal 9 스위트 46건 + 스냅샷 26건 통과
- `check-types` 13건 = 기준선, 신규 0 / eslint 접촉 파일 exit 0
- playwright `tsc -b` 0건 / i18n 게이트 2종 exit 0

## 알려진 기존 실패 (우리 변경과 무관, master 재현 확인)

- `advanced_text_editor.test.tsx` 10건 — post_textbox testid 부재
- `users.test.ts` LockTeammateNameDisplay 1건
- `check-lint` 46개 파일