### PR TITLE
i18n(ko): 라이선스 메일·초대 모달 한국어 번역 정비

### DIFF
--- a/server/i18n/ko.json
+++ b/server/i18n/ko.json
@@ -3603,20 +3603,32 @@
     "translation": "워크스페이스에 접속하는 데 문제가 있습니까?"
   },
   {
+    "id": "api.templates.license_need_help.info",
+    "translation": "<a href=\"https://mattermost.com/contact-sales/\">영업팀에 문의</a>하여 요금제와 갱신 옵션을 안내받으세요."
+  },
+  {
+    "id": "api.templates.license_need_help.title",
+    "translation": "도움이 필요하신가요?"
+  },
+  {
     "id": "api.templates.license_up_for_renewal_contact_sales",
     "translation": "판매 문의"
   },
   {
     "id": "api.templates.license_up_for_renewal_subject",
-    "translation": "당신의 라이선스가 갱신되었습니다"
+    "translation": "{{.SkuName}} 라이선스 갱신 시기가 되었습니다"
   },
   {
     "id": "api.templates.license_up_for_renewal_subtitle",
-    "translation": "{{.UserName}}, 당신의 구독은 {{.Days}}일 후에 만료됩니다. 우리는 당신이 OKR.BEST가 제공하는 유연하고 안전한 팀 협업을 경험하고 있기를 바랍니다. 빨리 갱신하여 팀이 이러한 이점을 계속 즐길 수 있도록 해주세요."
+    "translation": "<a href=\"{{.SiteURL}}\">{{.SiteName}}</a>의 {{.SkuName}} 라이선스가 {{.Days}}일 후 만료됩니다. OKR.BEST가 제공하는 안전하고 중요한 협업 환경을 잘 활용하고 계시길 바랍니다."
+  },
+  {
+    "id": "api.templates.license_up_for_renewal_subtitle_two",
+    "translation": "지금 갱신하면 팀이 이러한 이점을 계속 누릴 수 있습니다."
   },
   {
     "id": "api.templates.license_up_for_renewal_title",
-    "translation": "OKR.BEST 구독이 갱신되었습니다"
+    "translation": "OKR.BEST 라이선스 갱신 시기가 되었습니다"
   },
   {
     "id": "api.templates.mfa_activated_body.info",
@@ -3663,12 +3675,20 @@
     "translation": "문의사항이 있으신가요?"
   },
   {
-    "id": "api.templates.remove_expired_license.body.title",
-    "translation": "당신의 엔터프라이즈 라이선스가 만료되었고 일부 기능이 비활성화될 수 있습니다. 지금 라이선스를 갱신하세요."
+    "id": "api.templates.remove_expired_license.body.heading",
+    "translation": "OKR.BEST 라이선스가 만료되었습니다"
+  },
+  {
+    "id": "api.templates.remove_expired_license.body.subtitle",
+    "translation": "<a href=\"{{.SiteURL}}\">{{.SiteName}}</a>의 {{.SkuName}} 라이선스가 만료되어 일부 기능이 비활성화될 수 있습니다."
+  },
+  {
+    "id": "api.templates.remove_expired_license.body.subtitle_two",
+    "translation": "OKR.BEST의 모든 기능을 계속 사용하려면 지금 라이선스를 갱신하세요."
   },
   {
     "id": "api.templates.remove_expired_license.subject",
-    "translation": "OKR.BEST 엔터프라이즈 라이선스가 비활성화되었습니다."
+    "translation": "{{.SkuName}} 라이선스가 만료되었습니다"
   },
   {
     "id": "api.templates.reset_body.button",

--- a/webapp/channels/src/i18n/ko.json
+++ b/webapp/channels/src/i18n/ko.json
@@ -5503,7 +5503,7 @@
   "onboarding_wizard.invite_members.copied_link": "링크 복사됨",
   "onboarding_wizard.invite_members.copy_link": "링크 복사",
   "onboarding_wizard.invite_members.copy_link_input": "팀 초대 링크",
-  "onboarding_wizard.invite_members.description": "혼자서는 협업하기 어렵습니다. 팀 멤버를 초대하세요. 각 이메일 주소는 공백이나 쉼표로 구분하세요.",
+  "onboarding_wizard.invite_members.description": "혼자서는 협업하기 어렵습니다. 팀 멤버를 초대하세요. 각 이메일 주소는 쉼표나 세미콜론으로 구분하세요.",
   "onboarding_wizard.invite_members.description_link": "혼자서는 협업하기 어렵습니다. 아래 초대 링크를 사용하여 팀 멤버를 초대하세요.",
   "onboarding_wizard.invite_members.next": "초대 보내기",
   "onboarding_wizard.invite_members.next_link": "설정 완료",


### PR DESCRIPTION
upstream sync(f6d5d9e1, 00b25946) 후속으로 밀려 있던 ko 항목 10건을 정리한다.

- 오안내 1건: 초대 모달 안내가 '공백이나 쉼표로 구분'이라 했으나 00b25946으로
  공백이 구분자에서 빠졌다. '쉼표나 세미콜론'으로 정정.
- 깨진 변수 1건: license_up_for_renewal_subtitle의 ko가 {{.UserName}}을 참조했으나
  f6d5d9e1 이후 email.go는 SkuName/SiteURL/SiteName/Days만 넘긴다 — 한국어 메일에
  <no value>가 찍히던 상태였다.
- 오역 3건: '갱신 시기가 되었다'를 '갱신되었다'로, '만료'를 '비활성화'로 옮겨
  의미가 뒤집혀 있던 subject·title을 바로잡았다.
- 신규 6건 번역 추가, orphan 1건(remove_expired_license.body.title) 제거로
  server ko orphan을 기준선 58로 되돌린다.

제품명은 기존 ko 관례대로 OKR.BEST로 쓰고, upstream URL은 그대로 둔다
(api.license.request-trial.can-start-trial.not-allowed 등 8개 키와 동일한 처리).
