### PR TITLE
upstream sync 2026-04-20 (picked 4, adapted 2)

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,28 @@
+name: YAML Lint
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".yamllint"
+
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Lint workflow YAML files
+        run: yamllint .github/workflows/

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+extends: default
+
+rules:
+  key-duplicates: enable
+  empty-lines: disable
+  line-length: disable
+  trailing-spaces: disable

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2807,7 +2807,7 @@ This product contains 'aws/aws-sdk-go-v2' by Amazon Web Services.
 AWS SDK for the Go programming language. 
 
 * HOMEPAGE:
-  * https://github.com/aws/aws-sdk-go-v2
+  * https://docs.aws.amazon.com/sdk-for-go/
 
 * LICENSE: Apache License 2.0
 
@@ -3024,7 +3024,7 @@ This product contains 'aws/aws-sdk-go-v2' by Amazon Web Services.
 AWS SDK for the Go programming language. 
 
 * HOMEPAGE:
-  * https://github.com/aws/aws-sdk-go-v2
+  * https://docs.aws.amazon.com/sdk-for-go/
 
 * LICENSE: Apache License 2.0
 
@@ -3241,7 +3241,7 @@ This product contains 'aws/aws-sdk-go-v2' by Amazon Web Services.
 AWS SDK for the Go programming language. 
 
 * HOMEPAGE:
-  * https://github.com/aws/aws-sdk-go-v2
+  * https://docs.aws.amazon.com/sdk-for-go/
 
 * LICENSE: Apache License 2.0
 
@@ -3458,7 +3458,7 @@ This product contains 'aws/aws-sdk-go-v2' by Amazon Web Services.
 AWS SDK for the Go programming language. 
 
 * HOMEPAGE:
-  * https://github.com/aws/aws-sdk-go-v2
+  * https://docs.aws.amazon.com/sdk-for-go/
 
 * LICENSE: Apache License 2.0
 
@@ -3675,7 +3675,7 @@ This product contains 'aws/aws-sdk-go-v2' by Amazon Web Services.
 AWS SDK for the Go programming language. 
 
 * HOMEPAGE:
-  * https://github.com/aws/aws-sdk-go-v2
+  * https://docs.aws.amazon.com/sdk-for-go/
 
 * LICENSE: Apache License 2.0
 
@@ -12924,6 +12924,48 @@ copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+---
+
+## x/text
+
+This product contains 'x/text' by Go.
+
+[mirror] Go text processing support
+
+* HOMEPAGE:
+  * https://golang.org/x/text
+
+* LICENSE: BSD 3-Clause "New" or "Revised" License
+
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 

--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,21 +3,15 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-18 14:28
+- 갱신일: 2026-08-19 12:00
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 785개
+- 남은 커밋: 792개
 
