### PR TITLE
upstream sync 2026-03-25 일부 (picked 2, adapted 1)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,17 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-12 22:42
+- 갱신일: 2026-08-13 00:04
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
 - 남은 커밋: 906개
 
-**마지막 반영 커밋:** `cc66081f` | [Fix flaky test for makeGetProfilesInChannel (#35765)](https://github.com/mattermost/mattermost/commit/cc66081f6b6812a77158847d5270072313553287) | 2026-03-24
+**마지막 반영 커밋:** `4f16a29c` | [MM-67793: Remove dependency on blang/semver/v4 (#35742)](https://github.com/mattermost/mattermost/commit/4f16a29cb5e8bf4978763581602caa6012865091) | 2026-03-25
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 95e33dbc | [MM-63848: Enforce unique names for parent access control policies (#35676)](https://github.com/mattermost/mattermost/commit/95e33dbc7229a28d768ce1f5c4a14a673d0303a4) | 2026-03-25 |
-| 7d6d834f | [MM-68016, MM-68017, MM-68018 Add plugin pre-hooks for membership and channel archive (#35731)](https://github.com/mattermost/mattermost/commit/7d6d834f1f4feea8ecbf2eedf505cc76cbe62998) | 2026-03-25 |
-| 4f16a29c | [MM-67793: Remove dependency on blang/semver/v4 (#35742)](https://github.com/mattermost/mattermost/commit/4f16a29cb5e8bf4978763581602caa6012865091) | 2026-03-25 |
 | 8de0b366 | [ MM-63056 Migrate thread menu to new component and minor a11y tweaks (#33401)](https://github.com/mattermost/mattermost/commit/8de0b36639641e1459f21142380fe8deb2749c03) | 2026-03-25 |
 | b0c38bac | [Fix channel not found after creation on deployments with read replicas (#35728)](https://github.com/mattermost/mattermost/commit/b0c38bac0bab915a0b717c6dc356c9cd52b4f3b8) | 2026-03-25 |
 | 85dcb8b9 | [MM-67944: Add shared channel integration test tool  (#35639)](https://github.com/mattermost/mattermost/commit/85dcb8b9e7e89977584922709b74e597139d5f23) | 2026-03-25 |
@@ -917,6 +914,9 @@
 | 523292f0 | [Remove unused context import left behind by UserStore.Get migration (#37921)](https://github.com/mattermost/mattermost/commit/523292f0816a3a5ebc5f836d323a4d9beecc5860) | 2026-08-12 |
 | 46102626 | [MM-70151/MM-70152: fix slash commands in the WYSIWYG composer (#37880)](https://github.com/mattermost/mattermost/commit/46102626dbad7473f461307b7be4c98cd387bf4f) | 2026-08-12 |
 | 0fc1ff17 | [\[MM-69557\] Fix post actions menu not closing on outside click in mobile view (#37394)](https://github.com/mattermost/mattermost/commit/0fc1ff17c8a92a00c2694a059214d0b823db2a83) | 2026-08-12 |
+| 81d6d1ea | [Fix link preview image layout shift by using SizeAwareImage (#37357)](https://github.com/mattermost/mattermost/commit/81d6d1ea20c07d9394cb569e7dd4da546cfc56fe) | 2026-08-12 |
+| 929a2e9e | [\[MM-70106\] Prevent search startup bulk processor leaks (#37873)](https://github.com/mattermost/mattermost/commit/929a2e9e3f908c09b0582cea75433b2a482bc019) | 2026-08-12 |
+| 7a06c7ae | [\[MM-64357\] Fix ABAC policy editor unable to switch back to Simple Mode when a value contains an apostrophe (#37819)](https://github.com/mattermost/mattermost/commit/7a06c7ae5263a37e4916149b029619f1d7fd4b67) | 2026-08-12 |
 
 ## 제외된 커밋
 

--- a/e2e-tests/playwright/specs/functional/system_console/abac/policies/create_policies.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/policies/create_policies.spec.ts
@@ -365,4 +365,56 @@ test.describe('ABAC Policies - Create Policies', () => {
         const user3AfterSync = await verifyUserInChannel(adminClient, nonSatisfyingUserInChannel.id, privateChannel.id);
         expect(user3AfterSync).toBe(false); // AUTO-REMOVED
     });
+
+    /**
+     * MM-63848: Creating a policy with a name that already exists should show an error
+     */
+    test('MM-63848 Should show error when creating policy with duplicate name', async ({pw}) => {
+        await pw.skipIfNoLicense();
+
+        const {adminUser, adminClient, team} = await pw.initSetup();
+
+        await enableUserManagedAttributes(adminClient);
+
+        const departmentAttribute: CustomProfileAttribute[] = [{name: 'Department', type: 'text', value: ''}];
+        await setupCustomProfileAttributeFields(adminClient, departmentAttribute);
+
+        const privateChannel = await createPrivateChannelForABAC(adminClient, team.id);
+
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        const page = systemConsolePage.page;
+
+        await navigateToABACPage(page);
+        await enableABAC(page);
+
+        // Create the first policy
+        const policyName = `Duplicate Test ${await pw.random.id()}`;
+        await createBasicPolicy(page, {
+            name: policyName,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: false,
+            channels: [privateChannel.display_name],
+        });
+
+        // Navigate back and try to create another policy with the same name
+        await navigateToABACPage(page);
+
+        await createBasicPolicy(page, {
+            name: policyName,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Sales',
+            autoSync: false,
+            channels: [],
+        });
+
+        // Verify error message is shown
+        const errorMessage = page.locator('.EditPolicy__error');
+        await expect(errorMessage).toBeVisible({timeout: 5000});
+
+        const errorText = await errorMessage.textContent();
+        expect(errorText).toContain('A policy with this name already exists');
+    });
 });

--- a/e2e-tests/playwright/specs/functional/system_console/abac/policy_management/edit_policies.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/policy_management/edit_policies.spec.ts
@@ -814,4 +814,92 @@ test.describe('ABAC Policy Management - Edit Policies', () => {
         // Step 6: salesRemoteUser should NOT be in channel (never satisfied Dept requirement)
         expect(salesRemoteAfterEdit).toBe(false);
     });
+
+    /**
+     * MM-63848: Renaming a policy to a name that already exists should show an error
+     */
+    test('MM-63848 Should show error when renaming policy to an existing name', async ({pw}) => {
+        await pw.skipIfNoLicense();
+
+        const {adminUser, adminClient, team} = await pw.initSetup();
+
+        await enableUserManagedAttributes(adminClient);
+
+        const departmentAttribute: CustomProfileAttribute[] = [{name: 'Department', type: 'text', value: ''}];
+        await setupCustomProfileAttributeFields(adminClient, departmentAttribute);
+
+        const privateChannel = await createPrivateChannelForABAC(adminClient, team.id);
+
+        const {systemConsolePage} = await pw.testBrowser.login(adminUser);
+        const page = systemConsolePage.page;
+
+        await navigateToABACPage(page);
+        await enableABAC(page);
+
+        // Create two policies with different names
+        const policyName1 = `Edit Dup Test A ${await pw.random.id()}`;
+        await createBasicPolicy(page, {
+            name: policyName1,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Engineering',
+            autoSync: false,
+            channels: [privateChannel.display_name],
+        });
+
+        await navigateToABACPage(page);
+
+        const privateChannel2 = await createPrivateChannelForABAC(adminClient, team.id);
+        const policyName2 = `Edit Dup Test B ${await pw.random.id()}`;
+        await createBasicPolicy(page, {
+            name: policyName2,
+            attribute: 'Department',
+            operator: '==',
+            value: 'Sales',
+            autoSync: false,
+            channels: [privateChannel2.display_name],
+        });
+
+        // Navigate back and edit policy2's name to match policy1
+        await navigateToABACPage(page);
+        await page.waitForTimeout(1000);
+
+        // Search for the second policy
+        const policySearchInput = page.locator('input[placeholder*="Search" i]').first();
+        if (await policySearchInput.isVisible({timeout: 3000})) {
+            await policySearchInput.fill(policyName2);
+            await page.waitForTimeout(1000);
+        }
+
+        const policyRow = page.locator('tr.clickable, .DataGrid_row').filter({hasText: policyName2}).first();
+        await policyRow.waitFor({state: 'visible', timeout: 10000});
+        await policyRow.click();
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(1000);
+
+        // Change the name to match the first policy
+        const nameInput = page.locator('#admin\\.access_control\\.policy\\.edit_policy\\.policyName');
+        await nameInput.waitFor({state: 'visible', timeout: 10000});
+        await nameInput.fill('');
+        await nameInput.fill(policyName1);
+
+        // Save and expect failure
+        const saveButton = page.getByRole('button', {name: 'Save'});
+        await saveButton.click();
+        await page.waitForTimeout(2000);
+
+        // Handle confirmation modal if it appears
+        const applyPolicyButton = page.getByRole('button', {name: /apply policy/i});
+        if (await applyPolicyButton.isVisible({timeout: 3000}).catch(() => false)) {
+            await applyPolicyButton.click();
+            await page.waitForTimeout(2000);
+        }
+
+        // Verify error message is shown
+        const errorMessage = page.locator('.EditPolicy__error');
+        await expect(errorMessage).toBeVisible({timeout: 5000});
+
+        const errorText = await errorMessage.textContent();
+        expect(errorText).toContain('A policy with this name already exists');
+    });
 });

--- a/server/channels/api4/user.go
+++ b/server/channels/api4/user.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/blang/semver/v4"
+	"github.com/Masterminds/semver/v3"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 
@@ -2541,7 +2541,7 @@ func handleDeviceProps(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	mobileVersion := receivedProps[model.SessionPropMobileVersion]
 	if mobileVersion != "" {
-		if _, err := semver.Parse(mobileVersion); err != nil {
+		if _, err := semver.StrictNewVersion(mobileVersion); err != nil {
 			c.SetInvalidParam(model.SessionPropMobileVersion)
 			return
 		}

--- a/server/channels/app/agents.go
+++ b/server/channels/app/agents.go
@@ -6,7 +6,7 @@ package app
 import (
 	"net/http"
 
-	"github.com/blang/semver/v4"
+	"github.com/Masterminds/semver/v3"
 
 	agentclient "github.com/mattermost/mattermost-plugin-ai/public/bridgeclient"
 	"github.com/mattermost/mattermost/server/public/model"
@@ -45,7 +45,7 @@ func (a *App) GetAIPluginBridgeStatus(rctx request.CTX) (bool, string) {
 	plugins := pluginsEnvironment.Active()
 	for _, plugin := range plugins {
 		if plugin.Manifest != nil && plugin.Manifest.Id == aiPluginID {
-			pluginVersion, err := semver.Parse(plugin.Manifest.Version)
+			pluginVersion, err := semver.StrictNewVersion(plugin.Manifest.Version)
 			if err != nil {
 				rctx.Logger().Debug("AI plugin bridge not available - failed to parse plugin version",
 					mlog.String("plugin_id", aiPluginID),
@@ -55,12 +55,12 @@ func (a *App) GetAIPluginBridgeStatus(rctx request.CTX) (bool, string) {
 				return false, "app.agents.bridge.not_available.plugin_version_parse_failed"
 			}
 
-			minVersion, err := semver.Parse(minAIPluginVersionForBridge)
+			minVersion, err := semver.StrictNewVersion(minAIPluginVersionForBridge)
 			if err != nil {
 				return false, "app.agents.bridge.not_available.min_version_parse_failed"
 			}
 
-			if pluginVersion.LT(minVersion) {
+			if pluginVersion.LessThan(minVersion) {
 				rctx.Logger().Debug("AI plugin bridge not available - plugin version is too old",
 					mlog.String("plugin_id", aiPluginID),
 					mlog.String("current_version", plugin.Manifest.Version),

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -1745,6 +1745,18 @@ func (a *App) DeleteChannel(rctx request.CTX, channel *model.Channel, userID str
 		return err
 	}
 
+	var archiveRejectionReason string
+	pluginContext := pluginContext(rctx)
+	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
+		archiveRejectionReason = hooks.ChannelWillBeArchived(pluginContext, channel)
+		return archiveRejectionReason == ""
+	}, plugin.ChannelWillBeArchivedID)
+
+	if archiveRejectionReason != "" {
+		return model.NewAppError("DeleteChannel", "app.channel.delete_channel.rejected_by_plugin",
+			map[string]any{"Reason": archiveRejectionReason}, "", http.StatusBadRequest)
+	}
+
 	if user != nil {
 		T := i18n.GetUserTranslations(user.Locale)
 
@@ -1895,6 +1907,25 @@ func (a *App) addUserToChannel(rctx request.CTX, user *model.User, channel *mode
 		} else if appErr != nil {
 			return nil, appErr
 		}
+	}
+
+	var rejectionReason string
+	pluginContext := pluginContext(rctx)
+	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
+		updatedMember, reason := hooks.ChannelMemberWillBeAdded(pluginContext, newMember)
+		if reason != "" {
+			rejectionReason = reason
+			return false
+		}
+		if updatedMember != nil {
+			newMember = updatedMember
+		}
+		return true
+	}, plugin.ChannelMemberWillBeAddedID)
+
+	if rejectionReason != "" {
+		return nil, model.NewAppError("AddUserToChannel", "app.channel.add_user.to.channel.rejected_by_plugin",
+			map[string]any{"Reason": rejectionReason}, "", http.StatusBadRequest)
 	}
 
 	newMember, nErr = a.Srv().Store().Channel().SaveMember(rctx, newMember)

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/blang/semver/v4"
+	"github.com/Masterminds/semver/v3"
 	svg "github.com/h2non/go-is-svg"
 	"github.com/pkg/errors"
 
@@ -687,18 +687,18 @@ func (a *App) mergePrepackagedPlugins(remoteMarketplacePlugins map[string]*model
 		}
 
 		// If available in the marketplace, only overwrite if newer.
-		prepackagedVersion, err := semver.Parse(prepackaged.Manifest.Version)
+		prepackagedVersion, err := semver.StrictNewVersion(prepackaged.Manifest.Version)
 		if err != nil {
 			return model.NewAppError("mergePrepackagedPlugins", "app.plugin.invalid_version.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 		}
 
 		marketplacePlugin := remoteMarketplacePlugins[prepackaged.Manifest.Id]
-		marketplaceVersion, err := semver.Parse(marketplacePlugin.Manifest.Version)
+		marketplaceVersion, err := semver.StrictNewVersion(marketplacePlugin.Manifest.Version)
 		if err != nil {
 			return model.NewAppError("mergePrepackagedPlugins", "app.plugin.invalid_version.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 		}
 
-		if prepackagedVersion.GT(marketplaceVersion) {
+		if prepackagedVersion.GreaterThan(marketplaceVersion) {
 			remoteMarketplacePlugins[prepackaged.Manifest.Id] = prepackagedMarketplace
 		}
 	}
@@ -1075,7 +1075,7 @@ func (ch *Channels) shouldPersistTransitionallyPrepackagedPlugin(availablePlugin
 		return true
 	}
 
-	prepackagedVersion, err := semver.Parse(p.Manifest.Version)
+	prepackagedVersion, err := semver.StrictNewVersion(p.Manifest.Version)
 	if err != nil {
 		logger.Error("Should not persist transitionally prepackged plugin: invalid prepackaged version", mlog.Err(err))
 		return false
@@ -1083,14 +1083,14 @@ func (ch *Channels) shouldPersistTransitionallyPrepackagedPlugin(availablePlugin
 
 	logger = logger.With(mlog.String("existing_version", existing.Manifest.Version))
 
-	existingVersion, err := semver.Parse(existing.Manifest.Version)
+	existingVersion, err := semver.StrictNewVersion(existing.Manifest.Version)
 	if err != nil {
 		// Consider this an old version and replace with the prepackaged version instead.
 		logger.Warn("Should persist transitionally prepackged plugin: invalid existing version", mlog.Err(err))
 		return true
 	}
 
-	if prepackagedVersion.GT(existingVersion) {
+	if prepackagedVersion.GreaterThan(existingVersion) {
 		logger.Info("Should persist transitionally prepackged plugin: newer version")
 		return true
 	}

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -2306,3 +2306,429 @@ func TestUserHasJoinedChannel(t *testing.T) {
 		}
 	})
 }
+
+func TestHookChannelMemberWillBeAdded(t *testing.T) {
+	mainHelper.Parallel(t)
+	t.Run("rejected", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) ChannelMemberWillBeAdded(c *plugin.Context, channelMember *model.ChannelMember) (*model.ChannelMember, string) {
+				return nil, "not allowed"
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		user := th.CreateUser(t)
+		_, _, appErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, user.Id, "")
+		require.Nil(t, appErr)
+
+		_, appErr = th.App.AddChannelMember(th.Context, user.Id, th.BasicChannel, ChannelMemberOpts{})
+		require.NotNil(t, appErr)
+		assert.Contains(t, appErr.Id, "rejected_by_plugin")
+	})
+
+	t.Run("modified", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) ChannelMemberWillBeAdded(c *plugin.Context, channelMember *model.ChannelMember) (*model.ChannelMember, string) {
+				channelMember.NotifyProps = model.GetDefaultChannelNotifyProps()
+				channelMember.NotifyProps[model.DesktopNotifyProp] = model.ChannelNotifyAll
+				return channelMember, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		user := th.CreateUser(t)
+		_, _, appErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, user.Id, "")
+		require.Nil(t, appErr)
+
+		member, appErr := th.App.AddChannelMember(th.Context, user.Id, th.BasicChannel, ChannelMemberOpts{})
+		require.Nil(t, appErr)
+		assert.Equal(t, model.ChannelNotifyAll, member.NotifyProps[model.DesktopNotifyProp])
+	})
+
+	t.Run("allowed", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) ChannelMemberWillBeAdded(c *plugin.Context, channelMember *model.ChannelMember) (*model.ChannelMember, string) {
+				return nil, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		user := th.CreateUser(t)
+		_, _, appErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, user.Id, "")
+		require.Nil(t, appErr)
+
+		member, appErr := th.App.AddChannelMember(th.Context, user.Id, th.BasicChannel, ChannelMemberOpts{})
+		require.Nil(t, appErr)
+		assert.Equal(t, th.BasicChannel.Id, member.ChannelId)
+		assert.Equal(t, user.Id, member.UserId)
+	})
+}
+
+func TestHookTeamMemberWillBeAdded(t *testing.T) {
+	mainHelper.Parallel(t)
+	t.Run("rejected", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) TeamMemberWillBeAdded(c *plugin.Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+				return nil, "not allowed"
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		user := th.CreateUser(t)
+		team := th.CreateTeam(t)
+
+		_, appErr := th.App.JoinUserToTeam(th.Context, team, user, "")
+		require.NotNil(t, appErr)
+		assert.Contains(t, appErr.Id, "rejected_by_plugin")
+	})
+
+	t.Run("modified", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) TeamMemberWillBeAdded(c *plugin.Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+				teamMember.SchemeAdmin = true
+				return teamMember, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		user := th.CreateUser(t)
+		team := th.CreateTeam(t)
+
+		member, appErr := th.App.JoinUserToTeam(th.Context, team, user, "")
+		require.Nil(t, appErr)
+		assert.True(t, member.SchemeAdmin)
+	})
+
+	t.Run("allowed", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) TeamMemberWillBeAdded(c *plugin.Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+				return nil, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		user := th.CreateUser(t)
+		team := th.CreateTeam(t)
+
+		member, appErr := th.App.JoinUserToTeam(th.Context, team, user, "")
+		require.Nil(t, appErr)
+		assert.Equal(t, team.Id, member.TeamId)
+		assert.Equal(t, user.Id, member.UserId)
+	})
+
+	t.Run("already active member skips hook", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) TeamMemberWillBeAdded(c *plugin.Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+				return nil, "should not fire for existing member"
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		// BasicUser is already a member of BasicTeam via InitBasic
+		member, appErr := th.App.JoinUserToTeam(th.Context, th.BasicTeam, th.BasicUser, "")
+		require.Nil(t, appErr)
+		assert.Equal(t, th.BasicTeam.Id, member.TeamId)
+	})
+
+	t.Run("re-join after leaving applies hook", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) TeamMemberWillBeAdded(c *plugin.Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+				teamMember.SchemeAdmin = true
+				return teamMember, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		user := th.CreateUser(t)
+		team := th.CreateTeam(t)
+
+		// First join
+		_, appErr := th.App.JoinUserToTeam(th.Context, team, user, "")
+		require.Nil(t, appErr)
+
+		// Leave
+		err := th.App.LeaveTeam(th.Context, team, user, "")
+		require.Nil(t, err)
+
+		// Re-join — hook should fire on the re-add path
+		member, appErr := th.App.JoinUserToTeam(th.Context, team, user, "")
+		require.Nil(t, appErr)
+		assert.True(t, member.SchemeAdmin)
+	})
+
+	t.Run("CreateTeamWithUser rejected by hook", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) TeamMemberWillBeAdded(c *plugin.Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+				return nil, "team join blocked"
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		team := &model.Team{
+			DisplayName: "Test Team",
+			Name:        "test-team-" + model.NewId()[:8],
+			Type:        model.TeamOpen,
+		}
+		_, appErr := th.App.CreateTeamWithUser(th.Context, team, th.BasicUser.Id)
+		require.NotNil(t, appErr)
+		assert.Contains(t, appErr.Id, "rejected_by_plugin")
+	})
+}
+
+func TestHookChannelWillBeArchived(t *testing.T) {
+	mainHelper.Parallel(t)
+	t.Run("rejected", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) ChannelWillBeArchived(c *plugin.Context, channel *model.Channel) string {
+				return "archive not permitted"
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		appErr := th.App.DeleteChannel(th.Context, th.BasicChannel, th.BasicUser.Id)
+		require.NotNil(t, appErr)
+		assert.Contains(t, appErr.Id, "rejected_by_plugin")
+
+		// Verify channel was NOT archived
+		ch, err := th.App.GetChannel(th.Context, th.BasicChannel.Id)
+		require.Nil(t, err)
+		assert.Equal(t, int64(0), ch.DeleteAt)
+	})
+
+	t.Run("allowed", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) ChannelWillBeArchived(c *plugin.Context, channel *model.Channel) string {
+				return ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		appErr := th.App.DeleteChannel(th.Context, th.BasicChannel, th.BasicUser.Id)
+		require.Nil(t, appErr)
+
+		// Verify channel was archived
+		ch, err := th.App.GetChannel(th.Context, th.BasicChannel.Id)
+		require.Nil(t, err)
+		assert.NotEqual(t, int64(0), ch.DeleteAt)
+	})
+}

--- a/server/channels/app/plugin_install.go
+++ b/server/channels/app/plugin_install.go
@@ -81,7 +81,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/blang/semver/v4"
+	"github.com/Masterminds/semver/v3"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
@@ -301,21 +301,21 @@ func (ch *Channels) InstallMarketplacePlugin(request *model.InstallMarketplacePl
 		}
 
 		if plugin != nil {
-			var prepackagedVersion semver.Version
+			prepackagedVersion, _ := semver.StrictNewVersion("0.0.0")
 			if prepackagedPlugin != nil {
 				var err error
-				prepackagedVersion, err = semver.Parse(prepackagedPlugin.Manifest.Version)
+				prepackagedVersion, err = semver.StrictNewVersion(prepackagedPlugin.Manifest.Version)
 				if err != nil {
 					return nil, model.NewAppError("InstallMarketplacePlugin", "app.plugin.invalid_version.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 				}
 			}
 
-			marketplaceVersion, err := semver.Parse(plugin.Manifest.Version)
+			marketplaceVersion, err := semver.StrictNewVersion(plugin.Manifest.Version)
 			if err != nil {
 				return nil, model.NewAppError("InstallMarketplacePlugin", "app.prepackged-plugin.invalid_version.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 			}
 
-			if prepackagedVersion.LT(marketplaceVersion) { // Always true if no prepackaged plugin was found
+			if prepackagedVersion.LessThan(marketplaceVersion) { // Always true if no prepackaged plugin was found
 				logger.Debug("Found upgraded plugin from remote marketplace", mlog.String("version", plugin.Manifest.Version), mlog.String("download_url", plugin.DownloadURL))
 
 				downloadedPluginBytes, err := ch.srv.downloadFromURL(plugin.DownloadURL)
@@ -462,19 +462,17 @@ func (ch *Channels) installExtractedPlugin(manifest *model.Manifest, fromPluginD
 
 		// Skip installation if already installed and newer.
 		if installationStrategy == installPluginLocallyOnlyIfNewOrUpgrade {
-			var version, existingVersion semver.Version
-
-			version, err = semver.Parse(manifest.Version)
-			if err != nil {
-				return nil, model.NewAppError("installExtractedPlugin", "app.plugin.invalid_version.app_error", nil, "", http.StatusBadRequest).Wrap(err)
+			version, vErr := semver.StrictNewVersion(manifest.Version)
+			if vErr != nil {
+				return nil, model.NewAppError("installExtractedPlugin", "app.plugin.invalid_version.app_error", nil, "", http.StatusBadRequest).Wrap(vErr)
 			}
 
-			existingVersion, err = semver.Parse(existingManifest.Version)
-			if err != nil {
-				return nil, model.NewAppError("installExtractedPlugin", "app.plugin.invalid_version.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+			existingVersion, vErr := semver.StrictNewVersion(existingManifest.Version)
+			if vErr != nil {
+				return nil, model.NewAppError("installExtractedPlugin", "app.plugin.invalid_version.app_error", nil, "", http.StatusInternalServerError).Wrap(vErr)
 			}
 
-			if version.LTE(existingVersion) {
+			if version.LessThanEqual(existingVersion) {
 				logger.Warn("Skipping local installation of plugin since not a newer version", mlog.String("version", version.String()), mlog.String("existing_version", existingVersion.String()))
 				return nil, model.NewAppError("installExtractedPlugin", "app.plugin.skip_installation.app_error", map[string]any{"Id": manifest.Id}, "", http.StatusInternalServerError)
 			}

--- a/server/channels/app/team.go
+++ b/server/channels/app/team.go
@@ -771,7 +771,28 @@ func (a *App) AddUserToTeamByInviteId(rctx request.CTX, inviteId string, userID 
 }
 
 func (a *App) JoinUserToTeam(rctx request.CTX, team *model.Team, user *model.User, userRequestorId string) (*model.TeamMember, *model.AppError) {
-	teamMember, alreadyAdded, err := a.ch.srv.teamService.JoinUserToTeam(rctx, team, user)
+	preSaveHook := func(tm *model.TeamMember) (*model.TeamMember, error) {
+		var rejectionReason string
+		pluginContext := pluginContext(rctx)
+		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
+			updatedMember, reason := hooks.TeamMemberWillBeAdded(pluginContext, tm)
+			if reason != "" {
+				rejectionReason = reason
+				return false
+			}
+			if updatedMember != nil {
+				tm = updatedMember
+			}
+			return true
+		}, plugin.TeamMemberWillBeAddedID)
+		if rejectionReason != "" {
+			return nil, model.NewAppError("JoinUserToTeam", "app.team.join_user_to_team.rejected_by_plugin",
+				map[string]any{"Reason": rejectionReason}, "", http.StatusBadRequest)
+		}
+		return tm, nil
+	}
+
+	teamMember, alreadyAdded, err := a.ch.srv.teamService.JoinUserToTeam(rctx, team, user, preSaveHook)
 	if err != nil {
 		var appErr *model.AppError
 		var conflictErr *store.ErrConflict

--- a/server/channels/app/teams/teams.go
+++ b/server/channels/app/teams/teams.go
@@ -4,6 +4,8 @@
 package teams
 
 import (
+	"fmt"
+
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/i18n"
 	"github.com/mattermost/mattermost/server/public/shared/request"
@@ -132,11 +134,28 @@ func (ts *TeamService) PatchTeam(teamID string, patch *model.TeamPatch) (*model.
 	return team, nil
 }
 
+func applyPreSaveHooks(hooks []func(*model.TeamMember) (*model.TeamMember, error), tm *model.TeamMember) (*model.TeamMember, error) {
+	for _, hook := range hooks {
+		var err error
+		tm, err = hook(tm)
+		if err != nil {
+			return nil, err
+		}
+		if tm == nil {
+			return nil, fmt.Errorf("preSaveHook returned nil TeamMember without error")
+		}
+	}
+	return tm, nil
+}
+
 // JoinUserToTeam adds a user to the team and it returns three values:
 // 1. a pointer to the team member, if successful
 // 2. a boolean: true if the user has a non-deleted team member for that team already, otherwise false.
 // 3. a pointer to an AppError if something went wrong.
-func (ts *TeamService) JoinUserToTeam(rctx request.CTX, team *model.Team, user *model.User) (*model.TeamMember, bool, error) {
+//
+// An optional preSaveHook can be provided to inspect/modify the TeamMember before it is persisted.
+// If the hook returns an error, the addition is rejected.
+func (ts *TeamService) JoinUserToTeam(rctx request.CTX, team *model.Team, user *model.User, preSaveHooks ...func(*model.TeamMember) (*model.TeamMember, error)) (*model.TeamMember, bool, error) {
 	if !ts.IsTeamEmailAllowed(user, team) {
 		return nil, false, AcceptedDomainError
 	}
@@ -164,6 +183,11 @@ func (ts *TeamService) JoinUserToTeam(rctx request.CTX, team *model.Team, user *
 	rtm, err := ts.store.GetMember(rctx, team.Id, user.Id)
 	if err != nil {
 		// Membership appears to be missing. Lets try to add.
+		tm, err = applyPreSaveHooks(preSaveHooks, tm)
+		if err != nil {
+			return nil, false, err
+		}
+
 		tmr, nErr := ts.store.SaveMember(rctx, tm, *ts.config().TeamSettings.MaxUsersPerTeam)
 		if nErr != nil {
 			return nil, false, nErr
@@ -184,6 +208,11 @@ func (ts *TeamService) JoinUserToTeam(rctx request.CTX, team *model.Team, user *
 
 	if membersCount >= int64(*ts.config().TeamSettings.MaxUsersPerTeam) {
 		return nil, false, MaxMemberCountError
+	}
+
+	tm, err = applyPreSaveHooks(preSaveHooks, tm)
+	if err != nil {
+		return nil, false, err
 	}
 
 	member, nErr := ts.store.UpdateMember(rctx, tm)

--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -325,3 +325,5 @@ channels/db/migrations/postgres/000162_backfill_roles_schemeid.down.sql
 channels/db/migrations/postgres/000162_backfill_roles_schemeid.up.sql
 channels/db/migrations/postgres/000163_add_roles_schemeid_index.down.sql
 channels/db/migrations/postgres/000163_add_roles_schemeid_index.up.sql
+channels/db/migrations/postgres/000164_deduplicate_policy_names.down.sql
+channels/db/migrations/postgres/000164_deduplicate_policy_names.up.sql

--- a/server/channels/db/migrations/postgres/000164_deduplicate_policy_names.down.sql
+++ b/server/channels/db/migrations/postgres/000164_deduplicate_policy_names.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_accesscontrolpolicies_name_type;
+-- Name deduplication cannot be reliably reversed.

--- a/server/channels/db/migrations/postgres/000164_deduplicate_policy_names.up.sql
+++ b/server/channels/db/migrations/postgres/000164_deduplicate_policy_names.up.sql
@@ -1,0 +1,13 @@
+-- Deduplicate parent policy names before adding unique constraint.
+-- The oldest policy (by CreateAt) keeps its original name; duplicates get ' (<id>)' appended.
+UPDATE AccessControlPolicies AS p
+SET Name = LEFT(p.Name, 128 - LENGTH(' (' || p.ID || ')')) || ' (' || p.ID || ')'
+FROM (
+    SELECT ID, Name, ROW_NUMBER() OVER (PARTITION BY Name ORDER BY CreateAt ASC) AS rn
+    FROM AccessControlPolicies
+    WHERE Type = 'parent'
+) AS dupes
+WHERE p.ID = dupes.ID
+  AND dupes.rn > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_accesscontrolpolicies_name_type ON AccessControlPolicies (Name, Type) WHERE Type = 'parent';

--- a/server/channels/store/sqlstore/access_control_policy_store.go
+++ b/server/channels/store/sqlstore/access_control_policy_store.go
@@ -209,10 +209,27 @@ func (s *SqlAccessControlPolicyStore) Save(rctx request.CTX, policy *model.Acces
 		}
 
 		// Check if the policy has actually changed
-		// We compare data, name, and version fields, and ensure type hasn't changed
+		// We compare data and version fields. Name changes are cosmetic
+		// and should not create a new revision in history.
 		if bytes.Equal(storePolicy.Data, tmp.Data) &&
-			storePolicy.Name == tmp.Name &&
 			storePolicy.Version == tmp.Version {
+			// Update name in place if it changed, without bumping revision
+			if storePolicy.Name != tmp.Name {
+				nameUpdate := s.getQueryBuilder().
+					Update("AccessControlPolicies").
+					Set("Name", storePolicy.Name).
+					Where(sq.Eq{"ID": policy.ID})
+				if _, err = tx.ExecBuilder(nameUpdate); err != nil {
+					if IsUniqueConstraintError(err, []string{"Name", "idx_accesscontrolpolicies_name_type"}) {
+						return nil, store.NewErrConflict("AccessControlPolicy", err, "name="+policy.Name)
+					}
+					return nil, errors.Wrapf(err, "failed to update name for policy with id=%s", policy.ID)
+				}
+				existingPolicy.Name = storePolicy.Name
+				if err = tx.Commit(); err != nil {
+					return nil, errors.Wrap(err, "commit_transaction")
+				}
+			}
 			return existingPolicy, nil
 		}
 
@@ -255,6 +272,9 @@ func (s *SqlAccessControlPolicyStore) Save(rctx request.CTX, policy *model.Acces
 
 	_, err = tx.ExecBuilder(query)
 	if err != nil {
+		if IsUniqueConstraintError(err, []string{"Name", "idx_accesscontrolpolicies_name_type"}) {
+			return nil, store.NewErrConflict("AccessControlPolicy", err, "name="+policy.Name)
+		}
 		return nil, errors.Wrapf(err, "failed to save policy with id=%s", policy.ID)
 	}
 

--- a/server/channels/store/storetest/access_control_policy_store.go
+++ b/server/channels/store/storetest/access_control_policy_store.go
@@ -15,6 +15,7 @@ import (
 
 func TestAccessControlPolicyStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
 	t.Run("Save", func(t *testing.T) { testAccessControlPolicyStoreSaveAndGet(t, rctx, ss) })
+	t.Run("SaveDuplicateName", func(t *testing.T) { testAccessControlPolicyStoreSaveDuplicateName(t, rctx, ss) })
 	t.Run("Delete", func(t *testing.T) { testAccessControlPolicyStoreDelete(t, rctx, ss) })
 	t.Run("SetActive", func(t *testing.T) { testAccessControlPolicyStoreSetActive(t, rctx, ss) })
 	t.Run("SetActiveMultiple", func(t *testing.T) { testAccessControlPolicyStoreSetActiveMultiple(t, rctx, ss) })
@@ -27,7 +28,7 @@ func testAccessControlPolicyStoreSaveAndGet(t *testing.T, rctx request.CTX, ss s
 	t.Run("Save parent policy", func(t *testing.T) {
 		policy := &model.AccessControlPolicy{
 			ID:       model.NewId(),
-			Name:     "Name",
+			Name:     "Save Parent " + model.NewId(),
 			Type:     model.AccessControlPolicyTypeParent,
 			Active:   true,
 			Revision: 1,
@@ -133,11 +134,245 @@ func testAccessControlPolicyStoreSaveAndGet(t *testing.T, rctx request.CTX, ss s
 	})
 }
 
+func testAccessControlPolicyStoreSaveDuplicateName(t *testing.T, rctx request.CTX, ss store.Store) {
+	t.Run("Duplicate parent policy name should fail", func(t *testing.T) {
+		policy1 := &model.AccessControlPolicy{
+			ID:       model.NewId(),
+			Name:     "Unique Policy Name",
+			Type:     model.AccessControlPolicyTypeParent,
+			Active:   true,
+			Revision: 1,
+			Version:  model.AccessControlPolicyVersionV0_2,
+			Imports:  []string{},
+			Rules: []model.AccessControlPolicyRule{
+				{
+					Actions:    []string{"action"},
+					Expression: "user.properties.program == \"engineering\"",
+				},
+			},
+		}
+
+		policy1, err := ss.AccessControlPolicy().Save(rctx, policy1)
+		require.NoError(t, err)
+		require.NotNil(t, policy1)
+
+		t.Cleanup(func() {
+			deleteErr := ss.AccessControlPolicy().Delete(rctx, policy1.ID)
+			require.NoError(t, deleteErr)
+		})
+
+		policy2 := &model.AccessControlPolicy{
+			ID:       model.NewId(),
+			Name:     "Unique Policy Name",
+			Type:     model.AccessControlPolicyTypeParent,
+			Active:   true,
+			Revision: 1,
+			Version:  model.AccessControlPolicyVersionV0_2,
+			Imports:  []string{},
+			Rules: []model.AccessControlPolicyRule{
+				{
+					Actions:    []string{"action"},
+					Expression: "user.properties.department == \"sales\"",
+				},
+			},
+		}
+
+		_, err = ss.AccessControlPolicy().Save(rctx, policy2)
+		require.Error(t, err)
+		var conflictErr *store.ErrConflict
+		require.ErrorAs(t, err, &conflictErr)
+	})
+
+	t.Run("Same name across different types should succeed", func(t *testing.T) {
+		parentPolicy := &model.AccessControlPolicy{
+			ID:       model.NewId(),
+			Name:     "Cross Type Name",
+			Type:     model.AccessControlPolicyTypeParent,
+			Active:   true,
+			Revision: 1,
+			Version:  model.AccessControlPolicyVersionV0_2,
+			Imports:  []string{},
+			Rules: []model.AccessControlPolicyRule{
+				{
+					Actions:    []string{"action"},
+					Expression: "user.properties.program == \"engineering\"",
+				},
+			},
+		}
+
+		parentPolicy, err := ss.AccessControlPolicy().Save(rctx, parentPolicy)
+		require.NoError(t, err)
+		require.NotNil(t, parentPolicy)
+
+		t.Cleanup(func() {
+			deleteErr := ss.AccessControlPolicy().Delete(rctx, parentPolicy.ID)
+			require.NoError(t, deleteErr)
+		})
+
+		channelPolicy := &model.AccessControlPolicy{
+			ID:       model.NewId(),
+			Name:     "Cross Type Name",
+			Type:     model.AccessControlPolicyTypeChannel,
+			Active:   true,
+			Revision: 1,
+			Version:  model.AccessControlPolicyVersionV0_2,
+			Imports:  []string{},
+			Rules: []model.AccessControlPolicyRule{
+				{
+					Actions:    []string{"action"},
+					Expression: "user.properties.program == \"engineering\"",
+				},
+			},
+		}
+
+		channelPolicy, err = ss.AccessControlPolicy().Save(rctx, channelPolicy)
+		require.NoError(t, err)
+		require.NotNil(t, channelPolicy)
+
+		t.Cleanup(func() {
+			deleteErr := ss.AccessControlPolicy().Delete(rctx, channelPolicy.ID)
+			require.NoError(t, deleteErr)
+		})
+	})
+
+	t.Run("Updating same policy name should succeed", func(t *testing.T) {
+		policy := &model.AccessControlPolicy{
+			ID:       model.NewId(),
+			Name:     "Update Same Name",
+			Type:     model.AccessControlPolicyTypeParent,
+			Active:   true,
+			Revision: 1,
+			Version:  model.AccessControlPolicyVersionV0_2,
+			Imports:  []string{},
+			Rules: []model.AccessControlPolicyRule{
+				{
+					Actions:    []string{"action"},
+					Expression: "user.properties.program == \"engineering\"",
+				},
+			},
+		}
+
+		policy, err := ss.AccessControlPolicy().Save(rctx, policy)
+		require.NoError(t, err)
+		require.NotNil(t, policy)
+		require.Equal(t, 1, policy.Revision)
+
+		t.Cleanup(func() {
+			deleteErr := ss.AccessControlPolicy().Delete(rctx, policy.ID)
+			require.NoError(t, deleteErr)
+		})
+
+		// Update rules but keep same name — should succeed and bump revision
+		policy.Rules = []model.AccessControlPolicyRule{
+			{
+				Actions:    []string{"action"},
+				Expression: "user.properties.department == \"sales\"",
+			},
+		}
+
+		policy, err = ss.AccessControlPolicy().Save(rctx, policy)
+		require.NoError(t, err)
+		require.NotNil(t, policy)
+		require.Equal(t, 2, policy.Revision)
+	})
+
+	t.Run("Changing policy name should not bump revision", func(t *testing.T) {
+		policy := &model.AccessControlPolicy{
+			ID:       model.NewId(),
+			Name:     "Original Name",
+			Type:     model.AccessControlPolicyTypeParent,
+			Active:   true,
+			Revision: 1,
+			Version:  model.AccessControlPolicyVersionV0_2,
+			Imports:  []string{},
+			Rules: []model.AccessControlPolicyRule{
+				{
+					Actions:    []string{"action"},
+					Expression: "user.properties.program == \"engineering\"",
+				},
+			},
+		}
+
+		policy, err := ss.AccessControlPolicy().Save(rctx, policy)
+		require.NoError(t, err)
+		require.Equal(t, 1, policy.Revision)
+
+		t.Cleanup(func() {
+			deleteErr := ss.AccessControlPolicy().Delete(rctx, policy.ID)
+			require.NoError(t, deleteErr)
+		})
+
+		// Change only the name — revision should NOT bump
+		policy.Name = "Renamed Policy"
+
+		policy, err = ss.AccessControlPolicy().Save(rctx, policy)
+		require.NoError(t, err)
+		require.NotNil(t, policy)
+		require.Equal(t, "Renamed Policy", policy.Name)
+		require.Equal(t, 1, policy.Revision)
+
+		// Verify the name persisted
+		fetched, err := ss.AccessControlPolicy().Get(rctx, policy.ID)
+		require.NoError(t, err)
+		require.Equal(t, "Renamed Policy", fetched.Name)
+		require.Equal(t, 1, fetched.Revision)
+	})
+
+	t.Run("Reusing name after deletion should succeed", func(t *testing.T) {
+		policy1 := &model.AccessControlPolicy{
+			ID:       model.NewId(),
+			Name:     "Reusable Name",
+			Type:     model.AccessControlPolicyTypeParent,
+			Active:   true,
+			Revision: 1,
+			Version:  model.AccessControlPolicyVersionV0_2,
+			Imports:  []string{},
+			Rules: []model.AccessControlPolicyRule{
+				{
+					Actions:    []string{"action"},
+					Expression: "user.properties.program == \"engineering\"",
+				},
+			},
+		}
+
+		policy1, err := ss.AccessControlPolicy().Save(rctx, policy1)
+		require.NoError(t, err)
+
+		err = ss.AccessControlPolicy().Delete(rctx, policy1.ID)
+		require.NoError(t, err)
+
+		policy2 := &model.AccessControlPolicy{
+			ID:       model.NewId(),
+			Name:     "Reusable Name",
+			Type:     model.AccessControlPolicyTypeParent,
+			Active:   true,
+			Revision: 1,
+			Version:  model.AccessControlPolicyVersionV0_2,
+			Imports:  []string{},
+			Rules: []model.AccessControlPolicyRule{
+				{
+					Actions:    []string{"action"},
+					Expression: "user.properties.department == \"sales\"",
+				},
+			},
+		}
+
+		policy2, err = ss.AccessControlPolicy().Save(rctx, policy2)
+		require.NoError(t, err)
+		require.NotNil(t, policy2)
+
+		t.Cleanup(func() {
+			deleteErr := ss.AccessControlPolicy().Delete(rctx, policy2.ID)
+			require.NoError(t, deleteErr)
+		})
+	})
+}
+
 func testAccessControlPolicyStoreDelete(t *testing.T, rctx request.CTX, ss store.Store) {
 	t.Run("Delete parent policy", func(t *testing.T) {
 		policy := &model.AccessControlPolicy{
 			ID:       model.NewId(),
-			Name:     "Name",
+			Name:     "Delete Parent " + model.NewId(),
 			Type:     model.AccessControlPolicyTypeParent,
 			Active:   true,
 			Revision: 1,
@@ -251,7 +486,7 @@ func testAccessControlPolicyStoreGetAll(t *testing.T, rctx request.CTX, ss store
 	id := model.NewId()
 	parentPolicy := &model.AccessControlPolicy{
 		ID:       id,
-		Name:     "Name",
+		Name:     "GetAll Parent " + id,
 		Type:     model.AccessControlPolicyTypeParent,
 		Active:   true,
 		Revision: 1,
@@ -297,7 +532,7 @@ func testAccessControlPolicyStoreGetAll(t *testing.T, rctx request.CTX, ss store
 	id3 := "zzz" + model.NewId()[3:] // ensure the order of the ID
 	parentPolicy2 := &model.AccessControlPolicy{
 		ID:       id3,
-		Name:     "Name",
+		Name:     "Name2",
 		Type:     model.AccessControlPolicyTypeParent,
 		Active:   true,
 		Revision: 1,
@@ -554,7 +789,7 @@ func testAccessControlPolicyStoreGetPoliciesByFieldID(t *testing.T, rctx request
 		t.Helper()
 		policy := &model.AccessControlPolicy{
 			ID:       model.NewId(),
-			Name:     "Policy",
+			Name:     "Policy " + model.NewId(),
 			Type:     model.AccessControlPolicyTypeParent,
 			Active:   true,
 			Revision: 1,
@@ -654,7 +889,7 @@ func testAccessControlPolicyStoreGetPoliciesByFieldID(t *testing.T, rctx request
 		deletableField := model.NewId()
 		policy := &model.AccessControlPolicy{
 			ID:       model.NewId(),
-			Name:     "Policy",
+			Name:     "Policy " + model.NewId(),
 			Type:     model.AccessControlPolicyTypeParent,
 			Active:   true,
 			Revision: 1,

--- a/server/channels/web/web.go
+++ b/server/channels/web/web.go
@@ -8,8 +8,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/avct/uasurfer"
-	"github.com/blang/semver/v4"
 	"github.com/gorilla/mux"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -67,15 +67,15 @@ func CheckDesktopAppCompatibility(agentString string, minVersion *string) bool {
 	if !ok {
 		return true
 	}
-	clientVersion, err := semver.ParseTolerant(clientVersionStr)
+	clientVersion, err := semver.NewVersion(clientVersionStr)
 	if err != nil {
 		return true
 	}
-	required, err := semver.Parse(*minVersion)
+	required, err := semver.StrictNewVersion(*minVersion)
 	if err != nil {
 		return true
 	}
-	return clientVersion.GTE(required)
+	return clientVersion.GreaterThanEqual(required)
 }
 
 func Handle404(a *app.App, w http.ResponseWriter, r *http.Request) {

--- a/server/go.mod
+++ b/server/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16
 	github.com/aws/aws-sdk-go-v2/service/marketplacemetering v1.34.4
 	github.com/bep/imagemeta v0.12.0
-	github.com/blang/semver/v4 v4.0.0
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/dgryski/dgoogauth v0.0.0-20190221195224-5a805980a5f3
 	github.com/dyatlov/go-opengraph/opengraph v0.0.0-20220524092352-606d7b1e5f8a
@@ -76,6 +75,7 @@ require (
 	golang.org/x/sync v0.18.0
 	golang.org/x/sys v0.38.0
 	golang.org/x/term v0.37.0
+	golang.org/x/text v0.31.0
 	gopkg.in/mail.v2 v2.3.1
 )
 
@@ -104,6 +104,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.1 // indirect
 	github.com/bits-and-blooms/bloom/v3 v3.7.0 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bodgit/plumbing v1.3.0 // indirect
 	github.com/bodgit/sevenzip v1.6.1 // indirect
 	github.com/bodgit/windows v1.0.1 // indirect
@@ -207,7 +208,6 @@ require (
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
 	golang.org/x/exp v0.0.0-20251009144603-d2f985daa21b // indirect
 	golang.org/x/mod v0.29.0 // indirect
-	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251007200510-49b9836ed3ff // indirect
 	google.golang.org/grpc v1.76.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -407,8 +407,6 @@ github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956 h1:Y1Tu/swM31pVwwb
 github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956/go.mod h1:SRl30Lb7/QoYyohYeVBuqYvvmXSZJxZgiV3Zf6VbxjI=
 github.com/mattermost/logr/v2 v2.0.22 h1:npFkXlkAWR9J8payh8ftPcCZvLbHSI125mAM5/r/lP4=
 github.com/mattermost/logr/v2 v2.0.22/go.mod h1:0sUKpO+XNMZApeumaid7PYaUZPBIydfuWZ0dqixXo+s=
-github.com/mattermost/mattermost-plugin-ai v1.8.1 h1:qymxDayy3vJPhm59XA8q0oLR8uobPgx0SOB7IMG9ZMM=
-github.com/mattermost/mattermost-plugin-ai v1.8.1/go.mod h1:Uco4K7ypsrZWcD256ezvgZDqolJfHYiExN2lYiHmVDo=
 github.com/mattermost/mattermost-plugin-ai v1.12.0 h1:cwRE2jjlqN5W42O9Xp0ncyHk7HL/ayMeypuINPX0WJ0=
 github.com/mattermost/mattermost-plugin-ai v1.12.0/go.mod h1:L/I/IpdWNGbxRfUduCstCYbhyX59OEftxcpDHtCT4EI=
 github.com/mattermost/mattermost/server/public v0.1.22-0.20251105210629-8bf4a00724e2 h1:RJtCnj9nF/wb0Fb+O0qAPgUoWP5CTTDnHzHD5ciGlJ8=

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -5043,6 +5043,10 @@
     "translation": "Unable to add the user as a member of the channel."
   },
   {
+    "id": "app.channel.add_user.to.channel.rejected_by_plugin",
+    "translation": "Adding channel member rejected by plugin: {{.Reason}}"
+  },
+  {
     "id": "app.channel.analytics_type_count.app_error",
     "translation": "Unable to get channel type counts."
   },
@@ -5113,6 +5117,10 @@
   {
     "id": "app.channel.delete.app_error",
     "translation": "Unable to delete the channel."
+  },
+  {
+    "id": "app.channel.delete_channel.rejected_by_plugin",
+    "translation": "Channel archive rejected by plugin: {{.Reason}}"
   },
   {
     "id": "app.channel.get.app_error",
@@ -8055,6 +8063,10 @@
   {
     "id": "app.team.join_user_to_team.max_accounts.app_error",
     "translation": "This team has reached the maximum number of allowed accounts. Contact your System Administrator to set a higher limit."
+  },
+  {
+    "id": "app.team.join_user_to_team.rejected_by_plugin",
+    "translation": "Adding team member rejected by plugin: {{.Reason}}"
   },
   {
     "id": "app.team.join_user_to_team.save_member.app_error",

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -7063,6 +7063,10 @@
     "translation": "Unable to save access control policy."
   },
   {
+    "id": "app.pap.save_policy.name_exists.app_error",
+    "translation": "A policy with this name already exists. Please choose a different name."
+  },
+  {
     "id": "app.pap.search_access_control_policies.app_error",
     "translation": "Could not search access control policies."
   },

--- a/server/public/go.mod
+++ b/server/public/go.mod
@@ -3,7 +3,7 @@ module github.com/mattermost/mattermost/server/public
 go 1.24.13
 
 require (
-	github.com/blang/semver/v4 v4.0.0
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/dyatlov/go-opengraph/opengraph v0.0.0-20220524092352-606d7b1e5f8a
 	github.com/francoispqt/gojay v1.2.13
 	github.com/goccy/go-yaml v1.18.0

--- a/server/public/go.sum
+++ b/server/public/go.sum
@@ -10,13 +10,13 @@ git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGy
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/beevik/etree v1.6.0 h1:u8Kwy8pp9D9XeITj2Z0XtA5qqZEmtJtuXZRQi+j03eE=
 github.com/beevik/etree v1.6.0/go.mod h1:bh4zJxiIr62SOf9pRzN7UUYaEDa9HEKafK25+sLc0Gc=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
-github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
-github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/blang/semver/v4"
+	"github.com/Masterminds/semver/v3"
 	"github.com/mattermost/ldap"
 	"github.com/pkg/errors"
 
@@ -4664,7 +4664,7 @@ func (s *ServiceSettings) isValid() *AppError {
 	}
 
 	if *s.MinimumDesktopAppVersion != "" {
-		if _, err := semver.Parse(*s.MinimumDesktopAppVersion); err != nil {
+		if _, err := semver.StrictNewVersion(*s.MinimumDesktopAppVersion); err != nil {
 			return NewAppError("Config.IsValid", "model.config.is_valid.minimum_desktop_app_version.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 		}
 	}

--- a/server/public/model/manifest.go
+++ b/server/public/model/manifest.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/blang/semver/v4"
+	"github.com/Masterminds/semver/v3"
 	"github.com/goccy/go-yaml"
 	"github.com/pkg/errors"
 )
@@ -299,12 +299,12 @@ func (m *Manifest) HasWebapp() bool {
 }
 
 func (m *Manifest) MeetMinServerVersion(serverVersion string) (bool, error) {
-	minServerVersion, err := semver.Parse(m.MinServerVersion)
+	minServerVersion, err := semver.StrictNewVersion(m.MinServerVersion)
 	if err != nil {
 		return false, errors.New("failed to parse MinServerVersion")
 	}
 	sv := semver.MustParse(serverVersion)
-	if sv.LT(minServerVersion) {
+	if sv.LessThan(minServerVersion) {
 		return false, nil
 	}
 	return true, nil
@@ -332,14 +332,14 @@ func (m *Manifest) IsValid() error {
 	}
 
 	if m.Version != "" {
-		_, err := semver.Parse(m.Version)
+		_, err := semver.StrictNewVersion(m.Version)
 		if err != nil {
 			return errors.Wrap(err, "failed to parse Version")
 		}
 	}
 
 	if m.MinServerVersion != "" {
-		_, err := semver.Parse(m.MinServerVersion)
+		_, err := semver.StrictNewVersion(m.MinServerVersion)
 		if err != nil {
 			return errors.Wrap(err, "failed to parse MinServerVersion")
 		}

--- a/server/public/model/metrics.go
+++ b/server/public/model/metrics.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/blang/semver/v4"
+	"github.com/Masterminds/semver/v3"
 )
 
 type MetricType string
@@ -112,12 +112,12 @@ func (r *PerformanceReport) IsValid() error {
 		return fmt.Errorf("the report is nil")
 	}
 
-	reportVersion, err := semver.ParseTolerant(r.Version)
+	reportVersion, err := semver.NewVersion(r.Version)
 	if err != nil {
 		return fmt.Errorf("could not parse semver version: %s, %w", r.Version, err)
 	}
 
-	if reportVersion.Major != performanceReportVersion.Major || reportVersion.Minor > performanceReportVersion.Minor {
+	if reportVersion.Major() != performanceReportVersion.Major() || reportVersion.Minor() > performanceReportVersion.Minor() {
 		return fmt.Errorf("report version is not supported: server version: %s, report version: %s", performanceReportVersion.String(), r.Version)
 	}
 

--- a/server/public/model/packet_metadata.go
+++ b/server/public/model/packet_metadata.go
@@ -6,7 +6,7 @@ package model
 import (
 	"fmt"
 
-	"github.com/blang/semver/v4"
+	"github.com/Masterminds/semver/v3"
 	"github.com/goccy/go-yaml"
 )
 
@@ -54,7 +54,7 @@ func (md *PacketMetadata) Validate() error {
 		return fmt.Errorf("generated_at should be a positive number")
 	}
 
-	if _, err := semver.ParseTolerant(md.ServerVersion); err != nil {
+	if _, err := semver.NewVersion(md.ServerVersion); err != nil {
 		return fmt.Errorf("could not parse server version: %w", err)
 	}
 

--- a/server/public/plugin/client_rpc.go
+++ b/server/public/plugin/client_rpc.go
@@ -1371,3 +1371,79 @@ func (s *hooksRPCServer) ServeMetrics(args *Z_ServeMetricsArgs, returns *struct{
 
 	return nil
 }
+
+// ChannelMemberWillBeAdded is hand-written to preserve the original ChannelMember as the default
+// return value, avoiding unintentional field removal by older plugins.
+func init() {
+	hookNameToId["ChannelMemberWillBeAdded"] = ChannelMemberWillBeAddedID
+}
+
+type Z_ChannelMemberWillBeAddedArgs struct {
+	A *Context
+	B *model.ChannelMember
+}
+
+type Z_ChannelMemberWillBeAddedReturns struct {
+	A *model.ChannelMember
+	B string
+}
+
+func (g *hooksRPCClient) ChannelMemberWillBeAdded(c *Context, channelMember *model.ChannelMember) (*model.ChannelMember, string) {
+	_args := &Z_ChannelMemberWillBeAddedArgs{c, channelMember}
+	_returns := &Z_ChannelMemberWillBeAddedReturns{A: _args.B}
+	if g.implemented[ChannelMemberWillBeAddedID] {
+		if err := g.client.Call("Plugin.ChannelMemberWillBeAdded", _args, _returns); err != nil {
+			g.log.Error("RPC call ChannelMemberWillBeAdded to plugin failed.", mlog.Err(err))
+		}
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *hooksRPCServer) ChannelMemberWillBeAdded(args *Z_ChannelMemberWillBeAddedArgs, returns *Z_ChannelMemberWillBeAddedReturns) error {
+	if hook, ok := s.impl.(interface {
+		ChannelMemberWillBeAdded(c *Context, channelMember *model.ChannelMember) (*model.ChannelMember, string)
+	}); ok {
+		returns.A, returns.B = hook.ChannelMemberWillBeAdded(args.A, args.B)
+	} else {
+		return encodableError(fmt.Errorf("hook ChannelMemberWillBeAdded called but not implemented"))
+	}
+	return nil
+}
+
+// TeamMemberWillBeAdded is hand-written to preserve the original TeamMember as the default
+// return value, avoiding unintentional field removal by older plugins.
+func init() {
+	hookNameToId["TeamMemberWillBeAdded"] = TeamMemberWillBeAddedID
+}
+
+type Z_TeamMemberWillBeAddedArgs struct {
+	A *Context
+	B *model.TeamMember
+}
+
+type Z_TeamMemberWillBeAddedReturns struct {
+	A *model.TeamMember
+	B string
+}
+
+func (g *hooksRPCClient) TeamMemberWillBeAdded(c *Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+	_args := &Z_TeamMemberWillBeAddedArgs{c, teamMember}
+	_returns := &Z_TeamMemberWillBeAddedReturns{A: _args.B}
+	if g.implemented[TeamMemberWillBeAddedID] {
+		if err := g.client.Call("Plugin.TeamMemberWillBeAdded", _args, _returns); err != nil {
+			g.log.Error("RPC call TeamMemberWillBeAdded to plugin failed.", mlog.Err(err))
+		}
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *hooksRPCServer) TeamMemberWillBeAdded(args *Z_TeamMemberWillBeAddedArgs, returns *Z_TeamMemberWillBeAddedReturns) error {
+	if hook, ok := s.impl.(interface {
+		TeamMemberWillBeAdded(c *Context, teamMember *model.TeamMember) (*model.TeamMember, string)
+	}); ok {
+		returns.A, returns.B = hook.TeamMemberWillBeAdded(args.A, args.B)
+	} else {
+		return encodableError(fmt.Errorf("hook TeamMemberWillBeAdded called but not implemented"))
+	}
+	return nil
+}

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -360,6 +360,41 @@ func (s *hooksRPCServer) ChannelHasBeenCreated(args *Z_ChannelHasBeenCreatedArgs
 }
 
 func init() {
+	hookNameToId["ChannelWillBeArchived"] = ChannelWillBeArchivedID
+}
+
+type Z_ChannelWillBeArchivedArgs struct {
+	A *Context
+	B *model.Channel
+}
+
+type Z_ChannelWillBeArchivedReturns struct {
+	A string
+}
+
+func (g *hooksRPCClient) ChannelWillBeArchived(c *Context, channel *model.Channel) string {
+	_args := &Z_ChannelWillBeArchivedArgs{c, channel}
+	_returns := &Z_ChannelWillBeArchivedReturns{}
+	if g.implemented[ChannelWillBeArchivedID] {
+		if err := g.client.Call("Plugin.ChannelWillBeArchived", _args, _returns); err != nil {
+			g.log.Error("RPC call ChannelWillBeArchived to plugin failed.", mlog.Err(err))
+		}
+	}
+	return _returns.A
+}
+
+func (s *hooksRPCServer) ChannelWillBeArchived(args *Z_ChannelWillBeArchivedArgs, returns *Z_ChannelWillBeArchivedReturns) error {
+	if hook, ok := s.impl.(interface {
+		ChannelWillBeArchived(c *Context, channel *model.Channel) string
+	}); ok {
+		returns.A = hook.ChannelWillBeArchived(args.A, args.B)
+	} else {
+		return encodableError(fmt.Errorf("Hook ChannelWillBeArchived called but not implemented."))
+	}
+	return nil
+}
+
+func init() {
 	hookNameToId["UserHasJoinedChannel"] = UserHasJoinedChannelID
 }
 

--- a/server/public/plugin/hooks.go
+++ b/server/public/plugin/hooks.go
@@ -65,6 +65,9 @@ const (
 	OnSAMLLoginID                             = 46
 	EmailNotificationWillBeSentID             = 47
 	FileWillBeDownloadedID                    = 48
+	ChannelMemberWillBeAddedID                = 49
+	TeamMemberWillBeAddedID                   = 50
+	ChannelWillBeArchivedID                   = 51
 	TotalHooksID                              = iota
 )
 
@@ -203,6 +206,25 @@ type Hooks interface {
 	// Minimum server version: 5.2
 	ChannelHasBeenCreated(c *Context, channel *model.Channel)
 
+	// ChannelWillBeArchived is invoked before a channel is archived, allowing plugins to
+	// reject the archive operation.
+	//
+	// To reject the archive, return a non-empty string describing why it was rejected.
+	// To allow the archive, return an empty string.
+	//
+	// Minimum server version: 11.7
+	ChannelWillBeArchived(c *Context, channel *model.Channel) string
+
+	// ChannelMemberWillBeAdded is invoked before a member is added to a channel, allowing
+	// plugins to modify the channel member or reject the addition.
+	//
+	// To reject the addition, return a non-empty string describing why it was rejected.
+	// To modify the member, return the replacement, non-nil *model.ChannelMember and an empty string.
+	// To allow the addition without modification, return a nil *model.ChannelMember and an empty string.
+	//
+	// Minimum server version: 11.7
+	ChannelMemberWillBeAdded(c *Context, channelMember *model.ChannelMember) (*model.ChannelMember, string)
+
 	// UserHasJoinedChannel is invoked after the membership has been committed to the database.
 	// If actor is not nil, the user was invited to the channel by the actor.
 	//
@@ -214,6 +236,16 @@ type Hooks interface {
 	//
 	// Minimum server version: 5.2
 	UserHasLeftChannel(c *Context, channelMember *model.ChannelMember, actor *model.User)
+
+	// TeamMemberWillBeAdded is invoked before a member is added to a team, allowing
+	// plugins to modify the team member or reject the addition.
+	//
+	// To reject the addition, return a non-empty string describing why it was rejected.
+	// To modify the member, return the replacement, non-nil *model.TeamMember and an empty string.
+	// To allow the addition without modification, return a nil *model.TeamMember and an empty string.
+	//
+	// Minimum server version: 11.7
+	TeamMemberWillBeAdded(c *Context, teamMember *model.TeamMember) (*model.TeamMember, string)
 
 	// UserHasJoinedTeam is invoked after the membership has been committed to the database.
 	// If actor is not nil, the user was added to the team by the actor.

--- a/server/public/plugin/hooks_timer_layer_generated.go
+++ b/server/public/plugin/hooks_timer_layer_generated.go
@@ -133,6 +133,20 @@ func (hooks *hooksTimerLayer) ChannelHasBeenCreated(c *Context, channel *model.C
 	hooks.recordTime(startTime, "ChannelHasBeenCreated", true)
 }
 
+func (hooks *hooksTimerLayer) ChannelWillBeArchived(c *Context, channel *model.Channel) string {
+	startTime := timePkg.Now()
+	_returnsA := hooks.hooksImpl.ChannelWillBeArchived(c, channel)
+	hooks.recordTime(startTime, "ChannelWillBeArchived", true)
+	return _returnsA
+}
+
+func (hooks *hooksTimerLayer) ChannelMemberWillBeAdded(c *Context, channelMember *model.ChannelMember) (*model.ChannelMember, string) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := hooks.hooksImpl.ChannelMemberWillBeAdded(c, channelMember)
+	hooks.recordTime(startTime, "ChannelMemberWillBeAdded", true)
+	return _returnsA, _returnsB
+}
+
 func (hooks *hooksTimerLayer) UserHasJoinedChannel(c *Context, channelMember *model.ChannelMember, actor *model.User) {
 	startTime := timePkg.Now()
 	hooks.hooksImpl.UserHasJoinedChannel(c, channelMember, actor)
@@ -143,6 +157,13 @@ func (hooks *hooksTimerLayer) UserHasLeftChannel(c *Context, channelMember *mode
 	startTime := timePkg.Now()
 	hooks.hooksImpl.UserHasLeftChannel(c, channelMember, actor)
 	hooks.recordTime(startTime, "UserHasLeftChannel", true)
+}
+
+func (hooks *hooksTimerLayer) TeamMemberWillBeAdded(c *Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := hooks.hooksImpl.TeamMemberWillBeAdded(c, teamMember)
+	hooks.recordTime(startTime, "TeamMemberWillBeAdded", true)
+	return _returnsA, _returnsB
 }
 
 func (hooks *hooksTimerLayer) UserHasJoinedTeam(c *Context, teamMember *model.TeamMember, actor *model.User) {

--- a/server/public/plugin/interface_generator/main.go
+++ b/server/public/plugin/interface_generator/main.go
@@ -23,7 +23,9 @@ import (
 )
 
 var excludedPluginHooks = []string{
+	"ChannelMemberWillBeAdded",
 	"FileWillBeUploaded",
+	"TeamMemberWillBeAdded",
 	"Implemented",
 	"LoadPluginConfiguration",
 	"InstallPlugin",

--- a/server/public/plugin/plugintest/hooks.go
+++ b/server/public/plugin/plugintest/hooks.go
@@ -27,6 +27,54 @@ func (_m *Hooks) ChannelHasBeenCreated(c *plugin.Context, channel *model.Channel
 	_m.Called(c, channel)
 }
 
+// ChannelMemberWillBeAdded provides a mock function with given fields: c, channelMember
+func (_m *Hooks) ChannelMemberWillBeAdded(c *plugin.Context, channelMember *model.ChannelMember) (*model.ChannelMember, string) {
+	ret := _m.Called(c, channelMember)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChannelMemberWillBeAdded")
+	}
+
+	var r0 *model.ChannelMember
+	var r1 string
+	if rf, ok := ret.Get(0).(func(*plugin.Context, *model.ChannelMember) (*model.ChannelMember, string)); ok {
+		return rf(c, channelMember)
+	}
+	if rf, ok := ret.Get(0).(func(*plugin.Context, *model.ChannelMember) *model.ChannelMember); ok {
+		r0 = rf(c, channelMember)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.ChannelMember)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*plugin.Context, *model.ChannelMember) string); ok {
+		r1 = rf(c, channelMember)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+
+	return r0, r1
+}
+
+// ChannelWillBeArchived provides a mock function with given fields: c, channel
+func (_m *Hooks) ChannelWillBeArchived(c *plugin.Context, channel *model.Channel) string {
+	ret := _m.Called(c, channel)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChannelWillBeArchived")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(*plugin.Context, *model.Channel) string); ok {
+		r0 = rf(c, channel)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // ConfigurationWillBeSaved provides a mock function with given fields: newCfg
 func (_m *Hooks) ConfigurationWillBeSaved(newCfg *model.Config) (*model.Config, error) {
 	ret := _m.Called(newCfg)
@@ -600,6 +648,36 @@ func (_m *Hooks) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 // ServeMetrics provides a mock function with given fields: c, w, r
 func (_m *Hooks) ServeMetrics(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
 	_m.Called(c, w, r)
+}
+
+// TeamMemberWillBeAdded provides a mock function with given fields: c, teamMember
+func (_m *Hooks) TeamMemberWillBeAdded(c *plugin.Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+	ret := _m.Called(c, teamMember)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TeamMemberWillBeAdded")
+	}
+
+	var r0 *model.TeamMember
+	var r1 string
+	if rf, ok := ret.Get(0).(func(*plugin.Context, *model.TeamMember) (*model.TeamMember, string)); ok {
+		return rf(c, teamMember)
+	}
+	if rf, ok := ret.Get(0).(func(*plugin.Context, *model.TeamMember) *model.TeamMember); ok {
+		r0 = rf(c, teamMember)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.TeamMember)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*plugin.Context, *model.TeamMember) string); ok {
+		r1 = rf(c, teamMember)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+
+	return r0, r1
 }
 
 // UserHasBeenCreated provides a mock function with given fields: c, user

--- a/server/public/pluginapi/client.go
+++ b/server/public/pluginapi/client.go
@@ -1,7 +1,7 @@
 package pluginapi
 
 import (
-	"github.com/blang/semver/v4"
+	"github.com/Masterminds/semver/v3"
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/pkg/errors"
 )
@@ -73,7 +73,7 @@ func ensureServerVersion(api plugin.API, required string) error {
 	currentVersion := semver.MustParse(serverVersion)
 	requiredVersion := semver.MustParse(required)
 
-	if currentVersion.LT(requiredVersion) {
+	if currentVersion.LessThan(requiredVersion) {
 		return errors.Errorf("incompatible server version for plugin, minimum required version: %s, current version: %s", required, serverVersion)
 	}
 

--- a/server/public/pluginapi/system.go
+++ b/server/public/pluginapi/system.go
@@ -7,7 +7,7 @@ import (
 	filePath "path"
 	"time"
 
-	"github.com/blang/semver/v4"
+	"github.com/Masterminds/semver/v3"
 	"github.com/goccy/go-yaml"
 	"github.com/pkg/errors"
 
@@ -127,7 +127,7 @@ func (s *SystemService) RequestTrialLicense(requesterID string, users int, terms
 	currentVersion := semver.MustParse(s.api.GetServerVersion())
 	requiredVersion := semver.MustParse("5.36.0")
 
-	if currentVersion.LT(requiredVersion) {
+	if currentVersion.LessThan(requiredVersion) {
 		return errors.Errorf("current server version is lower than 5.36")
 	}
 

--- a/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.tsx
@@ -202,7 +202,11 @@ function PolicyDetails({
                 version: 'v0.2',
             }).then((result) => {
                 if (result.error) {
-                    setServerError(result.error.message);
+                    if (result.error.server_error_id === 'app.pap.save_policy.name_exists.app_error') {
+                        setServerError(formatMessage({id: 'admin.access_control.edit_policy.name_exists', defaultMessage: 'A policy with this name already exists. Please choose a different name.'}));
+                    } else {
+                        setServerError(result.error.message);
+                    }
                     setShowConfirmationModal(false);
                     success = false;
                     return;

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -270,6 +270,7 @@
   "admin.access_control.edit": "Edit",
   "admin.access_control.edit_policy.apply_policy": "Apply policy",
   "admin.access_control.edit_policy.cancel": "Cancel",
+  "admin.access_control.edit_policy.name_exists": "A policy with this name already exists. Please choose a different name.",
   "admin.access_control.edit_policy.save": "Save",
   "admin.access_control.edit_policy.save_policy": "Save policy",
   "admin.access_control.edit_policy.serverError": "There are errors in the form above: {serverError}",


### PR DESCRIPTION
- MM-63848: Enforce unique names for parent access control policies (#35676)
- MM-68016, MM-68017, MM-68018 Add plugin pre-hooks for membership and channel archive (#35731)
- MM-67793: Remove dependency on blang/semver/v4 (#35742)
- docs: upstream sync 진행 (picked 2, adapted 1)

2026-03-25 묶음 7건 중 앞의 3건만 처리했다. 나머지 4건은 다음 세션에서 이어간다.

## adapt 1건 — 마이그레이션 번호 조정

`bcd6a9e7d1`(ABAC 정책 이름 유일성)의 DB 마이그레이션을 `000159` → `000164`로 조정했다.
okrbest는 자체 마이그레이션(notification_history, org_role_tables 등)이 있어 upstream보다
번호가 **+5** 앞서 있고, 000159는 이미 drop_translation_updateat_index가 점유 중이다.

| | 번역 | roles schemeid | 신규 정책 |
|---|---|---|---|
| upstream | 000153~155 | 000156~158 | 000159 |
| okrbest | 000158~160 | 000161~163 | **000164** |

선례: `1191788267`(upstream 76b3528c2b)도 같은 사유로 adapt됨. 반영 후 migrations.list
정합성을 검사했다 — 항목 329개, 번호 중복 0, 목록↔파일 양방향 일치.

## 검증

- `go build ./...` server·public 두 모듈 전체 통과
- semver 교체 후 `blang/semver` 잔여 임포트 **0건** (사용 파일 11개 = 커밋 수정 파일 11개, 완전 일치)
- `go vet` 접촉 패키지 전부, `go test -c` app 패키지 컴파일 통과
- `public/model` Manifest/Version/Metrics 테스트 통과
- `check-types` 13건 = master 기준선, 신규 0 / eslint exit 0
- `i18n-extract:check`·`i18n-check-empty` exit 0

## 실행하지 못한 검증

DB 필요 — 마이그레이션 000164, ABAC storetest(+247), plugin_hooks_test.go(+426)

## i18n 후속 5건 (ko 미번역)

server: `app.pap.save_policy.name_exists.app_error`, `app.channel.add_user.to.channel.rejected_by_plugin`, `app.channel.delete_channel.rejected_by_plugin`, `app.team.join_user_to_team.rejected_by_plugin`
webapp: `admin.access_control.edit_policy.name_exists`

## 알려진 기존 실패

`make check-style` vet — `storetest.Store`에 `NotificationHistory` 누락. 이번 실행에서 그 외 에러 줄 0건