### PR TITLE
fix(e2e): 팀원 이름 표시 기본값을 nickname_full_name으로 맞춘다

### DIFF
--- a/e2e-tests/cypress/tests/support/api/cloud_default_config.json
+++ b/e2e-tests/cypress/tests/support/api/cloud_default_config.json
@@ -128,7 +128,7 @@
         "MaxChannelsPerTeam": 2000,
         "MaxNotificationsPerChannel": 1000,
         "EnableConfirmNotificationsToChannel": true,
-        "TeammateNameDisplay": "username",
+        "TeammateNameDisplay": "nickname_full_name",
         "ExperimentalEnableAutomaticReplies": false,
         "LockTeammateNameDisplay": false,
         "ExperimentalPrimaryTeam": "",

--- a/e2e-tests/cypress/tests/support/api/on_prem_default_config.json
+++ b/e2e-tests/cypress/tests/support/api/on_prem_default_config.json
@@ -130,7 +130,7 @@
         "MaxChannelsPerTeam": 2000,
         "MaxNotificationsPerChannel": 1000,
         "EnableConfirmNotificationsToChannel": true,
-        "TeammateNameDisplay": "username",
+        "TeammateNameDisplay": "nickname_full_name",
         "ExperimentalEnableAutomaticReplies": false,
         "LockTeammateNameDisplay": false,
         "ExperimentalPrimaryTeam": "",

--- a/e2e-tests/cypress/tests/support/index.js
+++ b/e2e-tests/cypress/tests/support/index.js
@@ -253,7 +253,7 @@ function sysadminSetup(user) {
 }
 
 function resetUserPreference(userId) {
-    cy.apiSaveTeammateNameDisplayPreference('username');
+    cy.apiSaveTeammateNameDisplayPreference('nickname_full_name');
     cy.apiSaveLinkPreviewsPreference('true');
     cy.apiSaveCollapsePreviewsPreference('false');
     cy.apiSaveClockDisplayModeTo24HourPreference(false);

--- a/e2e-tests/playwright/lib/src/server/default_config.ts
+++ b/e2e-tests/playwright/lib/src/server/default_config.ts
@@ -234,7 +234,7 @@ const defaultServerConfig: AdminConfig = {
         MaxChannelsPerTeam: 2000,
         MaxNotificationsPerChannel: 1000,
         EnableConfirmNotificationsToChannel: true,
-        TeammateNameDisplay: 'username',
+        TeammateNameDisplay: 'nickname_full_name',
         ExperimentalEnableAutomaticReplies: false,
         LockTeammateNameDisplay: false,
         ExperimentalPrimaryTeam: '',


### PR DESCRIPTION
d832dacbc4가 서버 기본값(SetDefaults)을 ShowNicknameFullName으로 바꿨으나
e2e 기본 설정은 username으로 남아 있어, 테스트가 제품과 다른 표시 형식을
전제하고 있었다. Cypress 기본 config 2개, Playwright 기본 config,
resetUserPreference를 함께 맞춘다.

username 모드에서는 포크 자체 형식("<username> - <성명> (<별명>)")이 적용돼
게시물 작성자와 멘션이 "admin - 어드민"처럼 보인다. 제품 기본값은
nickname_full_name이므로 e2e도 같은 전제로 돌아야 한다.

명시적으로 apiSaveTeammateNameDisplayPreference를 호출하는 스펙 12개는
스스로 설정하므로 영향받지 않는다.