-**마지막 반영 커밋:** `bf843017` | [MM-38308 Remove remaining support for IE and pre-Chromium Edge (#36034)](https://github.com/mattermost/mattermost/commit/bf84301784777a6e08f9709ee882b0eac029437a) | 2026-04-17
+**마지막 반영 커밋:** `9c8191c3` | [ci: add yamllint workflow to detect duplicate YAML keys (#36010)](https://github.com/mattermost/mattermost/commit/9c8191c3b8a8a41352d21ca69be5b05a5f1de800) | 2026-04-20
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 0c99cc36 | [Add Playwright E2E tests for demo plugin server-side slash commands (#36146)](https://github.com/mattermost/mattermost/commit/0c99cc36cc45900f784a0cec3fa95d91988f6a5d) | 2026-04-20 |
-| 8cd48d46 | [\[MM-67880\] Add /mobile-logs slash command (#35658)](https://github.com/mattermost/mattermost/commit/8cd48d46514dfe42e1693c890e02ff5228be9d3d) | 2026-04-20 |
-| 978b0385 | [chore: Update NOTICE.txt file with updated dependencies (#36184)](https://github.com/mattermost/mattermost/commit/978b038561bed7935f9748776c78e55ca5f138b3) | 2026-04-20 |
-| 827fafca | [MM-68367: Warn in System Console when cluster sniffing is enabled (#36174)](https://github.com/mattermost/mattermost/commit/827fafca857f9d7d1fe487c9781cabcd4e5e1463) | 2026-04-20 |
 | c8f0a314 | [ci: move FIPS and binary params tests to weekly schedule (#36036)](https://github.com/mattermost/mattermost/commit/c8f0a31425a01cb7b95cc9ff1ef08714f88ffe52) | 2026-04-20 |
-| 5b810f91 | [fix(tests): re-enable 10 flaky tests across 12 JIRA tickets (#36159)](https://github.com/mattermost/mattermost/commit/5b810f917c54fa79310cd9ae915cf9ef1d07d7ef) | 2026-04-20 |
-| 9c8191c3 | [ci: add yamllint workflow to detect duplicate YAML keys (#36010)](https://github.com/mattermost/mattermost/commit/9c8191c3b8a8a41352d21ca69be5b05a5f1de800) | 2026-04-20 |
 | 39d25d94 | [MM-68259 Fixing text and emojis being clipped in channel banners (#36076)](https://github.com/mattermost/mattermost/commit/39d25d94ddd766ac9445eba0d2afdaffe74cc768) | 2026-04-21 |
 | 9aae84bc | [\[MM-67981\] Add process ID (PID) to support packet diagnostics (#35832)](https://github.com/mattermost/mattermost/commit/9aae84bc3f23be506f9a3b93f221290841555de6) | 2026-04-21 |
 | 52fa113d | [\[MM-67977\] Add Go runtime version to support packet diagnostics (#35833)](https://github.com/mattermost/mattermost/commit/52fa113dfc58af3c002ad5f3f5a743d2ebba328d) | 2026-04-21 |
@@ -796,6 +790,19 @@
 | fd62fe4f | [Allow granting delegated administration roles from the Manage Roles modal (#37202)](https://github.com/mattermost/mattermost/commit/fd62fe4faacf03845d9f723eeacba8798226587d) | 2026-08-17 |
 | d989f802 | [Disable TTL/grace period editing for server-derived attributes (#38001)](https://github.com/mattermost/mattermost/commit/d989f802d537023732e4d59fceca6cb731220bb6) | 2026-08-17 |
 | 6d78e8d5 | [Keep a collapse toggle for single video attachments (#38012)](https://github.com/mattermost/mattermost/commit/6d78e8d55189626ac765d4504dfca61d430b8490) | 2026-08-17 |
+| f112b9a7 | [Remove deprecated built-in Slack import API and CLI (#37999)](https://github.com/mattermost/mattermost/commit/f112b9a7159b25c630a52b05dc27dfc2f9b5d694) | 2026-08-18 |
+| 54939d47 | [\[MM-68249\] Drop support for OpenSearch v1.x (#37283)](https://github.com/mattermost/mattermost/commit/54939d47c0b64f0c15c0c992223f7db1aff2476a) | 2026-08-18 |
+| 95fc4743 | [Drop RHEL 7/8 support: switch build image to golang-bookworm (#37229)](https://github.com/mattermost/mattermost/commit/95fc4743df54efd8bbaba148c0e8542d8158c7c1) | 2026-08-18 |
+| dc6ab54f | [MM-67510 Drop deprecated autotranslation column from ChannelMembers (#37496)](https://github.com/mattermost/mattermost/commit/dc6ab54f82f624ec2bc1ffc895484df8198a063c) | 2026-08-18 |
+| 0912a75c | [Bump minimum supported Postgres version to v15 (#37285)](https://github.com/mattermost/mattermost/commit/0912a75c9c4580a00f14c565215fed5ffcb0fbf7) | 2026-08-18 |
+| eb3966e3 | [Remove atmos/camo image proxy support (#37284)](https://github.com/mattermost/mattermost/commit/eb3966e30bf4e13a0fdef43bb87429c54a6b7e25) | 2026-08-18 |
+| 6938caba | [\[MM-69646\] Disallow MoveThreadsEnabled feature flag (fail server startup) (#37966)](https://github.com/mattermost/mattermost/commit/6938cabac6b7d177962b74bc84df75b57b16d233) | 2026-08-18 |
+| 44d12bef | [\[MM-66243\] Omit sanitized last_viewed_at/last_update_at instead of returning -1 for other users (#37505)](https://github.com/mattermost/mattermost/commit/44d12bef8037de88f50150a5795e0b183924e1d6) | 2026-08-18 |
+| 5bd5b3b8 | [\[MM-69865\] Add Delete row action to Manage Attributes (#37875)](https://github.com/mattermost/mattermost/commit/5bd5b3b899f7ce2eb5d981015db2a37077746a8c) | 2026-08-18 |
+| 78d12039 | [MM-68396: Remove deprecated dialog date/datetime fields for v12.0 (#37759)](https://github.com/mattermost/mattermost/commit/78d120399f1b5e9474e9b453fdc909fabf65801a) | 2026-08-18 |
+| 0bff02c8 | [Graduate user typing settings to Site Configuration > Posts (#38023)](https://github.com/mattermost/mattermost/commit/0bff02c8148abbea87f260c28839ae2ab4da3aee) | 2026-08-18 |
+| 925a09a5 | [Remove dead Email login button color settings (#38021)](https://github.com/mattermost/mattermost/commit/925a09a5f22180b3250c2bd0c2a006cfea65aee5) | 2026-08-18 |
+| ede2edab | [Enforce snake_case for mlog field keys (#37998)](https://github.com/mattermost/mattermost/commit/ede2edab4dabc7d5777f02ec3135197a659615ca) | 2026-08-18 |
 
 ## 제외된 커밋
 

--- a/e2e-tests/playwright/specs/functional/channels/mobile_logs_command.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/mobile_logs_command.spec.ts
@@ -1,0 +1,320 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+/**
+ * Helper to find the attach_app_logs preference for a given user.
+ */
+async function getAttachLogsPreference(
+    userClient: {
+        getUserPreferences: (userId: string) => Promise<Array<{category: string; name: string; value: string}>>;
+    },
+    userId: string,
+) {
+    const prefs = await userClient.getUserPreferences(userId);
+    return prefs.find(
+        (p: {category: string; name: string}) => p.category === 'advanced_settings' && p.name === 'attach_app_logs',
+    );
+}
+
+test.describe('/mobile-logs slash command', () => {
+    /**
+     * @objective Verify that /mobile-logs on sets the attach_app_logs preference to true
+     *            and returns an ephemeral confirmation visible only to the invoking user.
+     */
+    test(
+        'MM-T67880 enables mobile logs for self and confirms preference is set',
+        {tag: '@slash_commands'},
+        async ({pw}) => {
+            // # Initialize setup
+            const {team, user, userClient} = await pw.initSetup();
+
+            // # Log in as the user and navigate to town-square
+            const {channelsPage} = await pw.testBrowser.login(user);
+            await channelsPage.goto(team.name, 'town-square');
+            await channelsPage.toBeVisible();
+
+            // # Execute /mobile-logs on
+            await channelsPage.postMessage('/mobile-logs on');
+
+            // * Verify ephemeral response confirms logs enabled
+            const lastPost = await channelsPage.getLastPost();
+            await lastPost.toContainText('Mobile app log attachment is now enabled for you');
+
+            // * Verify the response is ephemeral (only visible to the user)
+            await expect(lastPost.container.locator('.post__visibility')).toContainText('(Only visible to you)');
+
+            // * Verify the preference was actually set via API
+            const logPref = await getAttachLogsPreference(userClient, user.id);
+            expect(logPref).toBeDefined();
+            expect(logPref!.value).toBe('true');
+        },
+    );
+
+    /**
+     * @objective Verify that /mobile-logs off sets the attach_app_logs preference to false
+     *            and returns an ephemeral confirmation.
+     */
+    test('MM-T67880 disables mobile logs for self after enabling via API', {tag: '@slash_commands'}, async ({pw}) => {
+        // # Initialize setup
+        const {team, user, userClient} = await pw.initSetup();
+
+        // # Pre-enable the preference via API to avoid back-to-back commands
+        await userClient.savePreferences(user.id, [
+            {user_id: user.id, category: 'advanced_settings', name: 'attach_app_logs', value: 'true'},
+        ]);
+
+        // # Log in as the user and navigate to town-square
+        const {channelsPage} = await pw.testBrowser.login(user);
+        await channelsPage.goto(team.name, 'town-square');
+        await channelsPage.toBeVisible();
+
+        // # Execute /mobile-logs off
+        await channelsPage.postMessage('/mobile-logs off');
+
+        // * Verify ephemeral response confirms logs disabled
+        const lastPost = await channelsPage.getLastPost();
+        await lastPost.toContainText('Mobile app log attachment is now disabled for you');
+
+        // * Verify the preference was set to false via API
+        const logPref = await getAttachLogsPreference(userClient, user.id);
+        expect(logPref).toBeDefined();
+        expect(logPref!.value).toBe('false');
+    });
+
+    /**
+     * @objective Verify that /mobile-logs status reports disabled by default for a fresh user.
+     */
+    test(
+        'MM-T67880 reports mobile logs status as disabled for a fresh user',
+        {tag: '@slash_commands'},
+        async ({pw}) => {
+            // # Initialize setup
+            const {team, user} = await pw.initSetup();
+
+            // # Log in as the user and navigate to town-square
+            const {channelsPage} = await pw.testBrowser.login(user);
+            await channelsPage.goto(team.name, 'town-square');
+            await channelsPage.toBeVisible();
+
+            // # Execute /mobile-logs status
+            await channelsPage.postMessage('/mobile-logs status');
+
+            // * Verify ephemeral response shows disabled
+            const lastPost = await channelsPage.getLastPost();
+            await lastPost.toContainText('Mobile app log attachment is currently disabled for you');
+        },
+    );
+
+    /**
+     * @objective Verify that /mobile-logs status reports enabled after the preference
+     *            has been set to true via API.
+     */
+    test(
+        'MM-T67880 reports mobile logs status as enabled after preference is set',
+        {tag: '@slash_commands'},
+        async ({pw}) => {
+            // # Initialize setup
+            const {team, user, userClient} = await pw.initSetup();
+
+            // # Pre-enable the preference via API
+            await userClient.savePreferences(user.id, [
+                {user_id: user.id, category: 'advanced_settings', name: 'attach_app_logs', value: 'true'},
+            ]);
+
+            // # Log in as the user and navigate to town-square
+            const {channelsPage} = await pw.testBrowser.login(user);
+            await channelsPage.goto(team.name, 'town-square');
+            await channelsPage.toBeVisible();
+
+            // # Execute /mobile-logs status
+            await channelsPage.postMessage('/mobile-logs status');
+
+            // * Verify ephemeral response shows enabled
+            const lastPost = await channelsPage.getLastPost();
+            await lastPost.toContainText('Mobile app log attachment is currently enabled for you');
+        },
+    );
+
+    /**
+     * @objective Verify that /mobile-logs displays a usage hint when invoked
+     *            without arguments or with an invalid action.
+     */
+    test('MM-T67880 displays usage hint for invalid or missing arguments', {tag: '@slash_commands'}, async ({pw}) => {
+        // # Initialize setup
+        const {team, user} = await pw.initSetup();
+
+        // # Log in as the user and navigate to town-square
+        const {channelsPage} = await pw.testBrowser.login(user);
+        await channelsPage.goto(team.name, 'town-square');
+        await channelsPage.toBeVisible();
+
+        // # Execute /mobile-logs with an invalid action
+        await channelsPage.postMessage('/mobile-logs invalid');
+
+        // * Verify usage message is shown
+        const lastPost = await channelsPage.getLastPost();
+        await lastPost.toContainText('Usage: /mobile-logs [on|off|status] [@username]');
+    });
+
+    /**
+     * @objective Verify that a system admin can enable mobile logs for another user
+     *            and the preference is persisted on the target user's account.
+     */
+    test(
+        'MM-T67880 admin enables mobile logs for another user and preference is persisted',
+        {tag: '@slash_commands'},
+        async ({pw}) => {
+            // # Initialize setup
+            const {team, adminUser, user, userClient} = await pw.initSetup();
+
+            // # Log in as admin and navigate to town-square
+            const {channelsPage} = await pw.testBrowser.login(adminUser);
+            await channelsPage.goto(team.name, 'town-square');
+            await channelsPage.toBeVisible();
+
+            // # Execute /mobile-logs on for the regular user
+            await channelsPage.postMessage(`/mobile-logs on @${user.username}`);
+
+            // * Verify ephemeral response confirms logs enabled for the target user
+            const lastPost = await channelsPage.getLastPost();
+            await lastPost.toContainText(`Mobile app log attachment is now enabled for @${user.username}`);
+
+            // * Verify the preference was set on the target user via API
+            const logPref = await getAttachLogsPreference(userClient, user.id);
+            expect(logPref).toBeDefined();
+            expect(logPref!.value).toBe('true');
+        },
+    );
+
+    /**
+     * @objective Verify that a system admin can disable mobile logs for another user
+     *            after they have been enabled.
+     */
+    test(
+        'MM-T67880 admin disables mobile logs for another user after enabling via API',
+        {tag: '@slash_commands'},
+        async ({pw}) => {
+            // # Initialize setup
+            const {team, adminUser, user, userClient} = await pw.initSetup();
+
+            // # Pre-enable the preference for the target user via API
+            const {adminClient} = await pw.getAdminClient();
+            await adminClient.savePreferences(user.id, [
+                {user_id: user.id, category: 'advanced_settings', name: 'attach_app_logs', value: 'true'},
+            ]);
+
+            // # Log in as admin and navigate to town-square
+            const {channelsPage} = await pw.testBrowser.login(adminUser);
+            await channelsPage.goto(team.name, 'town-square');
+            await channelsPage.toBeVisible();
+
+            // # Disable for the regular user
+            await channelsPage.postMessage(`/mobile-logs off @${user.username}`);
+
+            // * Verify ephemeral response confirms logs disabled
+            const lastPost = await channelsPage.getLastPost();
+            await lastPost.toContainText(`Mobile app log attachment is now disabled for @${user.username}`);
+
+            // * Verify the preference was set to false on the target user
+            const logPref = await getAttachLogsPreference(userClient, user.id);
+            expect(logPref).toBeDefined();
+            expect(logPref!.value).toBe('false');
+        },
+    );
+
+    /**
+     * @objective Verify that a non-admin user is denied when attempting to modify
+     *            another user's mobile logs preference.
+     */
+    test(
+        'MM-T67880 rejects mobile log modification when caller is not an admin',
+        {tag: '@slash_commands'},
+        async ({pw}) => {
+            // # Initialize setup with two regular users
+            const {team, adminClient, user} = await pw.initSetup();
+
+            const otherUser = await pw.random.user('other');
+            const {id: otherUserId} = await adminClient.createUser(otherUser, '', '');
+            await adminClient.addToTeam(team.id, otherUserId);
+
+            // # Log in as the first regular user
+            const {channelsPage} = await pw.testBrowser.login(user);
+            await channelsPage.goto(team.name, 'town-square');
+            await channelsPage.toBeVisible();
+
+            // # Try to enable mobile logs for the other user
+            await channelsPage.postMessage(`/mobile-logs on @${otherUser.username}`);
+
+            // * Verify permission denied message
+            const lastPost = await channelsPage.getLastPost();
+            await lastPost.toContainText('Unable to change mobile log settings for that user.');
+        },
+    );
+
+    /**
+     * @objective Verify that a regular user cannot infer whether a username exists when
+     *            attempting to target another account (same denial as missing permission).
+     */
+    test(
+        'MM-T67880 regular user gets permission denial for nonexistent cross-user target',
+        {tag: '@slash_commands'},
+        async ({pw}) => {
+            const {team, user} = await pw.initSetup();
+
+            const {channelsPage} = await pw.testBrowser.login(user);
+            await channelsPage.goto(team.name, 'town-square');
+            await channelsPage.toBeVisible();
+
+            // # Post the mobile-logs command
+            await channelsPage.postMessage('/mobile-logs on @nonexistentuser12345');
+
+            const lastPost = await channelsPage.getLastPost();
+            // * Expect permission denial message
+            await lastPost.toContainText('Unable to change mobile log settings for that user.');
+        },
+    );
+
+    /**
+     * @objective Verify that a system admin can check the mobile logs status for another
+     *            user and it correctly reflects the current preference state.
+     */
+    test('MM-T67880 admin checks mobile logs status for another user', {tag: '@slash_commands'}, async ({pw}) => {
+        // # Initialize setup
+        const {team, adminUser, user} = await pw.initSetup();
+
+        // # Log in as admin and navigate to town-square
+        const {channelsPage} = await pw.testBrowser.login(adminUser);
+        await channelsPage.goto(team.name, 'town-square');
+        await channelsPage.toBeVisible();
+
+        // # Check status (default off)
+        await channelsPage.postMessage(`/mobile-logs status @${user.username}`);
+
+        // * Verify status shows disabled
+        const statusOffPost = await channelsPage.getLastPost();
+        await statusOffPost.toContainText(`Mobile app log attachment is currently disabled for @${user.username}`);
+    });
+
+    /**
+     * @objective Verify that /mobile-logs returns a user-not-found error when targeting
+     *            a nonexistent username.
+     */
+    test('MM-T67880 returns error for nonexistent target user', {tag: '@slash_commands'}, async ({pw}) => {
+        // # Initialize setup
+        const {team, adminUser} = await pw.initSetup();
+
+        // # Log in as admin
+        const {channelsPage} = await pw.testBrowser.login(adminUser);
+        await channelsPage.goto(team.name, 'town-square');
+        await channelsPage.toBeVisible();
+
+        // # Try to enable for a nonexistent user
+        await channelsPage.postMessage('/mobile-logs on @nonexistentuser12345');
+
+        // * Verify user not found message
+        const lastPost = await channelsPage.getLastPost();
+        await lastPost.toContainText('Could not find user "nonexistentuser12345"');
+    });
+});

--- a/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_dialog.spec.ts
+++ b/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_dialog.spec.ts
@@ -1,0 +1,202 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+import {setupDemoPlugin} from '../../helpers';
+
+test('should open /dialog and post submit confirmation on submit', async ({pw}) => {
+    // 1. Setup
+    const {adminClient, user, team} = await pw.initSetup();
+    await setupDemoPlugin(adminClient, pw);
+
+    // 2. Login
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    // 3. Navigate to Demo Plugin channel
+    await channelsPage.goto(team.name, 'town-square');
+    await channelsPage.toBeVisible();
+
+    // 4. Send /dialog command
+    await channelsPage.centerView.postCreate.input.fill('/dialog');
+    await channelsPage.centerView.postCreate.sendMessage();
+
+    // 5. Confirm dialog opens with title "Test Title"
+    const dialog = channelsPage.page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('heading', {level: 1})).toContainText('Test Title');
+
+    // 6. Fill required fields
+    // Display Name already has default "default text" — overwrite
+    await dialog.getByTestId('realnameinput').fill('Test Input');
+
+    // Email and Password are required
+    await dialog.getByTestId('someemailemail').fill('test@example.com');
+    await dialog.getByTestId('somepasswordpassword').fill('testpassword123');
+
+    // Number is required
+    await dialog.getByTestId('somenumbernumber').fill('42');
+
+    // Option Selector — required, no default (3rd combobox: User Selector, Channel Selector, Option Selector)
+    await dialog.getByRole('combobox').nth(2).click();
+    await channelsPage.page.getByRole('option', {name: 'Option1'}).click();
+
+    // Required checkboxes
+    await dialog.getByRole('checkbox', {name: 'Agree to the terms of service'}).check();
+    await dialog.getByRole('checkbox', {name: 'Agree to the annoying terms of service'}).check();
+
+    // Radio Option Selector — required
+    await dialog.getByRole('radio', {name: 'Option1'}).click();
+
+    // 7. Submit the dialog
+    await dialog.getByRole('button', {name: 'Submit'}).click();
+    await expect(dialog).not.toBeVisible();
+
+    // 8. Verify the submit post appears in the channel
+    // Note: "Interative" is a typo in the demo plugin — not a test error
+    await expect(
+        channelsPage.centerView.container.locator('p').filter({hasText: 'submitted an Interative Dialog'}),
+    ).toBeVisible();
+});
+
+test('should post cancellation notification when /dialog is cancelled', async ({pw}) => {
+    // 1. Setup
+    const {adminClient, user, team} = await pw.initSetup();
+    await setupDemoPlugin(adminClient, pw);
+
+    // 2. Login
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    // 3. Navigate to Demo Plugin channel
+    await channelsPage.goto(team.name, 'town-square');
+    await channelsPage.toBeVisible();
+
+    // 4. Send /dialog command
+    await channelsPage.centerView.postCreate.input.fill('/dialog');
+    await channelsPage.centerView.postCreate.sendMessage();
+
+    // 5. Confirm dialog opens
+    const dialog = channelsPage.page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('heading', {level: 1})).toContainText('Test Title');
+    await expect(dialog.getByRole('button', {name: 'Cancel'})).toBeVisible();
+    await expect(dialog.getByRole('button', {name: 'Submit'})).toBeVisible();
+
+    // 6. Cancel the dialog
+    await dialog.getByRole('button', {name: 'Cancel'}).click();
+    await expect(dialog).not.toBeVisible();
+
+    // 7. Verify the cancellation post appears in the channel
+    // Note: "Interative" is a typo in the demo plugin — not a test error
+    await expect(
+        channelsPage.centerView.container.locator('p').filter({hasText: 'canceled an Interative Dialog'}),
+    ).toBeVisible();
+});
+
+test('should show validation errors when required fields are submitted empty', async ({pw}) => {
+    // 1. Setup
+    const {adminClient, user, team} = await pw.initSetup();
+    await setupDemoPlugin(adminClient, pw);
+
+    // 2. Login
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    // 3. Navigate to Demo Plugin channel
+    await channelsPage.goto(team.name, 'town-square');
+    await channelsPage.toBeVisible();
+
+    // 4. Send /dialog command
+    await channelsPage.centerView.postCreate.input.fill('/dialog');
+    await channelsPage.centerView.postCreate.sendMessage();
+
+    // 5. Confirm dialog opens
+    const dialog = channelsPage.page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('heading', {level: 1})).toContainText('Test Title');
+
+    // 6. Clear the Number field and submit
+    await dialog.getByTestId('somenumbernumber').clear();
+    await dialog.getByRole('button', {name: 'Submit'}).click();
+
+    // 7. Verify dialog stays open with validation errors
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('Please fix all field errors', {exact: true})).toBeVisible();
+    await expect(dialog.getByTestId('somenumber').getByText('This field is required.', {exact: true})).toBeVisible();
+});
+
+test('should show general error and keep dialog open on /dialog error submit', async ({pw}) => {
+    // 1. Setup
+    const {adminClient, user, team} = await pw.initSetup();
+    await setupDemoPlugin(adminClient, pw);
+
+    // 2. Login
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    // 3. Navigate to Town Square
+    await channelsPage.goto(team.name, 'town-square');
+    await channelsPage.toBeVisible();
+
+    // 4. Send /dialog error command
+    await channelsPage.centerView.postCreate.input.fill('/dialog error');
+    await channelsPage.centerView.postCreate.sendMessage();
+
+    // 5. Confirm dialog opens with title "Simple Dialog Test"
+    const dialog = channelsPage.page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('heading', {level: 1})).toContainText('Simple Dialog Test');
+    await expect(dialog.getByRole('button', {name: 'Cancel'})).toBeVisible();
+    await expect(dialog.getByRole('button', {name: 'Submit Test'})).toBeVisible();
+
+    // 6. Fill the optional field and submit
+    await dialog.getByPlaceholder('Enter some text (optional)...').fill('sample test input');
+    await dialog.getByRole('button', {name: 'Submit Test'}).click();
+
+    // 7. Verify general error appears and dialog stays open
+    await expect(dialog.getByText('some error', {exact: true})).toBeVisible();
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByPlaceholder('Enter some text (optional)...')).toHaveValue('sample test input');
+});
+
+test('should show general error on /dialog error-no-elements confirm', async ({pw}) => {
+    // 1. Setup
+    const {adminClient, user, team} = await pw.initSetup();
+    await setupDemoPlugin(adminClient, pw);
+
+    // 2. Login
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    // 3. Navigate to Town Square
+    await channelsPage.goto(team.name, 'town-square');
+    await channelsPage.toBeVisible();
+
+    // 4. Send /dialog error-no-elements command
+    await channelsPage.centerView.postCreate.input.fill('/dialog error-no-elements');
+    await channelsPage.centerView.postCreate.sendMessage();
+
+    // 5. Confirm dialog opens with title "Sample Confirmation Dialog" and no form fields
+    const dialog = channelsPage.page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('heading', {level: 1})).toContainText('Sample Confirmation Dialog');
+    await expect(dialog.getByRole('button', {name: 'Cancel'})).toBeVisible();
+    await expect(dialog.getByRole('button', {name: 'Confirm'})).toBeVisible();
+    await expect(dialog.getByRole('textbox')).not.toBeVisible();
+
+    // 6. Click Confirm
+    await dialog.getByRole('button', {name: 'Confirm'}).click();
+
+    // 7. Verify general error appears and dialog stays open
+    await expect(dialog.getByText('some error', {exact: true})).toBeVisible();
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('button', {name: 'Cancel'})).toBeVisible();
+    await expect(dialog.getByRole('button', {name: 'Confirm'})).toBeVisible();
+});

--- a/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_dialog_date.spec.ts
+++ b/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_dialog_date.spec.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+import {setupDemoPlugin} from '../../helpers';
+
+test('should open /dialog date and post submit confirmation after selecting dates', async ({pw}) => {
+    // 1. Setup
+    const {adminClient, user, team} = await pw.initSetup();
+    await setupDemoPlugin(adminClient, pw);
+
+    // 2. Login
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    // 3. Navigate to Town Square
+    await channelsPage.goto(team.name, 'town-square');
+    await channelsPage.toBeVisible();
+
+    // 4. Send /dialog date command
+    await channelsPage.centerView.postCreate.input.fill('/dialog date');
+    await channelsPage.centerView.postCreate.sendMessage();
+
+    // 5. Confirm dialog opens with correct title
+    const dialog = channelsPage.page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('heading', {level: 1})).toContainText('Date & DateTime Test Dialog');
+
+    // 6. Verify field labels and Event Title default value
+    await expect(dialog.getByText('Meeting Date *', {exact: true})).toBeVisible();
+    await expect(dialog.getByText('Meeting Date & Time *', {exact: true})).toBeVisible();
+    await expect(dialog.getByText('Event Title *', {exact: true})).toBeVisible();
+    await expect(dialog.getByRole('textbox', {name: 'Event Title *'})).toHaveValue('Team Meeting');
+
+    // 7. Select a date using the Meeting Date picker
+    await dialog.getByRole('button', {name: /Select a meeting date/i}).click();
+    await expect(channelsPage.page.getByRole('grid')).toBeVisible();
+    // Click day 20 — reliably available in any month
+    await channelsPage.page.getByRole('grid').getByText('20', {exact: true}).click();
+
+    // 8. Select date and time using the Meeting Date & Time picker
+    await dialog
+        .getByRole('button', {name: /Date.*Today|Select a date/i})
+        .first()
+        .click();
+    await expect(channelsPage.page.getByRole('grid')).toBeVisible();
+    await channelsPage.page.getByRole('grid').getByText('22', {exact: true}).click();
+
+    // Select a time from the time picker
+    await dialog
+        .getByRole('button', {name: /Time|Select a time/i})
+        .first()
+        .click();
+    await channelsPage.page.getByRole('menuitem', {name: '3:00 PM'}).click();
+
+    // 9. Submit — button is labelled "Create Event"
+    await dialog.getByRole('button', {name: 'Create Event'}).click();
+    await expect(dialog).not.toBeVisible();
+
+    // 10. Verify submit post appears in the channel
+    await expect(
+        channelsPage.centerView.container.locator('p').filter({hasText: 'submitted a Date Dialog'}),
+    ).toBeVisible();
+});

--- a/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_dialog_field_refresh.spec.ts
+++ b/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_dialog_field_refresh.spec.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+import {setupDemoPlugin} from '../../helpers';
+
+test('should update form fields dynamically when project type changes via /dialog field-refresh', async ({pw}) => {
+    // 1. Setup
+    const {adminClient, user, team} = await pw.initSetup();
+    await setupDemoPlugin(adminClient, pw);
+
+    // 2. Login
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    // 3. Navigate to Town Square
+    await channelsPage.goto(team.name, 'town-square');
+    await channelsPage.toBeVisible();
+
+    // 4. Send /dialog field-refresh command
+    await channelsPage.centerView.postCreate.input.fill('/dialog field-refresh');
+    await channelsPage.centerView.postCreate.sendMessage();
+
+    // 5. Confirm dialog opens with title "Project Configuration"
+    const dialog = channelsPage.page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('heading', {level: 1})).toContainText('Project Configuration');
+
+    // 6. Verify initial state — only Project Type dropdown visible
+    await expect(dialog.getByText('Project Type *')).toBeVisible();
+    await expect(dialog.getByRole('button', {name: 'Cancel'})).toBeVisible();
+    await expect(dialog.getByRole('button', {name: 'Create Project'})).toBeVisible();
+    await expect(dialog.getByText('Frontend Framework')).not.toBeVisible();
+    await expect(dialog.getByText('Platform')).not.toBeVisible();
+    await expect(dialog.getByText('API Type')).not.toBeVisible();
+
+    // 7. Select "Web Application" — new fields should appear
+    // Click the react-select control (not the hidden input) to open the dropdown
+    await dialog.locator('[class*="Select__control"], [class*="react-select__control"]').first().click();
+    await channelsPage.page.getByRole('option', {name: 'Web Application'}).click();
+
+    await expect(dialog.getByText('Frontend Framework *')).toBeVisible();
+    await expect(dialog.getByText('Enable PWA')).toBeVisible();
+    await expect(dialog.getByText('Project Name *')).toBeVisible();
+    await expect(dialog.getByText('Platform')).not.toBeVisible();
+    await expect(dialog.getByText('API Type')).not.toBeVisible();
+
+    // 8. Change to "Mobile Application" — fields update
+    await dialog.locator('[class*="Select__control"], [class*="react-select__control"]').first().click();
+    await channelsPage.page.getByRole('option', {name: 'Mobile Application'}).click();
+
+    await expect(dialog.getByText('Platform *')).toBeVisible();
+    await expect(dialog.getByText('Minimum OS Version *')).toBeVisible();
+    await expect(dialog.getByText('Project Name *')).toBeVisible();
+    await expect(dialog.getByText('Frontend Framework')).not.toBeVisible();
+    await expect(dialog.getByText('Enable PWA')).not.toBeVisible();
+    await expect(dialog.getByText('API Type')).not.toBeVisible();
+
+    // 9. Change to "API Service" — fields update again
+    await dialog.locator('[class*="Select__control"], [class*="react-select__control"]').first().click();
+    await channelsPage.page.getByRole('option', {name: 'API Service'}).click();
+
+    await expect(dialog.getByText('API Type *')).toBeVisible();
+    await expect(dialog.getByRole('radio', {name: 'REST API'})).toBeVisible();
+    await expect(dialog.getByRole('radio', {name: 'GraphQL API'})).toBeVisible();
+    await expect(dialog.getByRole('radio', {name: 'gRPC Service'})).toBeVisible();
+    await expect(dialog.getByText('Database *')).toBeVisible();
+    await expect(dialog.getByText('Project Name *')).toBeVisible();
+    await expect(dialog.getByText('Platform')).not.toBeVisible();
+    await expect(dialog.getByText('Minimum OS Version')).not.toBeVisible();
+
+    // 10. Fill required fields and submit
+    await dialog.getByPlaceholder('Enter project name...').fill('Test Project');
+    await dialog.getByRole('radio', {name: 'REST API'}).click();
+
+    // Select PostgreSQL from Database dropdown
+    await dialog.locator('[class*="Select__control"], [class*="react-select__control"]').last().click();
+    await channelsPage.page.getByRole('option', {name: 'PostgreSQL'}).click();
+
+    await dialog.getByRole('button', {name: 'Create Project'}).click();
+    await expect(dialog).not.toBeVisible();
+
+    // 11. Verify response post in the channel
+    await expect(
+        channelsPage.centerView.container.locator('p').filter({hasText: 'api project: Test Project'}),
+    ).toBeVisible();
+});

--- a/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_ephemeral.spec.ts
+++ b/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_ephemeral.spec.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+import {setupDemoPlugin} from '../../helpers';
+
+test('should send ephemeral post with Update and Delete actions via /ephemeral command', async ({pw}) => {
+    // 1. Setup
+    const {adminClient, user, team} = await pw.initSetup();
+    await setupDemoPlugin(adminClient, pw);
+
+    // 2. Login
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    // 3. Navigate to Town Square — avoids noise from demo plugin's own ephemeral messages
+    await channelsPage.goto(team.name, 'town-square');
+    await channelsPage.toBeVisible();
+
+    // 4. Send /ephemeral command
+    await channelsPage.centerView.postCreate.input.fill('/ephemeral');
+    await channelsPage.centerView.postCreate.sendMessage();
+
+    // 5. Verify ephemeral post appears with correct content and action buttons
+    // Scope to the specific post to avoid strict mode violation if multiple ephemeral posts are visible
+    const ephemeralPost = channelsPage.centerView.container
+        .getByRole('listitem')
+        .filter({hasText: 'test ephemeral actions'})
+        .last();
+    await expect(ephemeralPost.getByText('(Only visible to you)', {exact: true})).toBeVisible();
+    await expect(ephemeralPost.getByText('test ephemeral actions', {exact: true})).toBeVisible();
+    await expect(ephemeralPost.getByRole('button', {name: 'Update', exact: true})).toBeVisible();
+    await expect(ephemeralPost.getByRole('button', {name: 'Delete', exact: true})).toBeVisible();
+
+    // 6. Click Update and verify post text and button label change
+    // After clicking Update the text changes — re-find the post by its new content
+    await ephemeralPost.getByRole('button', {name: 'Update', exact: true}).click();
+    const updatedPost = channelsPage.centerView.container
+        .getByRole('listitem')
+        .filter({hasText: 'updated ephemeral action'})
+        .last();
+    await expect(updatedPost.getByText('updated ephemeral action', {exact: true})).toBeVisible();
+    await expect(updatedPost.getByRole('button', {name: 'Update 1', exact: true})).toBeVisible();
+    await expect(updatedPost.getByRole('button', {name: 'Delete', exact: true})).toBeVisible();
+
+    // 7. Click Delete and verify post content is removed and buttons are gone
+    // After delete the text changes again — re-find by the new content
+    await updatedPost.getByRole('button', {name: 'Delete', exact: true}).click();
+    const deletedPost = channelsPage.centerView.container
+        .getByRole('listitem')
+        .filter({hasText: '(message deleted)'})
+        .last();
+    await expect(deletedPost.getByText('(message deleted)', {exact: true})).toBeVisible();
+    await expect(deletedPost.getByRole('button', {name: 'Update 1', exact: true})).not.toBeVisible();
+    await expect(deletedPost.getByRole('button', {name: 'Delete', exact: true})).not.toBeVisible();
+
+    // 8. Send /ephemeral_override command (still in Town Square)
+    await channelsPage.centerView.postCreate.input.fill('/ephemeral_override');
+    await channelsPage.centerView.postCreate.sendMessage();
+
+    // 9. Verify the override ephemeral post appears
+    const overridePost = channelsPage.centerView.container
+        .getByRole('listitem')
+        .filter({hasText: 'This is a demo of overriding an ephemeral post.'})
+        .last();
+    await expect(overridePost.getByText('(Only visible to you)', {exact: true})).toBeVisible();
+    await expect(
+        overridePost.getByText('This is a demo of overriding an ephemeral post.', {exact: true}),
+    ).toBeVisible();
+});

--- a/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_interactive.spec.ts
+++ b/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_interactive.spec.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+import {setupDemoPlugin} from '../../helpers';
+
+test('should post interactive button and respond with click attribution via /interactive command', async ({pw}) => {
+    // 1. Setup
+    const {adminClient, user, team} = await pw.initSetup();
+    await setupDemoPlugin(adminClient, pw);
+
+    // 2. Login
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    // 3. Navigate to Town Square
+    await channelsPage.goto(team.name, 'town-square');
+    await channelsPage.toBeVisible();
+
+    // 4. Send /interactive command
+    await channelsPage.centerView.postCreate.input.fill('/interactive');
+    await channelsPage.centerView.postCreate.sendMessage();
+
+    // 5. Confirm post appears with 'Test interactive button' and an 'Interactive Button' button
+    const interactivePost = channelsPage.centerView.container
+        .getByRole('listitem')
+        .filter({hasText: 'Test interactive button'})
+        .last();
+    await expect(interactivePost).toBeVisible();
+    await expect(interactivePost.getByRole('button', {name: 'Interactive Button'})).toBeVisible();
+
+    // 6. Click the Interactive Button
+    await interactivePost.getByRole('button', {name: 'Interactive Button'}).click();
+
+    // 7. Wait for thread reply indicator and open the thread
+    await expect(interactivePost.getByRole('button', {name: /1 reply/})).toBeVisible();
+    await interactivePost.getByRole('button', {name: /1 reply/}).click();
+
+    // 8. Confirm bot response in the thread panel
+    const threadPanel = channelsPage.page.getByRole('region', {name: /Thread/});
+    await expect(threadPanel).toBeVisible();
+
+    // Verify response credits the user who clicked
+    await expect(
+        threadPanel.locator('p').filter({hasText: `${user.username} clicked an interactive button.`}),
+    ).toBeVisible();
+
+    // Verify JSON payload contains expected static fields
+    await expect(
+        threadPanel.locator('code').filter({hasText: new RegExp(`"user_name"\\s*:\\s*"${user.username}"`)}),
+    ).toBeVisible();
+    await expect(threadPanel.locator('code').filter({hasText: '"type": "button"'})).toBeVisible();
+});

--- a/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_list_files.spec.ts
+++ b/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_list_files.spec.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Client4} from '@mattermost/client';
+
+import {expect, getFileFromAsset, test} from '@mattermost/playwright-lib';
+
+import {setupDemoPlugin} from '../../helpers';
+
+/**
+ * Uploads a batch of files to the channel via API and posts them as a single message.
+ * Using the API avoids the demo plugin's custom file upload menu which intercepts
+ * the attachment button in the UI.
+ */
+async function uploadAndPostFiles(client: Client4, channelId: string, filenames: string[]): Promise<void> {
+    const fileIds: string[] = [];
+
+    for (const filename of filenames) {
+        const file = getFileFromAsset(filename);
+        const formData = new FormData();
+        formData.set('files', file, filename);
+        formData.set('channel_id', channelId);
+        const result = await client.uploadFile(formData);
+        fileIds.push(result.file_infos[0].id);
+    }
+
+    await client.createPost({
+        channel_id: channelId,
+        message: '',
+        file_ids: fileIds,
+    });
+}
+
+test('should list uploaded files with running total via /list_files command', async ({pw}) => {
+    // 1. Setup
+    const {adminClient, user, team} = await pw.initSetup();
+    await setupDemoPlugin(adminClient, pw);
+
+    // 2. Create a dedicated channel for file isolation
+    const channel = pw.random.channel({
+        teamId: team.id,
+        name: 'list-files-test',
+        displayName: 'List Files Test',
+    });
+    const createdChannel = await adminClient.createChannel(channel);
+    await adminClient.addToChannel(user.id, createdChannel.id);
+
+    // 3. Login and navigate to the channel
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto(team.name, 'list-files-test');
+    await channelsPage.toBeVisible();
+
+    // 4. Send /list_files with no files — expect 0 count
+    await channelsPage.centerView.postCreate.input.fill('/list_files');
+    await channelsPage.centerView.postCreate.sendMessage();
+
+    await expect(
+        channelsPage.centerView.container.getByText('Last 0 Files uploaded to this channel', {exact: true}),
+    ).toBeVisible();
+
+    // 5. Upload first batch of 2 files via API
+    // (avoids demo plugin's custom attachment menu intercepting the UI)
+    await uploadAndPostFiles(adminClient, createdChannel.id, ['sample_text_file.txt', 'mattermost-icon_128x128.png']);
+
+    // 6. Send /list_files — expect count of 2 and both file names
+    await channelsPage.centerView.postCreate.input.fill('/list_files');
+    await channelsPage.centerView.postCreate.sendMessage();
+
+    const response2 = channelsPage.centerView.container
+        .getByRole('listitem')
+        .filter({hasText: 'Last 2 Files uploaded to this channel'})
+        .last();
+    await expect(response2).toBeVisible();
+    await expect(response2.getByRole('heading', {name: 'mattermost-icon_128x128.png'})).toBeVisible();
+    await expect(response2.getByRole('heading', {name: 'sample_text_file.txt'})).toBeVisible();
+
+    // 7. Upload second batch of 2 more files via API
+    await uploadAndPostFiles(adminClient, createdChannel.id, ['mattermost.png', 'archive.zip']);
+
+    // 8. Send /list_files — expect count of 4 and all file names
+    await channelsPage.centerView.postCreate.input.fill('/list_files');
+    await channelsPage.centerView.postCreate.sendMessage();
+
+    const response4 = channelsPage.centerView.container
+        .getByRole('listitem')
+        .filter({hasText: 'Last 4 Files uploaded to this channel'})
+        .last();
+    await expect(response4).toBeVisible();
+    await expect(response4.getByRole('heading', {name: 'mattermost.png'})).toBeVisible();
+    await expect(response4.getByRole('heading', {name: 'archive.zip'})).toBeVisible();
+    await expect(response4.getByRole('heading', {name: 'mattermost-icon_128x128.png'})).toBeVisible();
+    await expect(response4.getByRole('heading', {name: 'sample_text_file.txt'})).toBeVisible();
+});

--- a/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_show_mentions.spec.ts
+++ b/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_show_mentions.spec.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+import {setupDemoPlugin} from '../../helpers';
+
+test('should parse user and channel mentions from /show_mentions command text', async ({pw}) => {
+    // 1. Setup
+    const {adminClient, user, team} = await pw.initSetup();
+    await setupDemoPlugin(adminClient, pw);
+
+    // 2. Login
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    // 3. Navigate to Town Square
+    await channelsPage.goto(team.name, 'town-square');
+    await channelsPage.toBeVisible();
+
+    // 4. Send /show_mentions with a user mention and a channel mention
+    // sysadmin is a stable known user in every PW environment
+    await channelsPage.centerView.postCreate.input.fill('/show_mentions @sysadmin ~town-square');
+    await channelsPage.centerView.postCreate.sendMessage();
+
+    // 5. Wait for bot response
+    const responsePost = channelsPage.centerView.container
+        .getByRole('listitem')
+        .filter({hasText: 'contains the following different mentions'})
+        .last();
+    await expect(responsePost).toBeVisible();
+
+    // 6. Assert user mentions section
+    await expect(responsePost.getByRole('heading', {name: 'Mentions to users in the team'})).toBeVisible();
+    await expect(responsePost.getByRole('columnheader', {name: 'User name'})).toBeVisible();
+    await expect(responsePost.getByRole('cell', {name: '@sysadmin'})).toBeVisible();
+
+    // 7. Assert channel mentions section
+    await expect(responsePost.getByRole('heading', {name: 'Mentions to public channels'})).toBeVisible();
+    await expect(responsePost.getByRole('columnheader', {name: 'Channel name'})).toBeVisible();
+    await expect(responsePost.getByRole('cell', {name: '~Town Square'})).toBeVisible();
+
+    // 8. Assert ~Town Square is a link pointing to the town-square channel
+    await expect(responsePost.getByRole('link', {name: '~Town Square'})).toHaveAttribute(
+        'href',
+        /\/channels\/town-square$/,
+    );
+});

--- a/server/channels/api4/channel_test.go
+++ b/server/channels/api4/channel_test.go
@@ -5101,8 +5101,12 @@ func TestAddChannelMembers(t *testing.T) {
 }
 
 func TestAddChannelMemberFromThread(t *testing.T) {
-	mainHelper.Parallel(t)
+	// okrbest: upstream(5b810f91)이 재활성화했으나 로컬 3/3 실패해 skip을 유지한다.
+	// require.Eventually 단계(멘션 2건)는 통과하고, 아래 WS 루프가 수신하는 모든
+	// thread_updated 이벤트마다 UnreadMentions == 2를 단언하는 게 원인이다.
+	// 첫 답글 시점 이벤트는 1이라 두 이벤트가 모두 큐에 쌓이면 반드시 터진다.
 	t.Skip("MM-41285")
+	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)
 	team := th.BasicTeam
 	user := th.BasicUser
@@ -5152,12 +5156,11 @@ func TestAddChannelMemberFromThread(t *testing.T) {
 	_, _, err = th.SystemAdminClient.AddChannelMemberWithRootId(context.Background(), publicChannel.Id, user.Id, rpost.Id)
 	require.NoError(t, err)
 
-	// Threadmembership should exist for added user
-	ut, _, err := th.Client.GetUserThread(context.Background(), user.Id, team.Id, rpost.Id, false)
-	require.NoError(t, err)
-	// Should have two mentions. There might be a race condition
-	// here between the "added user to the channel" message and the GetUserThread call
-	require.LessOrEqual(t, int64(2), ut.UnreadMentions)
+	// Thread membership and mention counts may take a moment to propagate (MM-41285).
+	require.Eventually(t, func() bool {
+		ut, _, getErr := th.Client.GetUserThread(context.Background(), user.Id, team.Id, rpost.Id, false)
+		return getErr == nil && ut.UnreadMentions >= 2
+	}, 10*time.Second, 200*time.Millisecond, "expected at least 2 unread mentions in thread")
 
 	var caught bool
 	func() {
@@ -5176,7 +5179,7 @@ func TestAddChannelMemberFromThread(t *testing.T) {
 					require.EqualValues(t, float64(0), data["previous_unread_replies"])
 					require.EqualValues(t, float64(0), data["previous_unread_mentions"])
 				}
-			case <-time.After(2 * time.Second):
+			case <-time.After(15 * time.Second):
 				return
 			}
 		}

--- a/server/channels/api4/oauth_test.go
+++ b/server/channels/api4/oauth_test.go
@@ -85,7 +85,7 @@ func TestCreateOAuthApp(t *testing.T) {
 }
 
 func TestUpdateOAuthApp(t *testing.T) {
-	t.Skip("https://mattermost.atlassian.net/browse/MM-62895")
+	// MM-62895: re-enabled to collect failure data (14mo, empty Jira description).
 
 	mainHelper.Parallel(t)
 

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -4614,7 +4614,6 @@ func TestSearchPostsWithDateFlags(t *testing.T) {
 }
 
 func TestGetFileInfosForPost(t *testing.T) {
-	t.Skip("MM-46902")
 	th := Setup(t).InitBasic(t)
 	client := th.Client
 
@@ -4622,17 +4621,22 @@ func TestGetFileInfosForPost(t *testing.T) {
 	data, err := testutils.ReadTestFile("test.png")
 	require.NoError(t, err)
 	for i := range 3 {
-		fileResp, _, _ := client.UploadFile(context.Background(), data, th.BasicChannel.Id, "test.png")
+		fileResp, _, uploadErr := client.UploadFile(context.Background(), data, th.BasicChannel.Id, "test.png")
+		require.NoError(t, uploadErr, "failed to upload file %d", i)
 		fileIds[i] = fileResp.FileInfos[0].Id
 	}
 
 	post := &model.Post{ChannelId: th.BasicChannel.Id, Message: "zz" + model.NewId() + "a", FileIds: fileIds}
-	post, _, _ = client.CreatePost(context.Background(), post)
-
-	infos, resp, err := client.GetFileInfosForPost(context.Background(), post.Id, "")
+	post, _, err = client.CreatePost(context.Background(), post)
 	require.NoError(t, err)
 
-	require.Len(t, infos, 3, "missing file infos")
+	// File info association can be async; poll until all 3 are visible (MM-46902).
+	var infos []*model.FileInfo
+	var resp *model.Response
+	require.Eventually(t, func() bool {
+		infos, resp, err = client.GetFileInfosForPost(context.Background(), post.Id, "")
+		return err == nil && len(infos) == 3
+	}, 10*time.Second, 200*time.Millisecond, "expected 3 file infos")
 
 	found := false
 	for _, info := range infos {
@@ -5326,14 +5330,14 @@ func TestGetPostStripActionIntegrations(t *testing.T) {
 }
 
 func TestPostReminder(t *testing.T) {
-	t.Skip("MM-60329")
-
 	th := Setup(t).InitBasic(t)
 
 	client := th.Client
 	userWSClient := th.CreateConnectedWebSocketClient(t)
 
-	targetTime := time.Now().UTC().Unix()
+	// Set target time 1s in the future so the reminder processor picks it up
+	// on its next tick rather than relying on it already being in the past (MM-60329).
+	targetTime := time.Now().UTC().Unix() + 1
 	resp, err := client.SetPostReminder(context.Background(), &model.PostReminder{
 		TargetTime: targetTime,
 		PostId:     th.BasicPost.Id,
@@ -5374,7 +5378,7 @@ func TestPostReminder(t *testing.T) {
 					require.Equal(t, th.BasicTeam.Name, parsedPost.GetProp("team_name").(string))
 					return
 				}
-			case <-time.After(5 * time.Second):
+			case <-time.After(15 * time.Second):
 				return
 			}
 		}

--- a/server/channels/api4/shared_channel_metadata_test.go
+++ b/server/channels/api4/shared_channel_metadata_test.go
@@ -6,6 +6,7 @@ package api4
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -114,8 +115,8 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 	th, service := setupTestEnvironment(t)
 
 	t.Run("Post Priority Metadata Self-Referential Sync", func(t *testing.T) {
-		t.Skip("MM-64687")
 		var syncedPosts []*model.Post
+		var mu sync.Mutex
 
 		// Create test HTTP server using self-referential approach
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -135,7 +136,9 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 					post.Metadata.Priority.RequestedAck,
 					post.Metadata.Priority.PersistentNotifications)
 			}
+			mu.Lock()
 			syncedPosts = append(syncedPosts, post)
+			mu.Unlock()
 		}
 
 		// Update test server to use the sync handler
@@ -165,12 +168,16 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 
 		// Wait for sync completion using Eventually pattern
 		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
 			return len(syncedPosts) >= 2
 		}, 5*time.Second, 100*time.Millisecond, "Should receive synced posts via self-referential handler")
 
 		// Verify priority metadata is preserved through the complete sync flow
+		mu.Lock()
 		t.Logf("Found %d synced posts", len(syncedPosts))
 		syncedPost := syncedPosts[len(syncedPosts)-1]
+		mu.Unlock()
 		require.NotNil(t, syncedPost.Metadata, "Post metadata should be preserved")
 		require.NotNil(t, syncedPost.Metadata.Priority, "Priority metadata should be preserved")
 		assert.Equal(t, model.PostPriorityUrgent, *syncedPost.Metadata.Priority.Priority, "Priority should be preserved")
@@ -181,6 +188,7 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 	t.Run("Post Acknowledgement Metadata Self-Referential Sync", func(t *testing.T) {
 		EnsureCleanState(t, th, th.App.Srv().Store())
 		var syncedPosts []*model.Post
+		var mu sync.Mutex
 
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			writeOKResponse(w)
@@ -191,7 +199,9 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 
 		syncHandler := NewSelfReferentialSyncHandler(t, service, selfCluster)
 		syncHandler.OnPostSync = func(post *model.Post) {
+			mu.Lock()
 			syncedPosts = append(syncedPosts, post)
+			mu.Unlock()
 		}
 
 		testServer.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -227,11 +237,15 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 
 		// Wait for sync completion
 		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
 			return len(syncedPosts) >= 2
 		}, 5*time.Second, 100*time.Millisecond, "Should receive synced posts via self-referential handler")
 
 		// Verify acknowledgement metadata is preserved
+		mu.Lock()
 		syncedPost := syncedPosts[len(syncedPosts)-1]
+		mu.Unlock()
 		require.NotNil(t, syncedPost.Metadata, "Post metadata should be preserved")
 		require.NotNil(t, syncedPost.Metadata.Priority, "Priority metadata should be preserved")
 		assert.Equal(t, model.PostPriorityUrgent, *syncedPost.Metadata.Priority.Priority, "Priority should be preserved")
@@ -240,10 +254,10 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 	})
 
 	t.Run("Acknowledgement Count Sync Back to Sender", func(t *testing.T) {
-		t.Skip("MM-64687")
 		EnsureCleanState(t, th, th.App.Srv().Store())
 		var syncedPosts []*model.Post
 		var postIdToSync string
+		var mu sync.Mutex
 
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			writeOKResponse(w)
@@ -254,6 +268,8 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 
 		syncHandler := NewSelfReferentialSyncHandler(t, service, selfCluster)
 		syncHandler.OnPostSync = func(post *model.Post) {
+			mu.Lock()
+			defer mu.Unlock()
 			if post.Id == postIdToSync {
 				t.Logf("Received sync for target post: ID=%s, HasAcks=%v", post.Id,
 					post.Metadata != nil && post.Metadata.Acknowledgements != nil)
@@ -294,6 +310,8 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 
 		// Wait for initial sync
 		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
 			return len(syncedPosts) >= 2
 		}, 5*time.Second, 100*time.Millisecond, "Should complete initial sync")
 
@@ -308,11 +326,15 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 		require.Nil(t, appErr)
 
 		// Clear previous synced posts and trigger sync
+		mu.Lock()
 		syncedPosts = syncedPosts[:0]
+		mu.Unlock()
 		service.NotifyChannelChanged(testChannel.Id)
 
 		// Wait for acknowledgement sync
 		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
 			for _, post := range syncedPosts {
 				if post.Id == postIdToSync &&
 					post.Metadata != nil &&
@@ -325,6 +347,7 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 		}, 5*time.Second, 100*time.Millisecond, "Should sync acknowledgements back")
 
 		// Verify acknowledgement was synced
+		mu.Lock()
 		var syncedPostWithAcks *model.Post
 		for _, post := range syncedPosts {
 			if post.Id == postIdToSync && post.Metadata != nil && post.Metadata.Acknowledgements != nil {
@@ -332,6 +355,7 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 				break
 			}
 		}
+		mu.Unlock()
 
 		require.NotNil(t, syncedPostWithAcks, "Should find synced post with acknowledgements")
 		require.NotNil(t, syncedPostWithAcks.Metadata.Acknowledgements, "Acknowledgements should exist")
@@ -344,9 +368,9 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 	})
 
 	t.Run("Persistent Notifications Self-Referential Sync", func(t *testing.T) {
-		t.Skip("MM-64687")
 		EnsureCleanState(t, th, th.App.Srv().Store())
 		var syncedPosts []*model.Post
+		var mu sync.Mutex
 
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			writeOKResponse(w)
@@ -357,7 +381,9 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 
 		syncHandler := NewSelfReferentialSyncHandler(t, service, selfCluster)
 		syncHandler.OnPostSync = func(post *model.Post) {
+			mu.Lock()
 			syncedPosts = append(syncedPosts, post)
+			mu.Unlock()
 		}
 
 		testServer.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -384,11 +410,15 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 
 		// Wait for sync completion
 		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
 			return len(syncedPosts) >= 2
 		}, 5*time.Second, 100*time.Millisecond, "Should receive synced posts via self-referential handler")
 
 		// Verify persistent notifications setting is preserved
+		mu.Lock()
 		syncedPost := syncedPosts[len(syncedPosts)-1]
+		mu.Unlock()
 		require.NotNil(t, syncedPost.Metadata, "Post metadata should be preserved")
 		require.NotNil(t, syncedPost.Metadata.Priority, "Priority metadata should be preserved")
 		assert.Equal(t, model.PostPriorityUrgent, *syncedPost.Metadata.Priority.Priority, "Priority should be preserved")
@@ -397,11 +427,11 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 	})
 
 	t.Run("Cross-Cluster Acknowledgement End-to-End Flow", func(t *testing.T) {
-		t.Skip("MM-64687")
 		EnsureCleanState(t, th, th.App.Srv().Store())
 		var syncedPostsServerA []*model.Post
 		var syncedPostsServerB []*model.Post
 		var postIdToTrack string
+		var muA, muB sync.Mutex
 
 		// Create test HTTP servers for both "clusters"
 		testServerA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -502,6 +532,8 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 		// Initialize sync handlers for both clusters
 		syncHandlerA := NewSelfReferentialSyncHandler(t, service, clusterA)
 		syncHandlerA.OnPostSync = func(post *model.Post) {
+			muA.Lock()
+			defer muA.Unlock()
 			t.Logf("Cluster A received sync: ID=%s, Message=%s, HasAcks=%v",
 				post.Id, post.Message,
 				post.Metadata != nil && post.Metadata.Acknowledgements != nil)
@@ -513,6 +545,8 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 
 		syncHandlerB := NewSelfReferentialSyncHandler(t, service, clusterB)
 		syncHandlerB.OnPostSync = func(post *model.Post) {
+			muB.Lock()
+			defer muB.Unlock()
 			t.Logf("Cluster B received sync: ID=%s, Message=%s, RequestedAck=%v",
 				post.Id, post.Message,
 				post.Metadata != nil && post.Metadata.Priority != nil && post.Metadata.Priority.RequestedAck != nil && *post.Metadata.Priority.RequestedAck)
@@ -557,6 +591,8 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 		// Wait for Server B to receive the post
 		var syncedPostIdOnServerB string
 		require.Eventually(t, func() bool {
+			muB.Lock()
+			defer muB.Unlock()
 			for _, post := range syncedPostsServerB {
 				if post.Message == originalPost.Message && post.Metadata != nil && post.Metadata.Priority != nil &&
 					post.Metadata.Priority.RequestedAck != nil && *post.Metadata.Priority.RequestedAck {
@@ -588,14 +624,20 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 		// STEP 4: Acknowledgement syncs back from Server B to Server A
 		t.Log("=== STEP 4: Acknowledgement syncs back from Server B to Server A ===")
 		// Clear previous sync data to focus on acknowledgement sync
+		muA.Lock()
 		syncedPostsServerA = syncedPostsServerA[:0]
+		muA.Unlock()
+		muB.Lock()
 		syncedPostsServerB = syncedPostsServerB[:0]
+		muB.Unlock()
 
 		// Trigger sync to send acknowledgement back to Server A
 		service.NotifyChannelChanged(testChannel.Id)
 
 		// Wait for Server A to receive the acknowledgement sync
 		require.Eventually(t, func() bool {
+			muA.Lock()
+			defer muA.Unlock()
 			for _, post := range syncedPostsServerA {
 				if post.Id == postIdToTrack && post.Metadata != nil && post.Metadata.Acknowledgements != nil {
 					t.Logf("Server A received post %s with %d acknowledgements", post.Id, len(post.Metadata.Acknowledgements))
@@ -607,6 +649,7 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 
 		// STEP 5: Verify the complete acknowledgement flow
 		t.Log("=== STEP 5: Verify complete acknowledgement flow ===")
+		muA.Lock()
 		var serverAPostWithAcks *model.Post
 		for _, post := range syncedPostsServerA {
 			if post.Id == postIdToTrack && post.Metadata != nil && post.Metadata.Acknowledgements != nil {
@@ -614,6 +657,7 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 				break
 			}
 		}
+		muA.Unlock()
 
 		require.NotNil(t, serverAPostWithAcks, "Server A should receive post with acknowledgements")
 		require.NotNil(t, serverAPostWithAcks.Metadata.Acknowledgements, "Acknowledgements should exist")
@@ -632,13 +676,17 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 
 		// STEP 6: Test echo prevention - verify no duplicate acknowledgements
 		t.Log("=== STEP 6: Test echo prevention ===")
+		muA.Lock()
 		syncedPostsServerA = syncedPostsServerA[:0]
+		muA.Unlock()
 
 		// Trigger another sync to ensure no duplicates are created
 		service.NotifyChannelChanged(testChannel.Id)
 
 		// Verify acknowledgement count remains 1 (no duplicates)
 		require.Eventually(t, func() bool {
+			muA.Lock()
+			defer muA.Unlock()
 			for _, post := range syncedPostsServerA {
 				if post.Id == postIdToTrack && post.Metadata != nil && post.Metadata.Acknowledgements != nil {
 					return len(post.Metadata.Acknowledgements) == 1

--- a/server/channels/api4/status_test.go
+++ b/server/channels/api4/status_test.go
@@ -54,7 +54,6 @@ func TestGetUserStatus(t *testing.T) {
 	})
 
 	t.Run("dnd status timed restore after time interval", func(t *testing.T) {
-		t.Skip("https://mattermost.atlassian.net/browse/MM-63533")
 		task := model.CreateRecurringTaskFromNextIntervalTime("Unset DND Statuses From Test", th.App.UpdateDNDStatusOfUsers, 1*time.Second)
 		defer task.Cancel()
 		th.App.SetStatusOnline(th.BasicUser.Id, true)
@@ -65,10 +64,12 @@ func TestGetUserStatus(t *testing.T) {
 		userStatus, _, err = client.GetUserStatus(context.Background(), th.BasicUser.Id, "")
 		require.NoError(t, err)
 		assert.Equal(t, "dnd", userStatus.Status)
-		time.Sleep(3 * time.Second)
-		userStatus, _, err = client.GetUserStatus(context.Background(), th.BasicUser.Id, "")
-		require.NoError(t, err)
-		assert.Equal(t, "online", userStatus.Status)
+		// Poll for status restore instead of sleeping a fixed duration (MM-63533).
+		// The recurring task runs every 1s but can lag under CI load.
+		require.Eventually(t, func() bool {
+			userStatus, _, err = client.GetUserStatus(context.Background(), th.BasicUser.Id, "")
+			return err == nil && userStatus.Status == "online"
+		}, 15*time.Second, 500*time.Millisecond, "DND status was not restored to online within timeout")
 	})
 
 	t.Run("back to offline status", func(t *testing.T) {

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -1855,7 +1855,10 @@ func TestAutocompleteUsersInChannel(t *testing.T) {
 	})
 
 	t.Run("Check OutOfChannel results with/without VIEW_MEMBERS permissions", func(t *testing.T) {
-		t.Skip("https://mattermost.atlassian.net/browse/MM-61041")
+		// MM-61041: Re-enabled to collect failure data (17mo, "Broken Test").
+		// This subtest is fragile by design — shares th.Client with the parent,
+		// mutates global permissions/license/config. If it still fails, rewrite
+		// as focused app-layer unit tests rather than fixing shared state.
 
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.GuestAccountsSettings.Enable = true })
 		th.App.Srv().SetLicense(model.NewTestLicense())
@@ -3910,8 +3913,10 @@ func TestUpdateUserHashedPassword(t *testing.T) {
 }
 
 func TestResetPassword(t *testing.T) {
+	// okrbest: upstream(5b810f91)이 재활성화했으나 로컬 2/2 실패해 skip을 유지한다.
+	// Inbucket은 정상 구동 중이고 메일에서 64자 토큰도 추출되는데 Token().GetByToken()이
+	// 못 찾는다 — 메일함 [0]번이 기대한 재설정 메일이 아닌 것으로 보인다.
 	t.Skip("test disabled during old build server changes, should be investigated")
-
 	th := Setup(t).InitBasic(t)
 	_, err := th.Client.Logout(context.Background())
 	require.NoError(t, err)

--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -711,7 +711,6 @@ func TestGetDirectChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
 }
 
 func TestAddUserToChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
-	t.Skip("MM-67041")
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t).DeleteBots(t)
 
@@ -726,11 +725,13 @@ func TestAddUserToChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
 
 	channel := th.createChannel(t, th.BasicTeam, model.ChannelTypeOpen)
 
+	startTime := model.GetMillis()
 	_, appErr = th.App.AddUserToChannel(th.Context, user, channel, false)
 	require.Nil(t, appErr, "Failed to add user to channel.")
 
 	// there should be a ChannelMemberHistory record for the user
-	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, []string{channel.Id})
+	// Use a wide time window (±10s) to avoid flaky failures under CI load (MM-67041)
+	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(startTime-10000, model.GetMillis()+10000, []string{channel.Id})
 	require.NoError(t, nErr)
 	assert.Len(t, histories, 2)
 	channelMemberHistoryUserIds := make([]string, 0)
@@ -971,6 +972,10 @@ func TestLeaveLastChannel(t *testing.T) {
 }
 
 func TestAddChannelMemberNoUserRequestor(t *testing.T) {
+	// okrbest: upstream(5b810f91)이 시간 창을 ±10s로 넓혀 재활성화했으나 순서
+	// 비결정성은 남아 있다. GetUsersInChannelDuring은 ORDER BY JoinTime ASC뿐인데
+	// JoinTime이 밀리초라 두 가입이 같은 ms에 떨어지면 동률이 되고, 아래 단언은
+	// 순서를 고정으로 기대한다. 로컬 5회 중 3회 실패해 skip을 유지한다.
 	t.Skip("MM-67037")
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)
@@ -986,11 +991,13 @@ func TestAddChannelMemberNoUserRequestor(t *testing.T) {
 
 	channel := th.createChannel(t, th.BasicTeam, model.ChannelTypeOpen)
 
+	startTime := model.GetMillis()
 	_, appErr = th.App.AddChannelMember(th.Context, user.Id, channel, ChannelMemberOpts{})
 	require.Nil(t, appErr, "Failed to add user to channel.")
 
 	// there should be a ChannelMemberHistory record for the user
-	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, []string{channel.Id})
+	// Use a wide time window (±10s) to avoid flaky failures under CI load (MM-67037)
+	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(startTime-10000, model.GetMillis()+10000, []string{channel.Id})
 	require.NoError(t, nErr)
 	assert.Len(t, histories, 2)
 	channelMemberHistoryUserIds := make([]string, 0)

--- a/server/channels/app/shared_channel_membership_sync_self_referential_test.go
+++ b/server/channels/app/shared_channel_membership_sync_self_referential_test.go
@@ -518,7 +518,6 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		assert.Contains(t, syncedInSecondCall, user3.Id, "Second sync must include the new user")
 	})
 	t.Run("Test 4: Sync failure and recovery", func(t *testing.T) {
-		t.Skip("MM-64687")
 		// This test verifies that membership sync handles remote server failures gracefully
 		// and successfully syncs members once the remote server recovers.
 		// We test that:
@@ -530,6 +529,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		var failureMode atomic.Bool
 		failureMode.Store(true)
 		var successfulSyncs []string
+		var syncsMu sync.Mutex
 		var selfCluster *model.RemoteCluster
 		var syncHandler *SelfReferentialSyncHandler
 
@@ -597,10 +597,14 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		// Initialize sync handler with callbacks
 		syncHandler = NewSelfReferentialSyncHandler(t, service, selfCluster)
 		syncHandler.OnBatchSync = func(userIds []string, messageNumber int32) {
+			syncsMu.Lock()
 			successfulSyncs = append(successfulSyncs, userIds...)
+			syncsMu.Unlock()
 		}
 		syncHandler.OnIndividualSync = func(userId string, messageNumber int32) {
+			syncsMu.Lock()
 			successfulSyncs = append(successfulSyncs, userId)
+			syncsMu.Unlock()
 		}
 
 		// Add a user to sync
@@ -621,7 +625,9 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 
 		initialAttempts := syncAttempts.Load()
 		assert.Greater(t, initialAttempts, int32(0), "Should have attempted sync")
+		syncsMu.Lock()
 		assert.Empty(t, successfulSyncs, "No successful syncs during failure mode")
+		syncsMu.Unlock()
 
 		// Recover from failure mode
 		failureMode.Store(false)
@@ -631,6 +637,8 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 
 		// Wait for successful sync with more robust checking
 		require.Eventually(t, func() bool {
+			syncsMu.Lock()
+			defer syncsMu.Unlock()
 			return slices.Contains(successfulSyncs, testUser.Id)
 		}, 15*time.Second, 100*time.Millisecond, "Should have successful sync after recovery")
 

--- a/server/channels/app/slashcommands/command_mobile_logs.go
+++ b/server/channels/app/slashcommands/command_mobile_logs.go
@@ -1,0 +1,246 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package slashcommands
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/i18n"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+	"github.com/mattermost/mattermost/server/v8/channels/app"
+)
+
+type MobileLogsProvider struct {
+}
+
+const (
+	CmdMobileLogs = "mobile-logs"
+)
+
+func init() {
+	app.RegisterCommandProvider(&MobileLogsProvider{})
+}
+
+func mobileLogsCrossUserUnavailableResponse(args *model.CommandArgs) *model.CommandResponse {
+	return &model.CommandResponse{
+		Text:         args.T("api.command_mobile_logs.cross_user_unavailable.app_error"),
+		ResponseType: model.CommandResponseTypeEphemeral,
+	}
+}
+
+func logMobileLogsAttachAppLogsAudit(a *app.App, rctx request.CTX, actorUserID, targetUserID, value string) {
+	rec := &model.AuditRecord{
+		EventName: model.AuditEventUpdatePreferences,
+		Status:    model.AuditStatusSuccess,
+		Actor: model.AuditEventActor{
+			UserId:        actorUserID,
+			SessionId:     rctx.Session().Id,
+			Client:        rctx.UserAgent(),
+			IpAddress:     rctx.IPAddress(),
+			XForwardedFor: rctx.XForwardedFor(),
+		},
+		Meta: map[string]any{
+			model.AuditKeyAPIPath:   rctx.Path(),
+			model.AuditKeyClusterID: a.GetClusterId(),
+		},
+		EventData: model.AuditEventData{
+			Parameters: map[string]any{
+				"source":              "slash_command/" + CmdMobileLogs,
+				"target_user_id":      targetUserID,
+				"preference_category": model.PreferenceCategoryAdvancedSettings,
+				"preference_name":     model.PreferenceNameAttachAppLogs,
+				"value":               value,
+			},
+			PriorState:  map[string]any{},
+			ResultState: map[string]any{},
+			ObjectType:  "user_preference",
+		},
+	}
+	a.LogAuditRecWithLevel(rctx, rec, app.LevelAPI, nil)
+}
+
+func (*MobileLogsProvider) GetTrigger() string {
+	return CmdMobileLogs
+}
+
+func (*MobileLogsProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Command {
+	return &model.Command{
+		Trigger:          CmdMobileLogs,
+		AutoComplete:     true,
+		AutoCompleteDesc: T("api.command_mobile_logs.desc"),
+		AutoCompleteHint: T("api.command_mobile_logs.hint"),
+		DisplayName:      T("api.command_mobile_logs.name"),
+	}
+}
+
+func (*MobileLogsProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+	fields := strings.Fields(message)
+	if len(fields) == 0 || len(fields) > 2 {
+		return &model.CommandResponse{
+			Text:         args.T("api.command_mobile_logs.usage"),
+			ResponseType: model.CommandResponseTypeEphemeral,
+		}
+	}
+
+	action := strings.ToLower(fields[0])
+	if action != "on" && action != "off" && action != "status" {
+		return &model.CommandResponse{
+			Text:         args.T("api.command_mobile_logs.usage"),
+			ResponseType: model.CommandResponseTypeEphemeral,
+		}
+	}
+
+	targetUserID := args.UserId
+	targetDisplayName := args.T("api.command_mobile_logs.you")
+
+	if len(fields) > 1 {
+		username := strings.TrimPrefix(fields[1], "@")
+		username = strings.ToLower(username)
+
+		if !model.IsValidUsername(username) {
+			return &model.CommandResponse{
+				Text:         args.T("api.command_mobile_logs.user_not_found.app_error", map[string]any{"Username": username}),
+				ResponseType: model.CommandResponseTypeEphemeral,
+			}
+		}
+
+		caller, appErr := a.GetUser(args.UserId)
+		if appErr != nil {
+			rctx.Logger().Error("Failed to get caller for mobile-logs command", mlog.String("user_id", args.UserId), mlog.Err(appErr))
+			return &model.CommandResponse{
+				Text:         args.T("api.command_mobile_logs.update_error.app_error"),
+				ResponseType: model.CommandResponseTypeEphemeral,
+			}
+		}
+
+		isSelf := username == strings.ToLower(caller.Username)
+		if isSelf {
+			targetUserID = caller.Id
+			targetDisplayName = "@" + caller.Username
+		} else {
+			// Cross-user: callers without system admin get one neutral outcome for any failure
+			// (unknown user, deactivated, disallowed target, or missing role) to avoid username
+			// enumeration. System admins still get explicit not-found messages for support workflows.
+			if !a.HasPermissionTo(args.UserId, model.PermissionManageSystem) && !a.HasPermissionTo(args.UserId, model.PermissionEditOtherUsers) {
+				return mobileLogsCrossUserUnavailableResponse(args)
+			}
+
+			callerHasManageSystem := a.HasPermissionTo(args.UserId, model.PermissionManageSystem)
+
+			targetUser, lookupErr := a.GetUserByUsername(username)
+			if lookupErr != nil {
+				if lookupErr.StatusCode == http.StatusNotFound {
+					if callerHasManageSystem {
+						return &model.CommandResponse{
+							Text:         args.T("api.command_mobile_logs.user_not_found.app_error", map[string]any{"Username": username}),
+							ResponseType: model.CommandResponseTypeEphemeral,
+						}
+					}
+					return mobileLogsCrossUserUnavailableResponse(args)
+				}
+				rctx.Logger().Error("Failed to get user by username", mlog.String("username", username), mlog.Err(lookupErr))
+				if callerHasManageSystem {
+					return &model.CommandResponse{
+						Text:         args.T("api.command_mobile_logs.user_not_found.app_error", map[string]any{"Username": username}),
+						ResponseType: model.CommandResponseTypeEphemeral,
+					}
+				}
+				return mobileLogsCrossUserUnavailableResponse(args)
+			}
+
+			if targetUser.DeleteAt != 0 {
+				if callerHasManageSystem {
+					return &model.CommandResponse{
+						Text:         args.T("api.command_mobile_logs.user_not_found.app_error", map[string]any{"Username": username}),
+						ResponseType: model.CommandResponseTypeEphemeral,
+					}
+				}
+				return mobileLogsCrossUserUnavailableResponse(args)
+			}
+
+			targetUserID = targetUser.Id
+			targetDisplayName = "@" + targetUser.Username
+
+			if !callerHasManageSystem && targetUser.IsSystemAdmin() {
+				return mobileLogsCrossUserUnavailableResponse(args)
+			}
+		}
+	}
+
+	switch action {
+	case "on":
+		prefs := model.Preferences{
+			{
+				UserId:   targetUserID,
+				Category: model.PreferenceCategoryAdvancedSettings,
+				Name:     model.PreferenceNameAttachAppLogs,
+				Value:    "true",
+			},
+		}
+		if err := a.UpdatePreferences(rctx, targetUserID, prefs); err != nil {
+			rctx.Logger().Error("Failed to update attach_app_logs preference", mlog.String("user_id", targetUserID), mlog.Err(err))
+			return &model.CommandResponse{
+				Text:         args.T("api.command_mobile_logs.update_error.app_error"),
+				ResponseType: model.CommandResponseTypeEphemeral,
+			}
+		}
+		logMobileLogsAttachAppLogsAudit(a, rctx, args.UserId, targetUserID, "true")
+		return &model.CommandResponse{
+			Text:         args.T("api.command_mobile_logs.enabled", map[string]any{"User": targetDisplayName}),
+			ResponseType: model.CommandResponseTypeEphemeral,
+		}
+
+	case "off":
+		prefs := model.Preferences{
+			{
+				UserId:   targetUserID,
+				Category: model.PreferenceCategoryAdvancedSettings,
+				Name:     model.PreferenceNameAttachAppLogs,
+				Value:    "false",
+			},
+		}
+		if err := a.UpdatePreferences(rctx, targetUserID, prefs); err != nil {
+			rctx.Logger().Error("Failed to update attach_app_logs preference", mlog.String("user_id", targetUserID), mlog.Err(err))
+			return &model.CommandResponse{
+				Text:         args.T("api.command_mobile_logs.update_error.app_error"),
+				ResponseType: model.CommandResponseTypeEphemeral,
+			}
+		}
+		logMobileLogsAttachAppLogsAudit(a, rctx, args.UserId, targetUserID, "false")
+		return &model.CommandResponse{
+			Text:         args.T("api.command_mobile_logs.disabled", map[string]any{"User": targetDisplayName}),
+			ResponseType: model.CommandResponseTypeEphemeral,
+		}
+
+	case "status":
+		pref, err := a.GetPreferenceByCategoryAndNameForUser(rctx, targetUserID, model.PreferenceCategoryAdvancedSettings, model.PreferenceNameAttachAppLogs)
+		if err != nil {
+			rctx.Logger().Debug("Could not get attach_app_logs preference, defaulting to off", mlog.String("user_id", targetUserID), mlog.Err(err))
+			return &model.CommandResponse{
+				Text:         args.T("api.command_mobile_logs.status_off", map[string]any{"User": targetDisplayName}),
+				ResponseType: model.CommandResponseTypeEphemeral,
+			}
+		}
+		if pref.Value == "true" {
+			return &model.CommandResponse{
+				Text:         args.T("api.command_mobile_logs.status_on", map[string]any{"User": targetDisplayName}),
+				ResponseType: model.CommandResponseTypeEphemeral,
+			}
+		}
+		return &model.CommandResponse{
+			Text:         args.T("api.command_mobile_logs.status_off", map[string]any{"User": targetDisplayName}),
+			ResponseType: model.CommandResponseTypeEphemeral,
+		}
+
+	default:
+		// Defensive: action is already validated to be "on", "off", or "status" above.
+		return &model.CommandResponse{
+			Text:         args.T("api.command_mobile_logs.usage"),
+			ResponseType: model.CommandResponseTypeEphemeral,
+		}
+	}
+}

--- a/server/channels/app/slashcommands/command_mobile_logs_test.go
+++ b/server/channels/app/slashcommands/command_mobile_logs_test.go
@@ -1,0 +1,284 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package slashcommands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/i18n"
+)
+
+func TestMobileLogsGetCommand(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+	result := cmd.GetCommand(th.App, i18n.IdentityTfunc())
+	assert.Equal(t, CmdMobileLogs, result.Trigger)
+	assert.True(t, result.AutoComplete)
+	assert.NotEmpty(t, result.AutoCompleteDesc)
+	assert.NotEmpty(t, result.AutoCompleteHint)
+	assert.NotEmpty(t, result.DisplayName)
+}
+
+func TestMobileLogsOnSelf(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.BasicUser.Id,
+	}, "on")
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.enabled", resp.Text)
+
+	pref, err := th.App.GetPreferenceByCategoryAndNameForUser(th.Context, th.BasicUser.Id, model.PreferenceCategoryAdvancedSettings, model.PreferenceNameAttachAppLogs)
+	require.Nil(t, err)
+	assert.Equal(t, "true", pref.Value)
+}
+
+func TestMobileLogsOffSelf(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+	cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.BasicUser.Id,
+	}, "on")
+
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.BasicUser.Id,
+	}, "off")
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.disabled", resp.Text)
+
+	pref, err := th.App.GetPreferenceByCategoryAndNameForUser(th.Context, th.BasicUser.Id, model.PreferenceCategoryAdvancedSettings, model.PreferenceNameAttachAppLogs)
+	require.Nil(t, err)
+	assert.Equal(t, "false", pref.Value)
+}
+
+func TestMobileLogsStatusDefault(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.BasicUser.Id,
+	}, "status")
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.status_off", resp.Text)
+}
+
+func TestMobileLogsStatusOn(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+	cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.BasicUser.Id,
+	}, "on")
+
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.BasicUser.Id,
+	}, "status")
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.status_on", resp.Text)
+}
+
+func TestMobileLogsOnOtherUserWithPermission(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.SystemAdminUser.Id,
+	}, "on @"+th.BasicUser.Username)
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.enabled", resp.Text)
+
+	pref, err := th.App.GetPreferenceByCategoryAndNameForUser(th.Context, th.BasicUser.Id, model.PreferenceCategoryAdvancedSettings, model.PreferenceNameAttachAppLogs)
+	require.Nil(t, err)
+	assert.Equal(t, "true", pref.Value)
+}
+
+func TestMobileLogsOffOtherUserWithPermission(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+	cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.SystemAdminUser.Id,
+	}, "on @"+th.BasicUser.Username)
+
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.SystemAdminUser.Id,
+	}, "off @"+th.BasicUser.Username)
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.disabled", resp.Text)
+
+	pref, err := th.App.GetPreferenceByCategoryAndNameForUser(th.Context, th.BasicUser.Id, model.PreferenceCategoryAdvancedSettings, model.PreferenceNameAttachAppLogs)
+	require.Nil(t, err)
+	assert.Equal(t, "false", pref.Value)
+}
+
+func TestMobileLogsStatusOtherUser(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+
+	// Default status for other user
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.SystemAdminUser.Id,
+	}, "status @"+th.BasicUser.Username)
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.status_off", resp.Text)
+
+	// Enable for other user, then check status
+	cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.SystemAdminUser.Id,
+	}, "on @"+th.BasicUser.Username)
+
+	resp = cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.SystemAdminUser.Id,
+	}, "status @"+th.BasicUser.Username)
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.status_on", resp.Text)
+}
+
+func TestMobileLogsOnOtherUserWithoutPermission(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.BasicUser.Id,
+	}, "on @"+th.BasicUser2.Username)
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.cross_user_unavailable.app_error", resp.Text)
+}
+
+func TestMobileLogsOnOtherUserWithoutAtPrefix(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.SystemAdminUser.Id,
+	}, "on "+th.BasicUser.Username)
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.enabled", resp.Text)
+
+	pref, err := th.App.GetPreferenceByCategoryAndNameForUser(th.Context, th.BasicUser.Id, model.PreferenceCategoryAdvancedSettings, model.PreferenceNameAttachAppLogs)
+	require.Nil(t, err)
+	assert.Equal(t, "true", pref.Value)
+}
+
+func TestMobileLogsNoArgs(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.BasicUser.Id,
+	}, "")
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.usage", resp.Text)
+}
+
+func TestMobileLogsTooManyArgs(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+	cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.SystemAdminUser.Id,
+	}, "on @"+th.BasicUser.Username)
+
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.SystemAdminUser.Id,
+	}, "on @"+th.BasicUser.Username+" trailing")
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.usage", resp.Text)
+
+	pref, err := th.App.GetPreferenceByCategoryAndNameForUser(th.Context, th.BasicUser.Id, model.PreferenceCategoryAdvancedSettings, model.PreferenceNameAttachAppLogs)
+	require.Nil(t, err)
+	assert.Equal(t, "true", pref.Value)
+}
+
+func TestMobileLogsInvalidAction(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.BasicUser.Id,
+	}, "invalid")
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.usage", resp.Text)
+}
+
+func TestMobileLogsUserNotFound(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.SystemAdminUser.Id,
+	}, "on @nonexistentuser12345")
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.user_not_found.app_error", resp.Text)
+}
+
+func TestMobileLogsNonexistentTargetAsRegularUserReturnsNoPermission(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.BasicUser.Id,
+	}, "on @nonexistentuser12345")
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.cross_user_unavailable.app_error", resp.Text)
+}
+
+func TestMobileLogsOnSelfWithAtUsername(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	cmd := &MobileLogsProvider{}
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.BasicUser.Id,
+	}, "on @"+th.BasicUser.Username)
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.enabled", resp.Text)
+
+	pref, err := th.App.GetPreferenceByCategoryAndNameForUser(th.Context, th.BasicUser.Id, model.PreferenceCategoryAdvancedSettings, model.PreferenceNameAttachAppLogs)
+	require.Nil(t, err)
+	assert.Equal(t, "true", pref.Value)
+}
+
+func TestMobileLogsDeactivatedUser(t *testing.T) {
+	th := setup(t).initBasic(t)
+
+	_, err := th.App.UpdateActive(th.Context, th.BasicUser2, false)
+	require.Nil(t, err)
+
+	cmd := &MobileLogsProvider{}
+	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.SystemAdminUser.Id,
+	}, "on @"+th.BasicUser2.Username)
+	assert.Equal(t, model.CommandResponseTypeEphemeral, resp.ResponseType)
+	assert.Equal(t, "api.command_mobile_logs.user_not_found.app_error", resp.Text)
+}

--- a/server/channels/store/storetest/file_info_store.go
+++ b/server/channels/store/storetest/file_info_store.go
@@ -871,18 +871,20 @@ func testFileInfoGetStorageUsage(t *testing.T, rctx request.CTX, ss store.Store)
 }
 
 func testGetUptoNSizeFileTime(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
-	t.Skip("MM-53905")
-
 	_, err := ss.FileInfo().GetUptoNSizeFileTime(0)
 	assert.Error(t, err)
 	_, err = ss.FileInfo().GetUptoNSizeFileTime(-1)
 	assert.Error(t, err)
 
-	_, err = ss.FileInfo().PermanentDeleteBatch(rctx, model.GetMillis(), 100000)
+	// Delete all existing file infos so parallel tests don't interfere with
+	// the cumulative size calculation (MM-53905).
+	_, err = ss.FileInfo().PermanentDeleteBatch(rctx, model.GetMillis()+3600000, 100000)
 	require.NoError(t, err)
 
+	// Use far-future timestamps so these are always "most recent" even if
+	// parallel tests create file infos concurrently.
 	diff := int64(10000)
-	now := utils.MillisFromTime(time.Now()) + diff
+	now := utils.MillisFromTime(time.Now()) + 3600000 // 1 hour in the future
 
 	f1, err := ss.FileInfo().Save(rctx, &model.FileInfo{
 		PostId:    model.NewId(),

--- a/server/channels/store/storetest/post_store.go
+++ b/server/channels/store/storetest/post_store.go
@@ -5460,27 +5460,30 @@ func getPostIds(posts []*model.Post, morePosts ...*model.Post) []string {
 }
 
 func testGetNthRecentPostTime(t *testing.T, rctx request.CTX, ss store.Store) {
-	t.Skip("https://mattermost.atlassian.net/browse/MM-64438")
-
 	_, err := ss.Post().GetNthRecentPostTime(0)
 	assert.Error(t, err)
 	_, err = ss.Post().GetNthRecentPostTime(-1)
 	assert.Error(t, err)
 
+	// Use timestamps 1 hour in the future so these posts are always "most recent"
+	// regardless of what parallel tests create concurrently (MM-64438).
 	diff := int64(10000)
-	now := utils.MillisFromTime(time.Now()) + diff
+	now := utils.MillisFromTime(time.Now()) + 3600000
+
+	userId := model.NewId()
+	channelId := model.NewId()
 
 	p1 := &model.Post{}
-	p1.ChannelId = model.NewId()
-	p1.UserId = model.NewId()
+	p1.ChannelId = channelId
+	p1.UserId = userId
 	p1.Message = "test"
 	p1.CreateAt = now
 	p1, err = ss.Post().Save(rctx, p1)
 	require.NoError(t, err)
 
 	p2 := &model.Post{}
-	p2.ChannelId = p1.ChannelId
-	p2.UserId = p1.UserId
+	p2.ChannelId = channelId
+	p2.UserId = userId
 	p2.Message = p1.Message
 	now = now + diff
 	p2.CreateAt = now
@@ -5498,16 +5501,16 @@ func testGetNthRecentPostTime(t *testing.T, rctx request.CTX, ss store.Store) {
 
 	b1 := &model.Post{}
 	b1.Message = "bot test"
-	b1.ChannelId = p1.ChannelId
+	b1.ChannelId = channelId
 	b1.UserId = bot1.UserId
 	now = now + diff
 	b1.CreateAt = now
-	_, err = ss.Post().Save(rctx, b1)
+	b1, err = ss.Post().Save(rctx, b1)
 	require.NoError(t, err)
 
 	p3 := &model.Post{}
-	p3.ChannelId = p1.ChannelId
-	p3.UserId = p1.UserId
+	p3.ChannelId = channelId
+	p3.UserId = userId
 	p3.Message = p1.Message
 	now = now + diff
 	p3.CreateAt = now
@@ -5516,22 +5519,31 @@ func testGetNthRecentPostTime(t *testing.T, rctx request.CTX, ss store.Store) {
 
 	s1 := &model.Post{}
 	s1.Type = model.PostTypeJoinChannel
-	s1.ChannelId = p1.ChannelId
+	s1.ChannelId = channelId
 	s1.UserId = model.NewId()
 	s1.Message = "system_join_channel message"
 	now = now + diff
 	s1.CreateAt = now
-	_, err = ss.Post().Save(rctx, s1)
+	s1, err = ss.Post().Save(rctx, s1)
 	require.NoError(t, err)
 
 	p4 := &model.Post{}
-	p4.ChannelId = p1.ChannelId
-	p4.UserId = p1.UserId
+	p4.ChannelId = channelId
+	p4.UserId = userId
 	p4.Message = p1.Message
 	now = now + diff
 	p4.CreateAt = now
 	p4, err = ss.Post().Save(rctx, p4)
 	require.NoError(t, err)
+
+	// Clean up far-future posts so they don't leak into other tests (per review feedback).
+	defer func() {
+		for _, p := range []*model.Post{p1, p2, b1, p3, s1, p4} {
+			if delErr := ss.Post().PermanentDelete(rctx, p.Id); delErr != nil {
+				t.Logf("failed to delete post %s: %v", p.Id, delErr)
+			}
+		}
+	}()
 
 	r, err := ss.Post().GetNthRecentPostTime(1)
 	assert.NoError(t, err)

--- a/server/channels/store/storetest/thread_store.go
+++ b/server/channels/store/storetest/thread_store.go
@@ -418,8 +418,24 @@ func testThreadStorePopulation(t *testing.T, rctx request.CTX, ss store.Store) {
 		}
 	})
 	t.Run("Get unread reply counts for thread", func(t *testing.T) {
-		t.Skip("MM-41797")
+		// Create posts with explicit timestamp spacing to avoid timestamp
+		// collisions that make MarkAsRead boundaries ambiguous (MM-41797).
+		// makeSomePosts doesn't set CreateAt, so posts can share the same
+		// millisecond, causing MarkAsRead(rootPost.CreateAt) to also mark
+		// the replies as read.
 		newPosts := makeSomePosts(false)
+
+		// Ensure replies have later timestamps than the root post.
+		// The root post is newPosts[0], replies are newPosts[1] and newPosts[2].
+		baseTime := newPosts[0].CreateAt
+		for i := 1; i < len(newPosts); i++ {
+			if newPosts[i].RootId != "" && newPosts[i].CreateAt <= baseTime {
+				newPosts[i].CreateAt = baseTime + int64(i)*1000
+				_, sErr := ss.Post().Overwrite(rctx, newPosts[i])
+				require.NoError(t, sErr, "failed to update post timestamp")
+			}
+		}
+
 		opts := store.ThreadMembershipOpts{
 			Following:             true,
 			IncrementMentions:     false,

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -1282,6 +1282,54 @@
     "translation": "me"
   },
   {
+    "id": "api.command_mobile_logs.cross_user_unavailable.app_error",
+    "translation": "Unable to change mobile log settings for that user."
+  },
+  {
+    "id": "api.command_mobile_logs.desc",
+    "translation": "Manage mobile app log attachment for yourself or another user."
+  },
+  {
+    "id": "api.command_mobile_logs.disabled",
+    "translation": "Mobile app log attachment is now disabled for {{.User}}."
+  },
+  {
+    "id": "api.command_mobile_logs.enabled",
+    "translation": "Mobile app log attachment is now enabled for {{.User}}."
+  },
+  {
+    "id": "api.command_mobile_logs.hint",
+    "translation": "[on|off|status] [@username]"
+  },
+  {
+    "id": "api.command_mobile_logs.name",
+    "translation": "mobile-logs"
+  },
+  {
+    "id": "api.command_mobile_logs.status_off",
+    "translation": "Mobile app log attachment is currently disabled for {{.User}}."
+  },
+  {
+    "id": "api.command_mobile_logs.status_on",
+    "translation": "Mobile app log attachment is currently enabled for {{.User}}."
+  },
+  {
+    "id": "api.command_mobile_logs.update_error.app_error",
+    "translation": "Failed to update mobile app log attachment setting. Please try again."
+  },
+  {
+    "id": "api.command_mobile_logs.usage",
+    "translation": "Usage: /mobile-logs [on|off|status] [@username]"
+  },
+  {
+    "id": "api.command_mobile_logs.user_not_found.app_error",
+    "translation": "Could not find user \"{{.Username}}\"."
+  },
+  {
+    "id": "api.command_mobile_logs.you",
+    "translation": "you"
+  },
+  {
     "id": "api.command_msg.desc",
     "translation": "Send Direct Message to a user"
   },

--- a/server/public/model/preference.go
+++ b/server/public/model/preference.go
@@ -30,6 +30,7 @@ const (
 	// - "join_leave"
 	// - "unread_scroll_position"
 	// - "sync_drafts"
+	// - "attach_app_logs"
 	// - "feature_enabled_markdown_preview" <- deprecated in favor of "formatting"
 	PreferenceCategoryAdvancedSettings = "advanced_settings"
 	// PreferenceCategoryFlaggedPost is used to store the user's saved posts.
@@ -80,6 +81,7 @@ const (
 	// PreferenceCategoryTheme has the name for the team id where theme is set.
 	PreferenceCategoryTheme = "theme"
 
+	PreferenceNameAttachAppLogs           = "attach_app_logs"
 	PreferenceNameCollapsedThreadsEnabled = "collapsed_reply_threads"
 	PreferenceNameChannelDisplayMode      = "channel_display_mode"
 	PreferenceNameCollapseSetting         = "collapse_previews"

--- a/webapp/channels/src/components/admin_console/__snapshots__/elasticsearch_settings.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/__snapshots__/elasticsearch_settings.test.tsx.snap
@@ -1489,3 +1489,746 @@ exports[`components/ElasticSearchSettings should match snapshot, enabled 1`] = `
   </form>
 </div>
 `;
+
+exports[`components/ElasticSearchSettings should match snapshot, sniff enabled 1`] = `
+<div>
+  <form
+    class="form-horizontal"
+    role="form"
+  >
+    <div
+      class="wrapper--fixed"
+    >
+      <div
+        class="admin-console__header"
+      >
+        Elasticsearch
+      </div>
+      <div
+        class="admin-console__wrapper"
+      >
+        <div
+          class="admin-console__content"
+        >
+          <fieldset
+            class="form-group"
+            data-testid="enableIndexing"
+            id="enableIndexing"
+          >
+            <legend
+              class="control-label form-legend col-sm-4"
+            >
+              Enable Elasticsearch Indexing:
+            </legend>
+            <div
+              class="col-sm-8"
+            >
+              <label
+                class="Label-eJcoMl iShgPr"
+              >
+                <input
+                  checked=""
+                  data-testid="enableIndexingtrue"
+                  id="enableIndexingtrue"
+                  name="enableIndexing"
+                  type="radio"
+                  value="true"
+                />
+                True
+              </label>
+              <label
+                class="Label-eJcoMl iShgPr"
+              >
+                <input
+                  data-testid="enableIndexingfalse"
+                  id="enableIndexingfalse"
+                  name="enableIndexing"
+                  type="radio"
+                  value="false"
+                />
+                False
+              </label>
+              <div
+                class="help-text"
+                data-testid="enableIndexinghelp-text"
+              >
+                When true, indexing of new posts occurs automatically. Search queries will use database search until "Enable Elasticsearch for search queries" is enabled. 
+                <a
+                  href="https://okr.best/pl/setup-elasticsearch"
+                  location="elasticsearch_settings"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Learn more about Elasticsearch in our documentation.
+                </a>
+              </div>
+            </div>
+          </fieldset>
+          <div
+            class="form-group"
+            data-testid="backend"
+          >
+            <label
+              class="control-label col-sm-4"
+              data-testid="backendlabel"
+              for="backend"
+            >
+              Backend type:
+            </label>
+            <div
+              class="col-sm-8"
+            >
+              <input
+                class="form-control"
+                data-testid="backendinput"
+                id="backend"
+                maxlength="-1"
+                placeholder="E.g.: \\"elasticsearch\\""
+                type="text"
+                value=""
+              />
+              <div
+                class="help-text"
+                data-testid="backendhelp-text"
+              >
+                The type of the search backend. Changing this setting requires a server restart before taking effect.
+              </div>
+            </div>
+          </div>
+          <div
+            class="form-group"
+            data-testid="connectionUrl"
+          >
+            <label
+              class="control-label col-sm-4"
+              data-testid="connectionUrllabel"
+              for="connectionUrl"
+            >
+              Server Connection Address:
+            </label>
+            <div
+              class="col-sm-8"
+            >
+              <input
+                class="form-control"
+                data-testid="connectionUrlinput"
+                id="connectionUrl"
+                maxlength="-1"
+                placeholder="E.g.: \\"https://elasticsearch.example.org:9200\\""
+                type="text"
+                value="test"
+              />
+              <div
+                class="help-text"
+                data-testid="connectionUrlhelp-text"
+              >
+                The address of the Elasticsearch server. 
+                <a
+                  href="https://okr.best/pl/setup-elasticsearch"
+                  location="elasticsearch_settings"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Please see documentation with server setup instructions.
+                </a>
+              </div>
+            </div>
+          </div>
+          <div
+            class="form-group"
+            data-testid="ca"
+          >
+            <label
+              class="control-label col-sm-4"
+              data-testid="calabel"
+              for="ca"
+            >
+              CA path:
+            </label>
+            <div
+              class="col-sm-8"
+            >
+              <input
+                class="form-control"
+                data-testid="cainput"
+                id="ca"
+                maxlength="-1"
+                placeholder="E.g.: \\"./elasticsearch/ca.pem\\""
+                type="text"
+                value="test.ca"
+              />
+              <div
+                class="help-text"
+                data-testid="cahelp-text"
+              >
+                (Optional) Custom Certificate Authority certificates for the Elasticsearch server. Leave this empty to use the default CAs from the operating system.
+              </div>
+            </div>
+          </div>
+          <div
+            class="form-group"
+            data-testid="clientCert"
+          >
+            <label
+              class="control-label col-sm-4"
+              data-testid="clientCertlabel"
+              for="clientCert"
+            >
+              Client Certificate path:
+            </label>
+            <div
+              class="col-sm-8"
+            >
+              <input
+                class="form-control"
+                data-testid="clientCertinput"
+                id="clientCert"
+                maxlength="-1"
+                placeholder="E.g.: \\"./elasticsearch/client-cert.pem\\""
+                type="text"
+                value="test.crt"
+              />
+              <div
+                class="help-text"
+                data-testid="clientCerthelp-text"
+              >
+                (Optional) The client certificate for the connection to the Elasticsearch server in the PEM format.
+              </div>
+            </div>
+          </div>
+          <div
+            class="form-group"
+            data-testid="clientKey"
+          >
+            <label
+              class="control-label col-sm-4"
+              data-testid="clientKeylabel"
+              for="clientKey"
+            >
+              Client Certificate Key path:
+            </label>
+            <div
+              class="col-sm-8"
+            >
+              <input
+                class="form-control"
+                data-testid="clientKeyinput"
+                id="clientKey"
+                maxlength="-1"
+                placeholder="E.g.: \\"./elasticsearch/client-key.pem\\""
+                type="text"
+                value="test.key"
+              />
+              <div
+                class="help-text"
+                data-testid="clientKeyhelp-text"
+              >
+                (Optional) The key for the client certificate in the PEM format.
+              </div>
+            </div>
+          </div>
+          <fieldset
+            class="form-group"
+            data-testid="skipTLSVerification"
+            id="skipTLSVerification"
+          >
+            <legend
+              class="control-label form-legend col-sm-4"
+            >
+              Skip TLS Verification:
+            </legend>
+            <div
+              class="col-sm-8"
+            >
+              <label
+                class="Label-eJcoMl iShgPr"
+              >
+                <input
+                  data-testid="skipTLSVerificationtrue"
+                  id="skipTLSVerificationtrue"
+                  name="skipTLSVerification"
+                  type="radio"
+                  value="true"
+                />
+                True
+              </label>
+              <label
+                class="Label-eJcoMl iShgPr"
+              >
+                <input
+                  checked=""
+                  data-testid="skipTLSVerificationfalse"
+                  id="skipTLSVerificationfalse"
+                  name="skipTLSVerification"
+                  type="radio"
+                  value="false"
+                />
+                False
+              </label>
+              <div
+                class="help-text"
+                data-testid="skipTLSVerificationhelp-text"
+              >
+                When true, Mattermost will not require the Elasticsearch certificate to be signed by a trusted Certificate Authority.
+              </div>
+            </div>
+          </fieldset>
+          <div
+            class="form-group"
+            data-testid="username"
+          >
+            <label
+              class="control-label col-sm-4"
+              data-testid="usernamelabel"
+              for="username"
+            >
+              Server Username:
+            </label>
+            <div
+              class="col-sm-8"
+            >
+              <input
+                class="form-control"
+                data-testid="usernameinput"
+                id="username"
+                maxlength="-1"
+                placeholder="E.g.: \\"elastic\\""
+                type="text"
+                value="test"
+              />
+              <div
+                class="help-text"
+                data-testid="usernamehelp-text"
+              >
+                (Optional) The username to authenticate to the Elasticsearch server.
+              </div>
+            </div>
+          </div>
+          <div
+            class="form-group"
+            data-testid="password"
+          >
+            <label
+              class="control-label col-sm-4"
+              data-testid="passwordlabel"
+              for="password"
+            >
+              Server Password:
+            </label>
+            <div
+              class="col-sm-8"
+            >
+              <input
+                class="form-control"
+                data-testid="passwordinput"
+                id="password"
+                maxlength="-1"
+                placeholder="E.g.: \\"yourpassword\\""
+                type="text"
+                value="test"
+              />
+              <div
+                class="help-text"
+                data-testid="passwordhelp-text"
+              >
+                (Optional) The password to authenticate to the Elasticsearch server.
+              </div>
+            </div>
+          </div>
+          <fieldset
+            class="form-group"
+            data-testid="sniff"
+            id="sniff"
+          >
+            <legend
+              class="control-label form-legend col-sm-4"
+            >
+              Enable Cluster Sniffing:
+            </legend>
+            <div
+              class="col-sm-8"
+            >
+              <label
+                class="Label-eJcoMl iShgPr"
+              >
+                <input
+                  checked=""
+                  data-testid="snifftrue"
+                  id="snifftrue"
+                  name="sniff"
+                  type="radio"
+                  value="true"
+                />
+                True
+              </label>
+              <label
+                class="Label-eJcoMl iShgPr"
+              >
+                <input
+                  data-testid="snifffalse"
+                  id="snifffalse"
+                  name="sniff"
+                  type="radio"
+                  value="false"
+                />
+                False
+              </label>
+              <div
+                class="help-text"
+                data-testid="sniffhelp-text"
+              >
+                When true, sniffing finds and connects to all data nodes in your cluster automatically.
+                <div
+                  class="alert alert-warning"
+                >
+                  <i
+                    class="fa fa-warning"
+                    title="Warning Icon"
+                  />
+                  Do not enable cluster sniffing with cloud-hosted providers such as Elastic Cloud or Amazon OpenSearch Service.
+                </div>
+              </div>
+            </div>
+          </fieldset>
+          <div
+            class="form-group"
+            id="testConfig"
+          >
+            <div
+              class="col-sm-offset-4 col-sm-8"
+            >
+              <div>
+                <button
+                  class="btn btn-tertiary"
+                  type="button"
+                >
+                  Test Connection
+                </button>
+              </div>
+              <div
+                class="help-text"
+              >
+                Tests if the Mattermost server can connect to the Elasticsearch server specified. Testing the connection only saves the configuration if the test is successful. A successful test will also re-initialize the client if you have started Elasticsearch after starting Mattermost. But this will not restart the workers. To do that, please toggle "Enable Elasticsearch Indexing".
+              </div>
+            </div>
+          </div>
+          <fieldset
+            class="form-group"
+          >
+            <legend
+              class="control-label form-legend col-sm-4"
+            >
+              Bulk Indexing:
+            </legend>
+            <div
+              class="col-sm-8"
+            >
+              <div
+                class="job-table-setting"
+              >
+                <div
+                  class="JobTable job-table__panel"
+                >
+                  <div
+                    class="job-table__create-button"
+                  >
+                    <div>
+                      <button
+                        class="btn btn-tertiary"
+                        type="button"
+                      >
+                        Index Now
+                      </button>
+                    </div>
+                    <div
+                      class="help-text"
+                    >
+                      All users, channels and posts in the database will be indexed from oldest to newest. Elasticsearch is available during indexing but search results may be incomplete until the indexing job is complete.
+                    </div>
+                  </div>
+                  <div
+                    class="job-table__table"
+                  >
+                    <table
+                      class="table"
+                      data-testid="jobTable"
+                    >
+                      <thead>
+                        <tr>
+                          <th>
+                            Status
+                          </th>
+                          <th>
+                            Finish Time
+                          </th>
+                          <th>
+                            Run Time
+                          </th>
+                          <th
+                            colspan="3"
+                          >
+                            Details
+                          </th>
+                          <th
+                            class="cancel-button-field"
+                          />
+                        </tr>
+                      </thead>
+                      <tbody />
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </fieldset>
+          <div
+            class="form-group"
+            id="rebuildChannelsIndexButton"
+          >
+            <label
+              class="control-label col-sm-4"
+            >
+              Rebuild Channels Index
+            </label>
+            <div
+              class="col-sm-8"
+            >
+              <div>
+                <button
+                  class="btn btn-tertiary"
+                  type="button"
+                >
+                  Rebuild Channels Index
+                </button>
+              </div>
+              <div
+                class="help-text"
+              >
+                This purges the channels index and re-indexes all channels in the database, from oldest to newest. Channel autocomplete is available during indexing but search results may be incomplete until the indexing job is complete.
+
+                <b>
+                  Note- Please ensure no other indexing job is in progress in the table above.
+                </b>
+              </div>
+            </div>
+          </div>
+          <div
+            class="form-group"
+            id="purgeIndexesSection"
+          >
+            <label
+              class="control-label col-sm-4"
+            >
+              Purge Indexes:
+            </label>
+            <div
+              class="col-sm-8"
+            >
+              <div>
+                <button
+                  class="btn btn-tertiary"
+                  type="button"
+                >
+                  Purge Index
+                </button>
+              </div>
+              <div
+                class="help-text"
+              >
+                Purging will entirely remove the indexes on the Elasticsearch server. Search results may be incomplete until a bulk index of the existing database is rebuilt.
+              </div>
+            </div>
+          </div>
+          <div
+            class="form-group"
+            data-testid="ignoredPurgeIndexes"
+          >
+            <label
+              class="control-label col-sm-4"
+              data-testid="ignoredPurgeIndexeslabel"
+              for="ignoredPurgeIndexes"
+            >
+              Indexes to skip while purging:
+            </label>
+            <div
+              class="col-sm-8"
+            >
+              <input
+                class="form-control"
+                data-testid="ignoredPurgeIndexesinput"
+                id="ignoredPurgeIndexes"
+                maxlength="-1"
+                placeholder="E.g.: .opendistro*,.security*"
+                type="text"
+                value=""
+              />
+              <div
+                class="help-text"
+                data-testid="ignoredPurgeIndexeshelp-text"
+              >
+                When filled in, these indexes will be ignored during the purge, separated by commas.
+              </div>
+            </div>
+          </div>
+          <fieldset
+            class="form-group"
+            data-testid="enableSearching"
+            id="enableSearching"
+          >
+            <legend
+              class="control-label form-legend col-sm-4"
+            >
+              Enable Elasticsearch for search queries:
+            </legend>
+            <div
+              class="col-sm-8"
+            >
+              <label
+                class="Label-eJcoMl iShgPr"
+              >
+                <input
+                  data-testid="enableSearchingtrue"
+                  id="enableSearchingtrue"
+                  name="enableSearching"
+                  type="radio"
+                  value="true"
+                />
+                True
+              </label>
+              <label
+                class="Label-eJcoMl iShgPr"
+              >
+                <input
+                  checked=""
+                  data-testid="enableSearchingfalse"
+                  id="enableSearchingfalse"
+                  name="enableSearching"
+                  type="radio"
+                  value="false"
+                />
+                False
+              </label>
+              <div
+                class="help-text"
+                data-testid="enableSearchinghelp-text"
+              >
+                Requires a successful connection to the Elasticsearch server. When true, Elasticsearch will be used for all search queries using the latest index. Search results may be incomplete until a bulk index of the existing post database is finished. When false, database search is used.
+              </div>
+            </div>
+          </fieldset>
+          <fieldset
+            class="form-group"
+            data-testid="enableAutocomplete"
+            id="enableAutocomplete"
+          >
+            <legend
+              class="control-label form-legend col-sm-4"
+            >
+              Enable Elasticsearch for autocomplete queries:
+            </legend>
+            <div
+              class="col-sm-8"
+            >
+              <label
+                class="Label-eJcoMl iShgPr"
+              >
+                <input
+                  data-testid="enableAutocompletetrue"
+                  id="enableAutocompletetrue"
+                  name="enableAutocomplete"
+                  type="radio"
+                  value="true"
+                />
+                True
+              </label>
+              <label
+                class="Label-eJcoMl iShgPr"
+              >
+                <input
+                  checked=""
+                  data-testid="enableAutocompletefalse"
+                  id="enableAutocompletefalse"
+                  name="enableAutocomplete"
+                  type="radio"
+                  value="false"
+                />
+                False
+              </label>
+              <div
+                class="help-text"
+                data-testid="enableAutocompletehelp-text"
+              >
+                Requires a successful connection to the Elasticsearch server. When true, Elasticsearch will be used for all autocompletion queries on users and channels using the latest index. Autocompletion results may be incomplete until a bulk index of the existing users and channels database is finished. When false, database autocomplete is used.
+              </div>
+            </div>
+          </fieldset>
+          <fieldset
+            class="form-group"
+            data-testid="enableSearchPublicChannelsWithoutMembership"
+            id="enableSearchPublicChannelsWithoutMembership"
+          >
+            <legend
+              class="control-label form-legend col-sm-4"
+            >
+              Allow searching public channels without membership:
+            </legend>
+            <div
+              class="col-sm-8"
+            >
+              <label
+                class="Label-eJcoMl iShgPr"
+              >
+                <input
+                  data-testid="enableSearchPublicChannelsWithoutMembershiptrue"
+                  id="enableSearchPublicChannelsWithoutMembershiptrue"
+                  name="enableSearchPublicChannelsWithoutMembership"
+                  type="radio"
+                  value="true"
+                />
+                True
+              </label>
+              <label
+                class="Label-eJcoMl iShgPr"
+              >
+                <input
+                  checked=""
+                  data-testid="enableSearchPublicChannelsWithoutMembershipfalse"
+                  id="enableSearchPublicChannelsWithoutMembershipfalse"
+                  name="enableSearchPublicChannelsWithoutMembership"
+                  type="radio"
+                  value="false"
+                />
+                False
+              </label>
+              <div
+                class="help-text"
+                data-testid="enableSearchPublicChannelsWithoutMembershiphelp-text"
+              >
+                When enabled, users can find messages in public channels they have not joined. When enabled for the first time, existing posts will be updated in the background. This process is throttled to avoid impacting search performance. This setting has no effect when Compliance Mode is enabled.
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+      <div
+        class="admin-console-save"
+      >
+        <button
+          class="btn btn-primary"
+          data-testid="saveSetting"
+          disabled=""
+          id="saveSetting"
+          type="submit"
+        >
+          <span>
+            Save
+          </span>
+        </button>
+        <div
+          class="error-message"
+        />
+      </div>
+    </div>
+  </form>
+</div>
+`;

--- a/webapp/channels/src/components/admin_console/elasticsearch_settings.test.tsx
+++ b/webapp/channels/src/components/admin_console/elasticsearch_settings.test.tsx
@@ -74,6 +74,90 @@ describe('components/ElasticSearchSettings', () => {
         expect(container).toMatchSnapshot();
     });
 
+    test('should match snapshot, sniff enabled', () => {
+        const config = {
+            ElasticsearchSettings: {
+                ConnectionURL: 'test',
+                Backend: '',
+                SkipTLSVerification: false,
+                CA: 'test.ca',
+                ClientCert: 'test.crt',
+                ClientKey: 'test.key',
+                Username: 'test',
+                Password: 'test',
+                Sniff: true,
+                EnableIndexing: true,
+                EnableSearching: false,
+                EnableAutocomplete: false,
+                EnableSearchPublicChannelsWithoutMembership: false,
+                IgnoredPurgeIndexes: '',
+            },
+        };
+        const {container} = renderWithContext(
+            <ElasticSearchSettings
+                config={config as AdminConfig}
+                isDisabled={false}
+            />,
+        );
+        expect(container).toMatchSnapshot();
+    });
+
+    test('should show warning when sniff is enabled', () => {
+        const config = {
+            ElasticsearchSettings: {
+                ConnectionURL: 'test',
+                Backend: '',
+                SkipTLSVerification: false,
+                CA: '',
+                ClientCert: '',
+                ClientKey: '',
+                Username: '',
+                Password: '',
+                Sniff: true,
+                EnableIndexing: true,
+                EnableSearching: false,
+                EnableAutocomplete: false,
+                EnableSearchPublicChannelsWithoutMembership: false,
+                IgnoredPurgeIndexes: '',
+            },
+        };
+        renderWithContext(
+            <ElasticSearchSettings
+                config={config as AdminConfig}
+                isDisabled={false}
+            />,
+        );
+        expect(screen.getByText('Do not enable cluster sniffing with cloud-hosted providers such as Elastic Cloud or Amazon OpenSearch Service.')).toBeInTheDocument();
+    });
+
+    test('should not show warning when sniff is disabled', () => {
+        const config = {
+            ElasticsearchSettings: {
+                ConnectionURL: 'test',
+                Backend: '',
+                SkipTLSVerification: false,
+                CA: '',
+                ClientCert: '',
+                ClientKey: '',
+                Username: '',
+                Password: '',
+                Sniff: false,
+                EnableIndexing: true,
+                EnableSearching: false,
+                EnableAutocomplete: false,
+                EnableSearchPublicChannelsWithoutMembership: false,
+                IgnoredPurgeIndexes: '',
+            },
+        };
+        renderWithContext(
+            <ElasticSearchSettings
+                config={config as AdminConfig}
+                isDisabled={false}
+            />,
+        );
+        expect(screen.queryByText('Do not enable cluster sniffing with cloud-hosted providers such as Elastic Cloud or Amazon OpenSearch Service.')).not.toBeInTheDocument();
+    });
+
     test('should maintain save disable until is tested', async () => {
         const config = {
             ElasticsearchSettings: {

--- a/webapp/channels/src/components/admin_console/elasticsearch_settings.tsx
+++ b/webapp/channels/src/components/admin_console/elasticsearch_settings.tsx
@@ -11,6 +11,7 @@ import type {Job, JobType} from '@mattermost/types/jobs';
 import {elasticsearchPurgeIndexes, elasticsearchTest, rebuildChannelsIndex} from 'actions/admin_actions.jsx';
 
 import ExternalLink from 'components/external_link';
+import WarningIcon from 'components/widgets/icons/fa_warning_icon';
 
 import {DocLinks, JobStatuses, JobTypes} from 'utils/constants';
 
@@ -61,6 +62,7 @@ export const messages = defineMessages({
     passwordDescription: {id: 'admin.elasticsearch.passwordDescription', defaultMessage: '(Optional) The password to authenticate to the Elasticsearch server.'},
     sniffTitle: {id: 'admin.elasticsearch.sniffTitle', defaultMessage: 'Enable Cluster Sniffing:'},
     sniffDescription: {id: 'admin.elasticsearch.sniffDescription', defaultMessage: 'When true, sniffing finds and connects to all data nodes in your cluster automatically.'},
+    sniffWarning: {id: 'admin.elasticsearch.sniffWarning', defaultMessage: 'Do not enable cluster sniffing with cloud-hosted providers such as Elastic Cloud or Amazon OpenSearch Service.'},
     testHelpText: {id: 'admin.elasticsearch.testHelpText', defaultMessage: 'Tests if the Mattermost server can connect to the Elasticsearch server specified. Testing the connection only saves the configuration if the test is successful. A successful test will also re-initialize the client if you have started Elasticsearch after starting Mattermost. But this will not restart the workers. To do that, please toggle "Enable Elasticsearch Indexing".'},
     elasticsearch_test_button: {id: 'admin.elasticsearch.elasticsearch_test_button', defaultMessage: 'Test Connection'},
     bulkIndexingTitle: {id: 'admin.elasticsearch.bulkIndexingTitle', defaultMessage: 'Bulk Indexing:'},
@@ -89,6 +91,7 @@ export const searchableStrings: Array<string|MessageDescriptor|[MessageDescripto
     messages.passwordDescription,
     messages.sniffTitle,
     messages.sniffDescription,
+    messages.sniffWarning,
     messages.testHelpText,
     messages.elasticsearch_test_button,
     messages.bulkIndexingTitle,
@@ -407,7 +410,17 @@ export default class ElasticsearchSettings extends OLDAdminSettings<Props, State
                 <BooleanSetting
                     id='sniff'
                     label={<FormattedMessage {...messages.sniffTitle}/>}
-                    helpText={<FormattedMessage {...messages.sniffDescription}/>}
+                    helpText={
+                        <>
+                            <FormattedMessage {...messages.sniffDescription}/>
+                            {this.state.sniff && (
+                                <div className='alert alert-warning'>
+                                    <WarningIcon/>
+                                    <FormattedMessage {...messages.sniffWarning}/>
+                                </div>
+                            )}
+                        </>
+                    }
                     value={this.state.sniff}
                     disabled={this.props.isDisabled || !this.state.enableIndexing}
                     onChange={this.handleSettingChanged}

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -984,6 +984,7 @@
   "admin.elasticsearch.skipTLSVerificationTitle": "Skip TLS Verification:",
   "admin.elasticsearch.sniffDescription": "When true, sniffing finds and connects to all data nodes in your cluster automatically.",
   "admin.elasticsearch.sniffTitle": "Enable Cluster Sniffing:",
+  "admin.elasticsearch.sniffWarning": "Do not enable cluster sniffing with cloud-hosted providers such as Elastic Cloud or Amazon OpenSearch Service.",
   "admin.elasticsearch.testConfigSuccess": "Test successful. Configuration saved.",
   "admin.elasticsearch.testHelpText": "Tests if the Mattermost server can connect to the Elasticsearch server specified. Testing the connection only saves the configuration if the test is successful. A successful test will also re-initialize the client if you have started Elasticsearch after starting Mattermost. But this will not restart the workers. To do that, please toggle \"Enable Elasticsearch Indexing\".",
   "admin.elasticsearch.title": "Elasticsearch",


### PR DESCRIPTION
- Add Playwright E2E tests for demo plugin server-side slash commands (#36146)
- [MM-67880] Add /mobile-logs slash command (#35658)
- chore: Update NOTICE.txt file with updated dependencies (#36184)
- MM-68367: Warn in System Console when cluster sniffing is enabled (#36174)
- fix(tests): re-enable 10 flaky tests across 12 JIRA tickets (#36159)
- ci: add yamllint workflow to detect duplicate YAML keys (#36010)
- docs: upstream sync 2026-04-20 마무리 (picked 4, adapted 2, skipped 1)