### PR TITLE
upstream sync 2026-03-31 (picked 2)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,16 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-14 10:56
+- 갱신일: 2026-08-14 11:18
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 882개
+- 남은 커밋: 880개
 
-**마지막 반영 커밋:** `96e4d7a7` | [MM-68076 Chunk bulk INSERTs to respect PostgreSQL parameter limit (#35767)](https://github.com/mattermost/mattermost/commit/96e4d7a76902d98a41c7d15e7618ad4ed8015dbc) | 2026-03-30
+**마지막 반영 커밋:** `3e2c3f70` | [fix: prevent sql.DB connectionCleaner race and harden flaky tests (#35891)](https://github.com/mattermost/mattermost/commit/3e2c3f70c25b261a164595854ce8a8cb00247e3c) | 2026-03-31
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 4b8a4ae2 | [fix: resolve DATA RACE in TestReplicaLagQuery, TestInvalidReplicaLagDataSource, and TestMetrics (#35881)](https://github.com/mattermost/mattermost/commit/4b8a4ae2b35381a46b891f831518a731d6f9e313) | 2026-03-31 |
-| 3e2c3f70 | [fix: prevent sql.DB connectionCleaner race and harden flaky tests (#35891)](https://github.com/mattermost/mattermost/commit/3e2c3f70c25b261a164595854ce8a8cb00247e3c) | 2026-03-31 |
 | 2550ecd8 | [ci: post success to required e2e status contexts when no relevant changes (#35880)](https://github.com/mattermost/mattermost/commit/2550ecd87bd1ad1dbb1c21054958be3ee46da0c9) | 2026-04-01 |
 | 47d2c607 | [Docs impact fixes (#35877)](https://github.com/mattermost/mattermost/commit/47d2c6074d61c2d7b4ecec2ddd58e3c024b36742) | 2026-04-01 |
 | f4d1abe7 | [MM-68140: Validate post read access before rewrite thread context (#35864)](https://github.com/mattermost/mattermost/commit/f4d1abe7e8f545f1a87f463fa9fe451c731aebf8) | 2026-04-01 |

--- a/server/channels/app/platform/helper_test.go
+++ b/server/channels/app/platform/helper_test.go
@@ -147,6 +147,13 @@ func setupTestHelper(dbStore store.Store, dbSettings *model.SqlSettings, enterpr
 
 	memoryConfig := configStore.Get()
 	memoryConfig.SqlSettings = *dbSettings
+	// Disable connection pool cleanup goroutines to prevent DATA RACE with
+	// testify mock argument diffing under the race detector. The sql.DB
+	// connectionCleaner goroutine writes to internal fields while testify's
+	// mock.Called() → Arguments.Diff() → fmt.Sprintf reads them via reflect.
+	// Setting lifetime/idle to 0 prevents the cleaner from starting.
+	memoryConfig.SqlSettings.ConnMaxLifetimeMilliseconds = model.NewPointer(0)
+	memoryConfig.SqlSettings.ConnMaxIdleTimeMilliseconds = model.NewPointer(0)
 	*memoryConfig.PluginSettings.Directory = filepath.Join(tempWorkspace, "plugins")
 	*memoryConfig.PluginSettings.ClientDirectory = filepath.Join(tempWorkspace, "webapp")
 	*memoryConfig.PluginSettings.AutomaticPrepackagedPlugins = false

--- a/server/channels/app/platform/service_test.go
+++ b/server/channels/app/platform/service_test.go
@@ -195,6 +195,18 @@ func TestMetrics(t *testing.T) {
 
 		_ = th.CreateUserOrGuest(t, false)
 
+		// Shut down the test helper before asserting mock expectations.
+		// The underlying sql.DB connection pool spawns a background
+		// connectionCleaner goroutine that periodically locks the DB's
+		// internal mutex via atomic.CompareAndSwapInt32. When testify's
+		// AssertExpectations calls reflect to diff the recorded *sql.DB
+		// call arguments, it reads those same internal fields without
+		// synchronization. Under Go 1.25's stricter race detector this
+		// is flagged as a DATA RACE. Shutting down first stops all
+		// background goroutines (store, metrics server, connection
+		// cleaner) so the reflect-based comparison runs without a
+		// concurrent writer.
+		th.Shutdown(t)
 		mockMetricsImpl.AssertExpectations(t)
 	})
 }

--- a/server/channels/app/platform/service_test.go
+++ b/server/channels/app/platform/service_test.go
@@ -195,17 +195,6 @@ func TestMetrics(t *testing.T) {
 
 		_ = th.CreateUserOrGuest(t, false)
 
-		// Shut down the test helper before asserting mock expectations.
-		// The underlying sql.DB connection pool spawns a background
-		// connectionCleaner goroutine that periodically locks the DB's
-		// internal mutex via atomic.CompareAndSwapInt32. When testify's
-		// AssertExpectations calls reflect to diff the recorded *sql.DB
-		// call arguments, it reads those same internal fields without
-		// synchronization. Under Go 1.25's stricter race detector this
-		// is flagged as a DATA RACE. Shutting down first stops all
-		// background goroutines (store, metrics server, connection
-		// cleaner) so the reflect-based comparison runs without a
-		// concurrent writer.
 		th.Shutdown(t)
 		mockMetricsImpl.AssertExpectations(t)
 	})

--- a/server/channels/store/sqlstore/store_test.go
+++ b/server/channels/store/sqlstore/store_test.go
@@ -815,6 +815,15 @@ func TestReplicaLagQuery(t *testing.T) {
 				QueryTimeLag:     model.NewPointer(query),
 			}}
 
+			// Disable connection pool cleanup goroutines to prevent DATA RACE
+			// with testify's reflect-based argument diffing. When sql.DB's
+			// connectionCleaner goroutine is active, it writes to internal
+			// fields while testify's mock.Called() → Arguments.Diff() reads
+			// them via fmt.Sprintf("%v", *sql.DB). Setting lifetime/idle to 0
+			// prevents the cleaner goroutine from starting at all.
+			settings.ConnMaxLifetimeMilliseconds = model.NewPointer(0)
+			settings.ConnMaxIdleTimeMilliseconds = model.NewPointer(0)
+
 			mockMetrics := &mocks.MetricsInterface{}
 			mockMetrics.On("SetReplicaLagAbsolute", tableName, float64(1))
 			mockMetrics.On("SetReplicaLagTime", tableName, float64(1))
@@ -840,15 +849,6 @@ func TestReplicaLagQuery(t *testing.T) {
 			err = store.ReplicaLagTime()
 			require.NoError(t, err)
 
-			// Close the store before asserting mock expectations. The sql.DB
-			// connection pool spawns a background connectionCleaner goroutine
-			// that mutates internal DB fields (e.g. the mutex in sql.DB via
-			// atomic.CompareAndSwapInt32). When testify's AssertExpectations
-			// uses reflect to diff the recorded *sql.DB call arguments, it
-			// reads those same fields without synchronization, triggering a
-			// DATA RACE under Go 1.25's stricter race detector. Closing the
-			// store first shuts down all background goroutines (including the
-			// connection cleaner), eliminating the concurrent writer.
 			store.Close()
 			mockMetrics.AssertExpectations(t)
 		})
@@ -880,6 +880,10 @@ func TestInvalidReplicaLagDataSource(t *testing.T) {
 				QueryTimeLag:     model.NewPointer("SELECT 1"),
 			}}
 
+			// Disable connection pool cleanup goroutines (see TestReplicaLagQuery).
+			settings.ConnMaxLifetimeMilliseconds = model.NewPointer(0)
+			settings.ConnMaxIdleTimeMilliseconds = model.NewPointer(0)
+
 			mockMetrics := &mocks.MetricsInterface{}
 			mockMetrics.On("RegisterDBCollector", mock.AnythingOfType("*sql.DB"), "master")
 
@@ -898,12 +902,6 @@ func TestInvalidReplicaLagDataSource(t *testing.T) {
 			// Verify no replica lag handles were added despite having ReplicaLagSettings
 			assert.Equal(t, 0, len(store.replicaLagHandles))
 
-			// Close the store before the test ends. Same rationale as
-			// TestReplicaLagQuery: the sql.DB connection pool's background
-			// connectionCleaner goroutine races with testify's reflect-based
-			// argument diffing in AssertExpectations (and with the race
-			// detector's tracking of goroutine lifetimes). Explicit close
-			// ensures all background goroutines are stopped before cleanup.
 			store.Close()
 		})
 	}

--- a/server/channels/store/sqlstore/store_test.go
+++ b/server/channels/store/sqlstore/store_test.go
@@ -835,12 +835,21 @@ func TestReplicaLagQuery(t *testing.T) {
 			err = store.migrate(migrationsDirectionUp, false, true)
 			require.NoError(t, err)
 
-			defer store.Close()
-
 			err = store.ReplicaLagAbs()
 			require.NoError(t, err)
 			err = store.ReplicaLagTime()
 			require.NoError(t, err)
+
+			// Close the store before asserting mock expectations. The sql.DB
+			// connection pool spawns a background connectionCleaner goroutine
+			// that mutates internal DB fields (e.g. the mutex in sql.DB via
+			// atomic.CompareAndSwapInt32). When testify's AssertExpectations
+			// uses reflect to diff the recorded *sql.DB call arguments, it
+			// reads those same fields without synchronization, triggering a
+			// DATA RACE under Go 1.25's stricter race detector. Closing the
+			// store first shuts down all background goroutines (including the
+			// connection cleaner), eliminating the concurrent writer.
+			store.Close()
 			mockMetrics.AssertExpectations(t)
 		})
 	}
@@ -885,10 +894,17 @@ func TestInvalidReplicaLagDataSource(t *testing.T) {
 			}
 
 			require.NoError(t, store.initConnection())
-			defer store.Close()
 
 			// Verify no replica lag handles were added despite having ReplicaLagSettings
 			assert.Equal(t, 0, len(store.replicaLagHandles))
+
+			// Close the store before the test ends. Same rationale as
+			// TestReplicaLagQuery: the sql.DB connection pool's background
+			// connectionCleaner goroutine races with testify's reflect-based
+			// argument diffing in AssertExpectations (and with the race
+			// detector's tracking of goroutine lifetimes). Explicit close
+			// ensures all background goroutines are stopped before cleanup.
+			store.Close()
 		})
 	}
 }

--- a/server/channels/store/storetest/group_store.go
+++ b/server/channels/store/storetest/group_store.go
@@ -3627,6 +3627,10 @@ func testGetGroupsByTeam(t *testing.T, rctx request.CTX, ss store.Store) {
 }
 
 func testGetGroups(t *testing.T, rctx request.CTX, ss store.Store) {
+	// Use a unique prefix for display names to avoid collisions with groups
+	// created by other parallel subtests sharing the same database.
+	uid := model.NewId()[:8]
+
 	// Create Team1
 	team1 := &model.Team{
 		DisplayName:      "Team1",
@@ -3657,7 +3661,7 @@ func testGetGroups(t *testing.T, rctx request.CTX, ss store.Store) {
 	// Create Groups 1 and 2
 	group1, err := ss.Group().Create(&model.Group{
 		Name:           model.NewPointer(model.NewId()),
-		DisplayName:    "group-1",
+		DisplayName:    uid + "-group-1",
 		RemoteId:       model.NewPointer(model.NewId()),
 		Source:         model.GroupSourceLdap,
 		AllowReference: true,
@@ -3665,8 +3669,8 @@ func testGetGroups(t *testing.T, rctx request.CTX, ss store.Store) {
 	require.NoError(t, err)
 
 	group2, err := ss.Group().Create(&model.Group{
-		Name:           model.NewPointer(model.NewId() + "-group-2"),
-		DisplayName:    "group-2",
+		Name:           model.NewPointer(model.NewId() + "-" + uid + "-group-2"),
+		DisplayName:    uid + "-group-2",
 		RemoteId:       model.NewPointer(model.NewId()),
 		Source:         model.GroupSourceLdap,
 		AllowReference: false,
@@ -3674,8 +3678,8 @@ func testGetGroups(t *testing.T, rctx request.CTX, ss store.Store) {
 	require.NoError(t, err)
 
 	deletedGroup, err := ss.Group().Create(&model.Group{
-		Name:           model.NewPointer(model.NewId() + "-group-deleted"),
-		DisplayName:    "group-deleted",
+		Name:           model.NewPointer(model.NewId() + "-" + uid + "-group-deleted"),
+		DisplayName:    uid + "-group-deleted",
 		RemoteId:       model.NewPointer(model.NewId()),
 		Source:         model.GroupSourceLdap,
 		AllowReference: false,
@@ -3730,8 +3734,8 @@ func testGetGroups(t *testing.T, rctx request.CTX, ss store.Store) {
 
 	// Create Group3
 	group3, err := ss.Group().Create(&model.Group{
-		Name:           model.NewPointer(model.NewId() + "-group-3"),
-		DisplayName:    "group-3",
+		Name:           model.NewPointer(model.NewId() + "-" + uid + "-group-3"),
+		DisplayName:    uid + "-group-3",
 		RemoteId:       model.NewPointer(model.NewId()),
 		Source:         model.GroupSourceLdap,
 		AllowReference: true,
@@ -3843,7 +3847,7 @@ func testGetGroups(t *testing.T, rctx request.CTX, ss store.Store) {
 	user2.DeleteAt = 1
 	u2Update, _ := ss.User().Update(rctx, user2, true)
 
-	group2NameSubstring := "group-2"
+	group2NameSubstring := uid + "-group-2"
 
 	endCreateTime := u2Update.New.UpdateAt + 1
 
@@ -3927,12 +3931,15 @@ func testGetGroups(t *testing.T, rctx request.CTX, ss store.Store) {
 		},
 		{
 			Name:    "Get group matching display name",
-			Opts:    model.GroupSearchOpts{Q: "rouP-3"},
+			Opts:    model.GroupSearchOpts{Q: uid + "-GrOuP-3"},
 			Page:    0,
 			PerPage: 100,
 			Resultf: func(groups []*model.Group) bool {
+				if len(groups) == 0 {
+					return false
+				}
 				for _, g := range groups {
-					if !strings.Contains(strings.ToLower(g.DisplayName), "roup-3") {
+					if !strings.Contains(strings.ToLower(g.DisplayName), uid+"-group-3") {
 						return false
 					}
 				}
@@ -3942,12 +3949,15 @@ func testGetGroups(t *testing.T, rctx request.CTX, ss store.Store) {
 		},
 		{
 			Name:    "Get group matching multiple display names",
-			Opts:    model.GroupSearchOpts{Q: "groUp"},
+			Opts:    model.GroupSearchOpts{Q: uid + "-GrOuP"},
 			Page:    0,
 			PerPage: 100,
 			Resultf: func(groups []*model.Group) bool {
+				if len(groups) < 2 {
+					return false
+				}
 				for _, g := range groups {
-					if !strings.Contains(strings.ToLower(g.DisplayName), "group") {
+					if !strings.Contains(strings.ToLower(g.DisplayName), uid+"-group") {
 						return false
 					}
 				}
@@ -4193,7 +4203,7 @@ func testGetGroups(t *testing.T, rctx request.CTX, ss store.Store) {
 		},
 		{
 			Name:    "Include archived groups",
-			Opts:    model.GroupSearchOpts{IncludeArchived: true, Q: "group-deleted"},
+			Opts:    model.GroupSearchOpts{IncludeArchived: true, Q: uid + "-group-deleted"},
 			Page:    0,
 			PerPage: 1,
 			Resultf: func(groups []*model.Group) bool {
@@ -4203,7 +4213,7 @@ func testGetGroups(t *testing.T, rctx request.CTX, ss store.Store) {
 		},
 		{
 			Name:    "Only return archived groups",
-			Opts:    model.GroupSearchOpts{FilterArchived: true, Q: "group-1"},
+			Opts:    model.GroupSearchOpts{FilterArchived: true, Q: uid + "-group-1"},
 			Page:    0,
 			PerPage: 1,
 			Resultf: func(groups []*model.Group) bool {

--- a/server/public/pluginapi/cluster/job_once_test.go
+++ b/server/public/pluginapi/cluster/job_once_test.go
@@ -343,29 +343,26 @@ func TestScheduleOnceSequential(t *testing.T) {
 		err = s.scheduleNewJobsFromDB()
 		require.NoError(t, err)
 
-		// wait for the testPagingJobs created in the setup to finish
-		time.Sleep(300 * time.Millisecond)
-
-		numInDB := 0
-		numActive := 0
-		numCountsAtZero := 0
-		for k, v := range testPagingJobs {
-			if getVal(oncePrefix+k) != nil {
-				numInDB++
+		// Wait for all paging jobs to complete. Use polling instead of a
+		// fixed sleep because the race detector slows execution significantly,
+		// making a 300ms window insufficient for 25+ scheduled jobs.
+		require.Eventually(t, func() bool {
+			for k, v := range testPagingJobs {
+				if getVal(oncePrefix+k) != nil {
+					return false
+				}
+				s.activeJobs.mu.RLock()
+				active := s.activeJobs.jobs[k] != nil
+				s.activeJobs.mu.RUnlock()
+				if active {
+					return false
+				}
+				if atomic.LoadInt32(v) != int32(1) {
+					return false
+				}
 			}
-			s.activeJobs.mu.RLock()
-			if s.activeJobs.jobs[k] != nil {
-				numActive++
-			}
-			s.activeJobs.mu.RUnlock()
-			if atomic.LoadInt32(v) == int32(0) {
-				numCountsAtZero++
-			}
-		}
-
-		assert.Equal(t, 0, numInDB)
-		assert.Equal(t, 0, numActive)
-		assert.Equal(t, 0, numCountsAtZero)
+			return true
+		}, 5*time.Second, 50*time.Millisecond, "timed out waiting for paging jobs to complete")
 	})
 
 	t.Run("failed at the db", func(t *testing.T) {


### PR DESCRIPTION
- fix: resolve DATA RACE in TestReplicaLagQuery, TestInvalidReplicaLagDataSource, and TestMetrics (#35881)
- fix: prevent sql.DB connectionCleaner race and harden flaky tests (#35891)
- docs: upstream sync 2026-03-31 진행 (picked 2)