### PR TITLE
upstream sync 2026-04-21 (picked 13)

### DIFF
--- a/.github/workflows/server-ci-nightly-race.yml
+++ b/.github/workflows/server-ci-nightly-race.yml
@@ -1,0 +1,52 @@
+# Nightly race detector run.
+#
+# Runs all server tests with Go's -race detector enabled to catch
+# data races. Runs sequentially (fullyparallel: false) on a 2-core
+# runner to minimize resource usage — race detection adds significant
+# overhead that makes parallel execution impractical.
+#
+# Schedule: Nightly at ~2am ET (6am UTC)
+#
+# Previously, -race was implicitly bundled with the binary params job
+# via the fullyparallel=false → RACE_MODE coupling. This decouples
+# the two concerns: binary params tests the Postgres driver encoding;
+# this workflow tests for data races.
+name: Server CI Nightly Race
+on:
+  schedule:
+    - cron: "0 6 * * *" # Daily 6am UTC (~2am ET)
+  workflow_dispatch: # Manual trigger for on-demand race detection
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    name: Compute Go Version
+    runs-on: ubuntu-22.04
+    outputs:
+      version: ${{ steps.calculate.outputs.GO_VERSION }}
+    steps:
+      - name: Checkout mattermost project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Calculate version
+        id: calculate
+        working-directory: server/
+        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
+
+  test-race:
+    name: Race Detector
+    needs: go
+    uses: ./.github/workflows/server-test-template.yml
+    secrets: inherit
+    with:
+      name: Race Detector
+      datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
+      drivername: postgres
+      logsartifact: race-detector-server-test-logs
+      go-version: ${{ needs.go.outputs.version }}
+      fips-enabled: false
+      fullyparallel: false
+      race-enabled: true
+      runner: ubuntu-22.04
+      allow-failure: true

--- a/.github/workflows/server-ci-nightly-race.yml
+++ b/.github/workflows/server-ci-nightly-race.yml
@@ -13,8 +13,11 @@
 # this workflow tests for data races.
 name: Server CI Nightly Race
 on:
-  schedule:
-    - cron: "0 6 * * *" # Daily 6am UTC (~2am ET)
+  # okrbest: 스케줄 실행 비활성화. 이 워크플로가 요구하는 ubuntu-latest-8-cores
+  # 러너 라벨이 우리 저장소에 없어 잡이 러너 대기로 멈춘다. Server CI를 되살릴 때
+  # 러너 라벨과 함께 다시 켠다. 수동 실행은 workflow_dispatch로 가능.
+  # schedule:
+  #   - cron: "0 6 * * *" # Daily 6am UTC (~2am ET)
   workflow_dispatch: # Manual trigger for on-demand race detection
 
 permissions:

--- a/.github/workflows/server-ci-weekly.yml
+++ b/.github/workflows/server-ci-weekly.yml
@@ -1,0 +1,75 @@
+# Weekly Server CI jobs that don't need to run on every push/PR.
+# These are important for compliance and compatibility but have low
+# regression rates, so running them weekly saves significant 8-core
+# runner capacity (9 fewer concurrent 8-core jobs per master push).
+#
+# Schedule: Monday ~1am ET (5am UTC)
+#
+# Jobs moved here from server-ci.yml:
+# - Postgres with binary parameters (1x 8-core)
+# - Postgres FIPS unsharded (1x 8-core) — sharded runs stay in server-ci.yml for PR iteration
+# - mmctl FIPS tests (1x 8-core)
+name: Server CI Weekly
+on:
+  schedule:
+    - cron: "0 5 * * 1" # Monday 5am UTC (~1am ET)
+  push:
+    branches:
+      - 'release-*'
+  workflow_dispatch: # Allow manual trigger for urgent FIPS/binary verification
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    name: Compute Go Version
+    runs-on: ubuntu-22.04
+    outputs:
+      version: ${{ steps.calculate.outputs.GO_VERSION }}
+    steps:
+      - name: Checkout mattermost project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Calculate version
+        id: calculate
+        working-directory: server/
+        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
+
+  test-postgres-binary:
+    name: Postgres with binary parameters
+    needs: go
+    uses: ./.github/workflows/server-test-template.yml
+    secrets: inherit
+    with:
+      name: Postgres with binary parameters
+      datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10&binary_parameters=yes
+      drivername: postgres
+      logsartifact: postgres-binary-server-test-logs
+      go-version: ${{ needs.go.outputs.version }}
+      fips-enabled: false
+
+  test-postgres-normal-fips:
+    name: Postgres FIPS
+    needs: go
+    uses: ./.github/workflows/server-test-template.yml
+    secrets: inherit
+    with:
+      name: Postgres FIPS
+      datasource: postgres://mmuser:mostest-fips-test@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
+      drivername: postgres
+      logsartifact: postgres-server-fips-test-logs
+      go-version: ${{ needs.go.outputs.version }}
+      fips-enabled: true
+
+  test-mmctl-fips:
+    name: Run mmctl tests (FIPS)
+    needs: go
+    uses: ./.github/workflows/mmctl-test-template.yml
+    secrets: inherit
+    with:
+      name: mmctl
+      datasource: postgres://mmuser:mostest-fips-test@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
+      drivername: postgres
+      logsartifact: mmctl-fips-test-logs
+      go-version: ${{ needs.go.outputs.version }}
+      fips-enabled: true

--- a/.github/workflows/server-ci-weekly.yml
+++ b/.github/workflows/server-ci-weekly.yml
@@ -11,8 +11,11 @@
 # - mmctl FIPS tests (1x 8-core)
 name: Server CI Weekly
 on:
-  schedule:
-    - cron: "0 5 * * 1" # Monday 5am UTC (~1am ET)
+  # okrbest: 스케줄 실행 비활성화. 이 워크플로가 요구하는 ubuntu-latest-8-cores
+  # 러너 라벨이 우리 저장소에 없어 잡이 러너 대기로 멈춘다. Server CI를 되살릴 때
+  # 러너 라벨과 함께 다시 켠다. 수동 실행은 workflow_dispatch로 가능.
+  # schedule:
+  #   - cron: "0 5 * * 1" # Monday 5am UTC (~1am ET)
   push:
     branches:
       - 'release-*'

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -195,20 +195,10 @@ jobs:
           echo "Making sure docs are updated"
           make mmctl-docs
           if [[ -n $(git status --porcelain) ]]; then echo "Please update the mmctl docs using make mmctl-docs"; exit 1; fi
-  test-postgres-binary:
-    if: github.event_name == 'push' # Only run postgres binary tests on master/release pushes: odds are low this regresses, so save the cycles for pull requests.
-    name: Postgres with binary parameters
-    needs: go
-    uses: ./.github/workflows/server-test-template.yml
-    secrets: inherit
-    with:
-      name: Postgres with binary parameters
-      datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10&binary_parameters=yes
-      drivername: postgres
-      logsartifact: postgres-binary-server-test-logs
-      go-version: ${{ needs.go.outputs.version }}
-      fips-enabled: false
-      fullyparallel: false
+  # NOTE: Postgres with binary parameters has been moved to server-ci-weekly.yml
+  # (runs Monday 1am EST / 5am UTC). Low regression risk doesn't justify
+  # consuming 8-core runners on every push.
+
   # -- Sharded into 4 parallel runners for ~88% wall-time improvement --
   test-postgres-normal:
     name: Postgres (shard ${{ matrix.shard }})
@@ -255,11 +245,11 @@ jobs:
       elasticsearch-version: "8.9.0"
       test-target: "test-server-elasticsearch"
 
+  # FIPS tests: run on PRs when go.mod changed or branch name contains "fips".
+  # Sharded for fast iteration. Weekly workflow provides regular full coverage.
   test-postgres-normal-fips:
-    # Always run on pushes to master/release branches.
-    # For PRs, run when the branch name contains "fips" or any go.mod was changed.
-    if: github.event_name == 'push' || contains(github.head_ref, 'fips') || needs.go.outputs.gomod-changed == 'true'
-    name: Postgres FIPS (shard ${{ matrix.shard }})
+    if: contains(github.head_ref, 'fips') || needs.go.outputs.gomod-changed == 'true'
+    name: "Postgres FIPS (shard ${{ matrix.shard }})"
     needs: go
     strategy:
       fail-fast: false
@@ -305,6 +295,7 @@ jobs:
       enablecoverage: true
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: false
+      # runner: ubuntu-22.04 # Coverage is non-blocking (allow-failure), no need for 8-core
       shard-index: ${{ matrix.shard }}
       shard-total: 4
   test-mmctl:
@@ -320,9 +311,8 @@ jobs:
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: false
   test-mmctl-fips:
+    if: contains(github.head_ref, 'fips') || needs.go.outputs.gomod-changed == 'true'
     name: Run mmctl tests (FIPS)
-    # Skip FIPS testing for forks, which won't have docker login credentials.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     needs: go
     uses: ./.github/workflows/mmctl-test-template.yml
     secrets: inherit
@@ -330,9 +320,10 @@ jobs:
       name: mmctl
       datasource: postgres://mmuser:mostest-fips-test@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
-      logsartifact: mmctl-test-logs
+      logsartifact: mmctl-fips-test-logs
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: true
+
   build-mattermost-server:
     name: Build mattermost server app
     needs: go

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -50,6 +50,16 @@ on:
         required: false
         type: number
         default: 1
+      runner:
+        description: "GitHub-hosted runner label (default: ubuntu-latest-8-cores)"
+        required: false
+        type: string
+        default: "ubuntu-latest-8-cores"
+      race-enabled:
+        description: "Run tests with Go race detector (-race)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -58,7 +68,7 @@ permissions:
 jobs:
   test:
     name: ${{ inputs.name }}
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ${{ inputs.runner }}
     continue-on-error: ${{ inputs.allow-failure }} # Used to avoid blocking PRs in case of flakiness
     env:
       COMPOSE_PROJECT_NAME: ghactions
@@ -175,7 +185,7 @@ jobs:
         env:
           BUILD_IMAGE: ${{ steps.build.outputs.BUILD_IMAGE }}
         run: |
-          if [[ ${{ github.ref_name }} == 'master' && ${{ inputs.fullyparallel }} != true && "${{ inputs.test-target }}" == "test-server" ]]; then
+          if [[ "${{ inputs.race-enabled }}" == "true" ]]; then
             export RACE_MODE="-race"
           fi
 

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -62,7 +62,6 @@ on:
         default: false
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:

--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,27 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-19 12:00
+- 갱신일: 2026-08-19 16:07
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 792개
+- 남은 커밋: 781개
 
-**마지막 반영 커밋:** `9c8191c3` | [ci: add yamllint workflow to detect duplicate YAML keys (#36010)](https://github.com/mattermost/mattermost/commit/9c8191c3b8a8a41352d21ca69be5b05a5f1de800) | 2026-04-20
+**마지막 반영 커밋:** `2d7a71b0` | [ci: fix startup_failure in nightly race and weekly workflows (#36198)](https://github.com/mattermost/mattermost/commit/2d7a71b01810112269a22329042534fe739fee12) | 2026-04-21
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| c8f0a314 | [ci: move FIPS and binary params tests to weekly schedule (#36036)](https://github.com/mattermost/mattermost/commit/c8f0a31425a01cb7b95cc9ff1ef08714f88ffe52) | 2026-04-20 |
-| 39d25d94 | [MM-68259 Fixing text and emojis being clipped in channel banners (#36076)](https://github.com/mattermost/mattermost/commit/39d25d94ddd766ac9445eba0d2afdaffe74cc768) | 2026-04-21 |
-| 9aae84bc | [\[MM-67981\] Add process ID (PID) to support packet diagnostics (#35832)](https://github.com/mattermost/mattermost/commit/9aae84bc3f23be506f9a3b93f221290841555de6) | 2026-04-21 |
-| 52fa113d | [\[MM-67977\] Add Go runtime version to support packet diagnostics (#35833)](https://github.com/mattermost/mattermost/commit/52fa113dfc58af3c002ad5f3f5a743d2ebba328d) | 2026-04-21 |
-| bfaff4da | [Add server/AGENTS.md (#35903)](https://github.com/mattermost/mattermost/commit/bfaff4da7e8d31188b2c34563b908c5472784dd0) | 2026-04-21 |
-| 848ceb3c | [\[MM-67978\] Add open file descriptor count to support packet diagnostics (#35834)](https://github.com/mattermost/mattermost/commit/848ceb3c732dc04cf187a1beb43aeca069d5b79d) | 2026-04-21 |
-| 58052db8 | [\[MM-67976\] Add server uptime to support packet (#35838)](https://github.com/mattermost/mattermost/commit/58052db8e3ee75f7bb3a0dffca0daa908edfa551) | 2026-04-21 |
-| 0431659c | [\[MM-68237\] Unshare channels when remote is removed (#35997)](https://github.com/mattermost/mattermost/commit/0431659c93605ed777c665cce1f04570fc3bc08a) | 2026-04-21 |
-| 66502c2e | [MM-68047: Hide update status button in RHS post header (#36120)](https://github.com/mattermost/mattermost/commit/66502c2e677096a6fd1649528d6526b4cd931e2f) | 2026-04-21 |
-| d3ecc090 | [MM-67782: Fetch group members on popover open to fix empty member list (#36122)](https://github.com/mattermost/mattermost/commit/d3ecc09064671f50d5a192cb473ca3c001f200a1) | 2026-04-21 |
-| 67a645d2 | [MM-68378: Fix silent bulk failures in OpenSearch/Elasticsearch indexers (#36189)](https://github.com/mattermost/mattermost/commit/67a645d2c6cbe9a2841d3731c7eb13a321739abf) | 2026-04-21 |
-| ef80288c | [MM-68160: Fix post reminder confirmation not appearing for replies in RHS (#36124)](https://github.com/mattermost/mattermost/commit/ef80288cacd97c85ecb289d1112fd22a6976632e) | 2026-04-21 |
-| 2d7a71b0 | [ci: fix startup_failure in nightly race and weekly workflows (#36198)](https://github.com/mattermost/mattermost/commit/2d7a71b01810112269a22329042534fe739fee12) | 2026-04-21 |
 | 3fa87760 | [\[MM-68100\] Implement Linked Properties for the Property System (#35808)](https://github.com/mattermost/mattermost/commit/3fa8776095087a9c928dee5d1b21d9aba5bcc0c3) | 2026-04-21 |
 | 29bab218 | [e2e: adjust some pipeline settings (#36178)](https://github.com/mattermost/mattermost/commit/29bab2184db42103dd30c0827059ef3f854847d4) | 2026-04-21 |
 | 50b8e108 | [Quick fixes for docs label automation (#36185)](https://github.com/mattermost/mattermost/commit/50b8e1086fa2efd07cd50c475a53165061473667) | 2026-04-22 |
@@ -803,6 +790,8 @@
 | 0bff02c8 | [Graduate user typing settings to Site Configuration > Posts (#38023)](https://github.com/mattermost/mattermost/commit/0bff02c8148abbea87f260c28839ae2ab4da3aee) | 2026-08-18 |
 | 925a09a5 | [Remove dead Email login button color settings (#38021)](https://github.com/mattermost/mattermost/commit/925a09a5f22180b3250c2bd0c2a006cfea65aee5) | 2026-08-18 |
 | ede2edab | [Enforce snake_case for mlog field keys (#37998)](https://github.com/mattermost/mattermost/commit/ede2edab4dabc7d5777f02ec3135197a659615ca) | 2026-08-18 |
+| 480c1c5e | [\[M-70285\] Fix plugin settings section handling (#38003)](https://github.com/mattermost/mattermost/commit/480c1c5ed1688a9502d98f74c84675034f2f1ad9) | 2026-08-19 |
+| 6941f569 | [\[MM-70252\] Return 400 for malformed date filters in logs query API (#37970)](https://github.com/mattermost/mattermost/commit/6941f569018775c17062ab1118c6df84386a28ad) | 2026-08-19 |
 
 ## 제외된 커밋
 

--- a/e2e-tests/playwright/lib/src/constant.ts
+++ b/e2e-tests/playwright/lib/src/constant.ts
@@ -5,6 +5,17 @@ export const appsPluginId = 'com.mattermost.apps';
 export const callsPluginId = 'com.mattermost.calls';
 export const playbooksPluginId = 'playbooks';
 
+// License SKU short names — mirrored from webapp/channels/src/utils/constants.tsx LicenseSkus
+export const LicenseSkus = {
+    E10: 'E10',
+    E20: 'E20',
+    Starter: 'starter',
+    Professional: 'professional',
+    Enterprise: 'enterprise',
+    EnterpriseAdvanced: 'advanced',
+    Entry: 'entry',
+} as const;
+
 // Remote users hour limit taken from webapp/channels/src/utils/constants.ts
 export const REMOTE_USERS_HOUR_LIMIT_END_OF_THE_DAY = 22;
 export const REMOTE_USERS_HOUR_LIMIT_BEGINNING_OF_THE_DAY = 6;

--- a/e2e-tests/playwright/lib/src/index.ts
+++ b/e2e-tests/playwright/lib/src/index.ts
@@ -8,6 +8,7 @@ export {TestBrowser} from './browser_context';
 export {getBlobFromAsset, getFileFromAsset} from './file';
 export {decomposeKorean, koreanTestPhrase, typeHangulCharacterWithIme, typeHangulWithIme} from './ime';
 export {duration, getRandomId, wait, newTestPassword} from './util';
+export {LicenseSkus, appsPluginId, callsPluginId, playbooksPluginId} from './constant';
 
 export {
     ChannelsPage,

--- a/e2e-tests/playwright/lib/src/ui/components/channels/center_view.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/center_view.ts
@@ -153,6 +153,12 @@ export default class ChannelsCenterView {
         await expect(this.channelBanner).not.toBeVisible();
     }
 
+    async assertChannelBannerTextNotClipped() {
+        const bannerText = this.channelBanner.getByTestId('channel_banner_text');
+        await expect(bannerText).toBeVisible();
+        await this.assertElementContainedInBanner(bannerText);
+    }
+
     async assertChannelBannerHasBoldText(text: string) {
         const boldText = await this.channelBanner.locator('strong');
         expect(boldText).toBeVisible();
@@ -175,5 +181,87 @@ export default class ChannelsCenterView {
 
         const actualText = await strikethroughText.textContent();
         expect(actualText).toBe(text);
+    }
+
+    async assertChannelBannerHasEmoticon() {
+        const emoji = this.channelBanner.locator('.emoticon:not(.emoticon--unicode)').first();
+        await expect(emoji).toBeVisible();
+
+        const backgroundImage = await emoji.evaluate((el) => {
+            return window.getComputedStyle(el).getPropertyValue('background-image');
+        });
+
+        expect(backgroundImage).not.toBe('none');
+    }
+
+    async assertChannelBannerImageEmojiSize(expectedSizePx: number) {
+        const emoji = this.channelBanner.locator('.emoticon:not(.emoticon--unicode)').first();
+        await expect(emoji).toBeVisible();
+
+        const {width, height} = await emoji.evaluate((el) => {
+            const styles = window.getComputedStyle(el);
+            return {
+                width: styles.getPropertyValue('width'),
+                height: styles.getPropertyValue('height'),
+            };
+        });
+
+        expect(width).toBe(`${expectedSizePx}px`);
+        expect(height).toBe(`${expectedSizePx}px`);
+
+        await this.assertElementContainedInBanner(emoji);
+    }
+
+    async assertChannelBannerUnicodeEmojiSize(expectedSizePx: number) {
+        const emoji = this.channelBanner.locator('.emoticon--unicode').first();
+        await expect(emoji).toBeVisible();
+
+        const fontSize = await emoji.evaluate((el) => {
+            return window.getComputedStyle(el).getPropertyValue('font-size');
+        });
+
+        expect(fontSize).toBe(`${expectedSizePx}px`);
+
+        await this.assertElementContainedInBanner(emoji);
+    }
+
+    /**
+     * Asserts that the given element's bounding box lies fully within the channel
+     * banner's content area (banner bounds minus computed padding).
+     *
+     * Uses getBoundingClientRect() coordinates, which are NOT clipped by parent
+     * overflow — so if an element protrudes into or beyond the padding zone it will
+     * be visually clipped by `overflow: hidden` on the text container, and this
+     * assertion will catch that.
+     *
+     * A small epsilon is applied to each boundary to avoid flaky failures caused
+     * by sub-pixel rounding differences in layout engines.
+     */
+    private async assertElementContainedInBanner(element: Locator) {
+        const EPSILON = 0.5;
+
+        const bannerBox = await this.channelBanner.boundingBox();
+        const elementBox = await element.boundingBox();
+
+        expect(bannerBox).not.toBeNull();
+        expect(elementBox).not.toBeNull();
+
+        const banner = bannerBox!;
+        const el = elementBox!;
+
+        const {paddingTop, paddingBottom, paddingLeft, paddingRight} = await this.channelBanner.evaluate((node) => {
+            const styles = window.getComputedStyle(node);
+            return {
+                paddingTop: parseFloat(styles.paddingTop),
+                paddingBottom: parseFloat(styles.paddingBottom),
+                paddingLeft: parseFloat(styles.paddingLeft),
+                paddingRight: parseFloat(styles.paddingRight),
+            };
+        });
+
+        expect(el.y).toBeGreaterThanOrEqual(banner.y + paddingTop - EPSILON);
+        expect(el.y + el.height).toBeLessThanOrEqual(banner.y + banner.height - paddingBottom + EPSILON);
+        expect(el.x).toBeGreaterThanOrEqual(banner.x + paddingLeft - EPSILON);
+        expect(el.x + el.width).toBeLessThanOrEqual(banner.x + banner.width - paddingRight + EPSILON);
     }
 }

--- a/e2e-tests/playwright/specs/functional/channels/channel_banner/channel_banner.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/channel_banner/channel_banner.spec.ts
@@ -3,6 +3,8 @@
 
 import {test} from '@mattermost/playwright-lib';
 
+const EMOJI_SIZE = 16;
+
 test('Should show channel banner when configured', async ({pw}) => {
     const {adminUser, adminClient} = await pw.initSetup();
     const license = await adminClient.getClientLicenseOld();
@@ -89,14 +91,93 @@ test('Should not show channel banner in thread view when disabled', async ({pw})
     await channelsPage.toBeVisible();
 
     await channelsPage.newChannel(pw.random.id(), 'O');
+    await channelsPage.centerView.toBeVisible();
 
-    // Post a message and open the thread
-    await channelsPage.centerView.postMessage('Message without banner');
+    // Focus and type character-by-character to avoid React clearing a programmatic fill()
+    await channelsPage.centerView.postCreate.input.click();
+    await channelsPage.centerView.postCreate.input.pressSequentially('Message without banner');
+    await channelsPage.centerView.postCreate.sendMessage();
     const post = await channelsPage.centerView.getLastPost();
     await post.reply();
 
     await channelsPage.sidebarRight.toBeVisible();
     await channelsPage.sidebarRight.assertChannelBannerNotVisible();
+});
+
+test('Should render image emoticons without clipping', async ({pw}) => {
+    const {adminUser, adminClient} = await pw.initSetup();
+    const license = await adminClient.getClientLicenseOld();
+    test.skip(license.SkuShortName !== 'advanced', 'Skipping test - server does not have Enterprise Advanced license');
+
+    const {channelsPage} = await pw.testBrowser.login(adminUser);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    await channelsPage.newChannel(pw.random.id(), 'O');
+
+    const channelSettingsModal = await channelsPage.openChannelSettings();
+    const configurationTab = await channelSettingsModal.openConfigurationTab();
+
+    await configurationTab.enableChannelBanner();
+    await configurationTab.setChannelBannerTextColor('77DD88');
+    // :dog: is in Mattermost's emoji map → renders as .emoticon (background-image).
+    // Unicode emojis that are also in the map (e.g. 🐶) follow the same path.
+    await configurationTab.setChannelBannerText('Hello :dog:');
+    await configurationTab.save();
+    await channelSettingsModal.close();
+
+    await channelsPage.centerView.assertChannelBannerImageEmojiSize(EMOJI_SIZE);
+});
+
+test('Should render unsupported unicode emoji without clipping', async ({pw}) => {
+    const {adminUser, adminClient} = await pw.initSetup();
+    const license = await adminClient.getClientLicenseOld();
+    test.skip(license.SkuShortName !== 'advanced', 'Skipping test - server does not have Enterprise Advanced license');
+
+    const {channelsPage} = await pw.testBrowser.login(adminUser);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    await channelsPage.newChannel(pw.random.id(), 'O');
+
+    const channelSettingsModal = await channelsPage.openChannelSettings();
+    const configurationTab = await channelSettingsModal.openConfigurationTab();
+
+    await configurationTab.enableChannelBanner();
+    await configurationTab.setChannelBannerTextColor('77DD88');
+    // 🫠 (U+1FAE0, Unicode 14.0) is above Mattermost's emoji map ceiling (1FAD6)
+    // so it falls through to the .emoticon--unicode span path.
+    await configurationTab.setChannelBannerText('Hello 🫠');
+    await configurationTab.save();
+    await channelSettingsModal.close();
+
+    await channelsPage.centerView.assertChannelBannerUnicodeEmojiSize(EMOJI_SIZE);
+});
+
+test('Should render text with descenders without clipping', async ({pw}) => {
+    const {adminUser, adminClient} = await pw.initSetup();
+    const license = await adminClient.getClientLicenseOld();
+    test.skip(license.SkuShortName !== 'advanced', 'Skipping test - server does not have Enterprise Advanced license');
+
+    const {channelsPage} = await pw.testBrowser.login(adminUser);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    await channelsPage.newChannel(pw.random.id(), 'O');
+
+    const channelSettingsModal = await channelsPage.openChannelSettings();
+    const configurationTab = await channelSettingsModal.openConfigurationTab();
+
+    await configurationTab.enableChannelBanner();
+    await configurationTab.setChannelBannerTextColor('77DD88');
+    // Characters with descenders (parts that extend below the baseline).
+    // Previously clipped because line-height equalled font-size (13px), leaving
+    // no room below the baseline for g, j, p, q, y etc.
+    await configurationTab.setChannelBannerText('YyGgQqJj');
+    await configurationTab.save();
+    await channelSettingsModal.close();
+
+    await channelsPage.centerView.assertChannelBannerTextNotClipped();
 });
 
 test('Should render markdown', async ({pw}) => {

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+Never run `go mod tidy` directly. Always run `make modules-tidy` instead — it excludes private enterprise imports that would otherwise break the tidy.
+
+After editing `i18n/en.json`, always run `make i18n-extract` — it regenerates the file with strings in the required order.

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -5329,6 +5329,32 @@ func TestGetPostStripActionIntegrations(t *testing.T) {
 	require.Nil(t, action["integration"])
 }
 
+func waitForPostReminderEphemeral(t *testing.T, userWSClient *model.WebSocketClient, timeout time.Duration) *model.Post {
+	t.Helper()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for {
+		select {
+		case ev := <-userWSClient.EventChannel:
+			if ev.EventType() != model.WebsocketEventEphemeralMessage {
+				continue
+			}
+			data := ev.GetData()
+			postJSON, ok := data["post"].(string)
+			require.True(t, ok)
+			var parsedPost model.Post
+			err := json.Unmarshal([]byte(postJSON), &parsedPost)
+			require.NoError(t, err)
+			if parsedPost.GetProp("type") != model.PostTypeReminder {
+				continue
+			}
+			return &parsedPost
+		case <-timer.C:
+			require.Fail(t, "timed out waiting for post reminder ephemeral websocket event")
+			return nil
+		}
+	}
+}
 func TestPostReminder(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 
@@ -5352,39 +5378,53 @@ func TestPostReminder(t *testing.T) {
 	user, _, err := client.GetUser(context.Background(), post.UserId, "")
 	require.NoError(t, err)
 
-	var caught bool
-	func() {
-		for {
-			select {
-			case ev := <-userWSClient.EventChannel:
-				if ev.EventType() == model.WebsocketEventEphemeralMessage {
-					caught = true
-					data := ev.GetData()
+	parsedPost := waitForPostReminderEphemeral(t, userWSClient, 15*time.Second)
+	require.NotNil(t, parsedPost)
 
-					post, ok := data["post"].(string)
-					require.True(t, ok)
+	assert.Equal(t, model.PostTypeEphemeral, parsedPost.Type)
+	assert.Equal(t, th.BasicUser.Id, parsedPost.UserId)
+	assert.Equal(t, th.BasicPost.Id, parsedPost.RootId)
 
-					var parsedPost model.Post
-					err := json.Unmarshal([]byte(post), &parsedPost)
-					require.NoError(t, err)
+	require.Equal(t, float64(targetTime), parsedPost.GetProp("target_time").(float64))
+	require.Equal(t, th.BasicPost.Id, parsedPost.GetProp("post_id").(string))
+	require.Equal(t, user.Username, parsedPost.GetProp("username").(string))
+	require.Equal(t, th.BasicTeam.Name, parsedPost.GetProp("team_name").(string))
+}
 
-					assert.Equal(t, model.PostTypeEphemeral, parsedPost.Type)
-					assert.Equal(t, th.BasicUser.Id, parsedPost.UserId)
-					assert.Equal(t, th.BasicPost.Id, parsedPost.RootId)
+func TestPostReminderReplyEphemeralUsesThreadRoot(t *testing.T) {
+	th := Setup(t).InitBasic(t)
+	client := th.Client
+	userWSClient := th.CreateConnectedWebSocketClient(t)
 
-					require.Equal(t, float64(targetTime), parsedPost.GetProp("target_time").(float64))
-					require.Equal(t, th.BasicPost.Id, parsedPost.GetProp("post_id").(string))
-					require.Equal(t, user.Username, parsedPost.GetProp("username").(string))
-					require.Equal(t, th.BasicTeam.Name, parsedPost.GetProp("team_name").(string))
-					return
-				}
-			case <-time.After(15 * time.Second):
-				return
-			}
-		}
-	}()
+	replyPost := &model.Post{
+		ChannelId: th.BasicChannel.Id,
+		RootId:    th.BasicPost.Id,
+		Message:   "reply for reminder " + model.NewId(),
+	}
+	replyCreated, _, err := client.CreatePost(context.Background(), replyPost)
+	require.NoError(t, err)
 
-	require.Truef(t, caught, "User should have received %s event", model.WebsocketEventEphemeralMessage)
+	targetTime := time.Now().UTC().Unix() + 1
+	resp, err := client.SetPostReminder(context.Background(), &model.PostReminder{
+		TargetTime: targetTime,
+		PostId:     replyCreated.Id,
+		UserId:     th.BasicUser.Id,
+	})
+	require.NoError(t, err)
+	CheckOKStatus(t, resp)
+
+	user, _, err := client.GetUser(context.Background(), replyCreated.UserId, "")
+	require.NoError(t, err)
+
+	parsedPost := waitForPostReminderEphemeral(t, userWSClient, 15*time.Second)
+	require.NotNil(t, parsedPost)
+
+	assert.Equal(t, model.PostTypeEphemeral, parsedPost.Type)
+	assert.Equal(t, th.BasicPost.Id, parsedPost.RootId, "ephemeral should be threaded under the thread root so RHS/center thread views show the ack")
+	assert.Equal(t, replyCreated.Id, parsedPost.GetProp("post_id").(string))
+	require.Equal(t, float64(targetTime), parsedPost.GetProp("target_time").(float64))
+	require.Equal(t, user.Username, parsedPost.GetProp("username").(string))
+	require.Equal(t, th.BasicTeam.Name, parsedPost.GetProp("team_name").(string))
 }
 
 func TestPostGetInfo(t *testing.T) {

--- a/server/channels/api4/remote_cluster_test.go
+++ b/server/channels/api4/remote_cluster_test.go
@@ -762,3 +762,110 @@ func TestDeleteRemoteCluster(t *testing.T) {
 		require.NotZero(t, deletedRC.DeleteAt)
 	})
 }
+
+func TestDeleteRemoteClusterUnsharesOrphanSharedChannels(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := setupForSharedChannels(t).InitBasic(t)
+
+	rc, appErr := th.App.AddRemoteCluster(&model.RemoteCluster{
+		Name:        "orphan-unshare-remote",
+		DisplayName: "orphan-unshare-remote",
+		SiteURL:     "http://orphan-unshare.example.com",
+		Token:       model.NewId(),
+		CreatorId:   th.SystemAdminUser.Id,
+	})
+	require.Nil(t, appErr)
+
+	channel := th.CreateChannelWithClientAndTeam(t, th.SystemAdminClient, model.ChannelTypeOpen, th.BasicTeam.Id)
+	sc := &model.SharedChannel{
+		ChannelId: channel.Id,
+		TeamId:    channel.TeamId,
+		Home:      true,
+		ShareName: "orphan_unshare_chan",
+		CreatorId: th.SystemAdminUser.Id,
+		RemoteId:  model.NewId(),
+	}
+	_, err := th.App.ShareChannel(th.Context, sc)
+	require.NoError(t, err)
+
+	scr := &model.SharedChannelRemote{
+		ChannelId:         channel.Id,
+		CreatorId:         th.SystemAdminUser.Id,
+		RemoteId:          rc.RemoteId,
+		IsInviteConfirmed: true,
+	}
+	_, err = th.App.Srv().Store().SharedChannel().SaveRemote(scr)
+	require.NoError(t, err)
+
+	chShared, appErr := th.App.GetChannel(th.Context, channel.Id)
+	require.Nil(t, appErr)
+	require.True(t, chShared.IsShared())
+
+	deleted, appErr := th.App.DeleteRemoteCluster(rc.RemoteId)
+	require.Nil(t, appErr)
+	require.True(t, deleted)
+
+	_, err = th.App.Srv().Store().SharedChannel().Get(channel.Id)
+	require.Error(t, err)
+
+	chAfter, appErr := th.App.GetChannel(th.Context, channel.Id)
+	require.Nil(t, appErr)
+	require.False(t, chAfter.IsShared())
+}
+
+func TestDeleteRemoteClusterKeepsSharedChannelWhenOtherRemoteRemains(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := setupForSharedChannels(t).InitBasic(t)
+
+	rc1, appErr := th.App.AddRemoteCluster(&model.RemoteCluster{
+		Name:        "keep-shared-a",
+		DisplayName: "keep-shared-a",
+		SiteURL:     "http://keep-shared-a.example.com",
+		Token:       model.NewId(),
+		CreatorId:   th.SystemAdminUser.Id,
+	})
+	require.Nil(t, appErr)
+
+	rc2, appErr := th.App.AddRemoteCluster(&model.RemoteCluster{
+		Name:        "keep-shared-b",
+		DisplayName: "keep-shared-b",
+		SiteURL:     "http://keep-shared-b.example.com",
+		Token:       model.NewId(),
+		CreatorId:   th.SystemAdminUser.Id,
+	})
+	require.Nil(t, appErr)
+
+	channel := th.CreateChannelWithClientAndTeam(t, th.SystemAdminClient, model.ChannelTypeOpen, th.BasicTeam.Id)
+	sc := &model.SharedChannel{
+		ChannelId: channel.Id,
+		TeamId:    channel.TeamId,
+		Home:      true,
+		ShareName: "keep_shared_chan",
+		CreatorId: th.SystemAdminUser.Id,
+		RemoteId:  model.NewId(),
+	}
+	_, err := th.App.ShareChannel(th.Context, sc)
+	require.NoError(t, err)
+
+	for _, rc := range []*model.RemoteCluster{rc1, rc2} {
+		scr := &model.SharedChannelRemote{
+			ChannelId:         channel.Id,
+			CreatorId:         th.SystemAdminUser.Id,
+			RemoteId:          rc.RemoteId,
+			IsInviteConfirmed: true,
+		}
+		_, err = th.App.Srv().Store().SharedChannel().SaveRemote(scr)
+		require.NoError(t, err)
+	}
+
+	deleted, appErr := th.App.DeleteRemoteCluster(rc1.RemoteId)
+	require.Nil(t, appErr)
+	require.True(t, deleted)
+
+	_, err = th.App.Srv().Store().SharedChannel().Get(channel.Id)
+	require.NoError(t, err)
+
+	chAfter, appErr := th.App.GetChannel(th.Context, channel.Id)
+	require.Nil(t, appErr)
+	require.True(t, chAfter.IsShared())
+}

--- a/server/channels/app/platform/fd_darwin.go
+++ b/server/channels/app/platform/fd_darwin.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build darwin
+
+package platform
+
+import (
+	"os"
+	"syscall"
+)
+
+// getOpenFileDescriptors returns the number of open file descriptors for the current process.
+func getOpenFileDescriptors() (int64, error) {
+	entries, err := os.ReadDir("/dev/fd")
+	if err != nil {
+		return -1, err
+	}
+	// Subtract 1 because the ReadDir call itself opens a file descriptor that appears in the listing.
+	return max(int64(len(entries))-1, 0), nil
+}
+
+// getMaxFileDescriptors returns the soft file descriptor limit for the current process.
+func getMaxFileDescriptors() (int64, error) {
+	var rlimit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlimit); err != nil {
+		return -1, err
+	}
+	return int64(rlimit.Cur), nil
+}

--- a/server/channels/app/platform/fd_linux.go
+++ b/server/channels/app/platform/fd_linux.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build linux
+
+package platform
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"syscall"
+)
+
+// getOpenFileDescriptors returns the number of open file descriptors for the current process.
+func getOpenFileDescriptors() (int64, error) {
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		return -1, err
+	}
+	// Subtract 1 because the ReadDir call itself opens a file descriptor that appears in the listing.
+	return max(int64(len(entries))-1, 0), nil
+}
+
+// getMaxFileDescriptors returns the soft file descriptor limit for the current process.
+func getMaxFileDescriptors() (int64, error) {
+	var rlimit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlimit); err != nil {
+		return -1, err
+	}
+	if rlimit.Cur > math.MaxInt64 {
+		return -1, fmt.Errorf("rlimit.Cur %d overflows int64", rlimit.Cur)
+	}
+	return int64(rlimit.Cur), nil
+}

--- a/server/channels/app/platform/fd_other.go
+++ b/server/channels/app/platform/fd_other.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build !linux && !darwin
+
+package platform
+
+// getOpenFileDescriptors returns -1 on unsupported platforms.
+func getOpenFileDescriptors() (int64, error) {
+	return -1, nil
+}
+
+// getMaxFileDescriptors returns -1 on unsupported platforms.
+func getMaxFileDescriptors() (int64, error) {
+	return -1, nil
+}

--- a/server/channels/app/platform/fd_test.go
+++ b/server/channels/app/platform/fd_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package platform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetOpenFileDescriptors(t *testing.T) {
+	count, err := getOpenFileDescriptors()
+	require.NoError(t, err)
+	if count == -1 {
+		return
+	}
+	assert.Positive(t, count)
+}
+
+func TestGetMaxFileDescriptors(t *testing.T) {
+	maxFDs, err := getMaxFileDescriptors()
+	require.NoError(t, err)
+	// -1 means unsupported platform; otherwise should be positive
+	assert.True(t, maxFDs == -1 || maxFDs > 0, "maxFDs should be -1 (unsupported) or positive, got %d", maxFDs)
+}

--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -120,6 +120,8 @@ type PlatformService struct {
 
 	pdpService einterfaces.PolicyDecisionPointInterface
 
+	startTime time.Time
+
 	// installTypeOverride overrides MM_INSTALL_TYPE in support packet diagnostics.
 	installTypeOverride string
 
@@ -150,6 +152,7 @@ func New(sc ServiceConfig, options ...Option) (*PlatformService, error) {
 		Store:               sc.Store,
 		clusterIFace:        sc.Cluster,
 		hashSeed:            maphash.MakeSeed(),
+		startTime:           time.Now(),
 		goroutineExitSignal: make(chan struct{}, 1),
 		goroutineBuffered:   make(chan struct{}, runtime.NumCPU()),
 		WebSocketRouter: &WebSocketRouter{

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -107,6 +107,11 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 	if err != nil {
 		rErr = multierror.Append(errors.Wrap(err, "error while getting hostname"))
 	}
+	d.Server.ProcessID = os.Getpid()
+	d.Server.StartedAt = ps.startTime.UTC()
+	if hostUptimeSeconds, hostUptimeErr := getHostUptimeSeconds(); hostUptimeErr == nil {
+		d.Server.HostStartedAt = time.Now().Add(-time.Duration(hostUptimeSeconds) * time.Second).UTC()
+	}
 	d.Server.Version = model.CurrentVersion
 	d.Server.BuildHash = model.BuildHash
 	d.Server.GoVersion = runtime.Version()
@@ -126,7 +131,6 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 	if err != nil {
 		rErr = multierror.Append(rErr, errors.Wrap(err, "error while getting max file descriptor limit"))
 	}
-	d.Server.ProcessID = os.Getpid()
 
 	/* Config */
 	d.Config.Source = ps.DescribeConfig()

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -109,6 +109,7 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 	}
 	d.Server.Version = model.CurrentVersion
 	d.Server.BuildHash = model.BuildHash
+	d.Server.GoVersion = runtime.Version()
 	installationType := ps.installTypeOverride
 	if installationType == "" {
 		installationType = os.Getenv(envVarInstallType)

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -118,6 +118,14 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 		installationType = unknownDataPoint
 	}
 	d.Server.InstallationType = installationType
+	d.Server.OpenFileDescriptors, err = getOpenFileDescriptors()
+	if err != nil {
+		rErr = multierror.Append(rErr, errors.Wrap(err, "error while getting open file descriptor count"))
+	}
+	d.Server.MaxFileDescriptors, err = getMaxFileDescriptors()
+	if err != nil {
+		rErr = multierror.Append(rErr, errors.Wrap(err, "error while getting max file descriptor limit"))
+	}
 	d.Server.ProcessID = os.Getpid()
 
 	/* Config */

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -117,6 +117,7 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 		installationType = unknownDataPoint
 	}
 	d.Server.InstallationType = installationType
+	d.Server.ProcessID = os.Getpid()
 
 	/* Config */
 	d.Config.Source = ps.DescribeConfig()

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"os"
 	"path"
+	"runtime"
 	"testing"
 
 	"github.com/goccy/go-yaml"
@@ -213,6 +214,13 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		assert.True(t, d.Server.OpenFileDescriptors == -1 || d.Server.OpenFileDescriptors > 0, "OpenFileDescriptors should be -1 (unsupported) or positive, got %d", d.Server.OpenFileDescriptors)
 		assert.True(t, d.Server.MaxFileDescriptors == -1 || d.Server.MaxFileDescriptors > 0, "MaxFileDescriptors should be -1 (unsupported) or positive, got %d", d.Server.MaxFileDescriptors)
 		assert.Positive(t, d.Server.ProcessID)
+		assert.False(t, d.Server.StartedAt.IsZero())
+		if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+			assert.False(t, d.Server.HostStartedAt.IsZero())
+			assert.True(t, !d.Server.HostStartedAt.After(d.Server.StartedAt))
+		} else {
+			assert.True(t, d.Server.HostStartedAt.IsZero(), "HostStartedAt should be zero on unsupported platforms")
+		}
 
 		/* Config */
 		assert.Equal(t, "memory://", d.Config.Source)

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -210,6 +210,8 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		assert.Equal(t, "docker", d.Server.InstallationType)
 		assert.Positive(t, d.Server.CPUCores)
 		assert.Positive(t, d.Server.TotalMemoryMB)
+		assert.True(t, d.Server.OpenFileDescriptors == -1 || d.Server.OpenFileDescriptors > 0, "OpenFileDescriptors should be -1 (unsupported) or positive, got %d", d.Server.OpenFileDescriptors)
+		assert.True(t, d.Server.MaxFileDescriptors == -1 || d.Server.MaxFileDescriptors > 0, "MaxFileDescriptors should be -1 (unsupported) or positive, got %d", d.Server.MaxFileDescriptors)
 		assert.Positive(t, d.Server.ProcessID)
 
 		/* Config */

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -206,6 +206,7 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		assert.NotEmpty(t, d.Server.Hostname)
 		assert.Equal(t, model.CurrentVersion, d.Server.Version)
 		// BuildHash is not present in tests
+		assert.NotEmpty(t, d.Server.GoVersion)
 		assert.Equal(t, "docker", d.Server.InstallationType)
 		assert.Positive(t, d.Server.CPUCores)
 		assert.Positive(t, d.Server.TotalMemoryMB)

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -209,6 +209,7 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		assert.Equal(t, "docker", d.Server.InstallationType)
 		assert.Positive(t, d.Server.CPUCores)
 		assert.Positive(t, d.Server.TotalMemoryMB)
+		assert.Positive(t, d.Server.ProcessID)
 
 		/* Config */
 		assert.Equal(t, "memory://", d.Config.Source)

--- a/server/channels/app/platform/uptime_darwin.go
+++ b/server/channels/app/platform/uptime_darwin.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build darwin
+
+package platform
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// getHostUptimeSeconds uses kern.boottime sysctl to return the number of seconds
+// the host OS has been running.
+func getHostUptimeSeconds() (int64, error) {
+	tv, err := unix.SysctlTimeval("kern.boottime")
+	if err != nil {
+		return 0, fmt.Errorf("failed to get kern.boottime: %w", err)
+	}
+	bootTime := time.Unix(tv.Sec, int64(tv.Usec)*int64(time.Microsecond))
+	return int64(time.Since(bootTime).Seconds()), nil
+}

--- a/server/channels/app/platform/uptime_darwin_test.go
+++ b/server/channels/app/platform/uptime_darwin_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build darwin
+
+package platform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetHostUptimeSeconds(t *testing.T) {
+	t.Run("returns a positive value from kern.boottime", func(t *testing.T) {
+		seconds, err := getHostUptimeSeconds()
+		require.NoError(t, err)
+		assert.Positive(t, seconds)
+	})
+}

--- a/server/channels/app/platform/uptime_linux.go
+++ b/server/channels/app/platform/uptime_linux.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build linux
+
+package platform
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// getHostUptimeSeconds reads /proc/uptime and returns the number of seconds
+// the host OS has been running.
+func getHostUptimeSeconds() (int64, error) {
+	return parseUptimeFile("/proc/uptime")
+}
+
+// parseUptimeFile reads an uptime file in the /proc/uptime format and returns
+// the number of seconds as an int64.  It is a separate function to allow unit
+// tests to supply a synthetic file path.
+func parseUptimeFile(path string) (int64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read /proc/uptime: %w", err)
+	}
+
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return 0, fmt.Errorf("unexpected /proc/uptime format")
+	}
+
+	f, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse /proc/uptime value: %w", err)
+	}
+
+	return int64(f), nil
+}

--- a/server/channels/app/platform/uptime_linux_test.go
+++ b/server/channels/app/platform/uptime_linux_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build linux
+
+package platform
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetHostUptimeSeconds(t *testing.T) {
+	t.Run("returns a positive value from /proc/uptime", func(t *testing.T) {
+		seconds, err := getHostUptimeSeconds()
+		require.NoError(t, err)
+		assert.Positive(t, seconds)
+	})
+
+	t.Run("error on unreadable file", func(t *testing.T) {
+		missingPath := t.TempDir() + "/uptime"
+		_, err := parseUptimeFile(missingPath)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read")
+	})
+
+	t.Run("error on empty file", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "uptime")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		_, err = parseUptimeFile(f.Name())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected /proc/uptime format")
+	})
+
+	t.Run("error on non-numeric first field", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "uptime")
+		require.NoError(t, err)
+		_, err = f.WriteString("notanumber 0.00\n")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		_, err = parseUptimeFile(f.Name())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse /proc/uptime value")
+	})
+
+	t.Run("parses valid uptime correctly", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "uptime")
+		require.NoError(t, err)
+		_, err = f.WriteString("12345.67 890.12\n")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		seconds, err := parseUptimeFile(f.Name())
+		require.NoError(t, err)
+		assert.Equal(t, int64(12345), seconds)
+	})
+}

--- a/server/channels/app/platform/uptime_other.go
+++ b/server/channels/app/platform/uptime_other.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build !linux && !darwin
+
+package platform
+
+import "errors"
+
+// ErrHostUptimeUnsupportedPlatform is returned when host uptime detection is not supported on the current platform.
+var ErrHostUptimeUnsupportedPlatform = errors.New("host uptime detection not supported on this platform")
+
+// getHostUptimeSeconds returns an error on non-Linux platforms.
+func getHostUptimeSeconds() (int64, error) {
+	return 0, ErrHostUptimeUnsupportedPlatform
+}

--- a/server/channels/app/platform/uptime_other_test.go
+++ b/server/channels/app/platform/uptime_other_test.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build !linux && !darwin
+
+package platform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetHostUptimeSeconds(t *testing.T) {
+	seconds, err := getHostUptimeSeconds()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrHostUptimeUnsupportedPlatform)
+	assert.Equal(t, int64(0), seconds)
+}

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -2719,18 +2719,27 @@ func (a *App) populateEditHistoryFileMetadata(editHistoryPosts []*model.Post) *m
 }
 
 func (a *App) SetPostReminder(rctx request.CTX, postID, userID string, targetTime int64) *model.AppError {
-	// Store the reminder in the DB
+	remindedPost, postErr := a.GetSinglePost(rctx, postID, false)
+	if postErr != nil {
+		return postErr
+	}
+	// Ephemeral ack must use the thread root so CRT/RHS thread views (keyed by root id) show the confirmation.
+	ephemeralRootID := remindedPost.Id
+	if remindedPost.RootId != "" {
+		ephemeralRootID = remindedPost.RootId
+	}
+
+	metadata, err := a.Srv().Store().Post().GetPostReminderMetadata(postID)
+	if err != nil {
+		return model.NewAppError("SetPostReminder", model.NoTranslation, nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+
 	reminder := &model.PostReminder{
 		PostId:     postID,
 		UserId:     userID,
 		TargetTime: targetTime,
 	}
-	err := a.Srv().Store().Post().SetPostReminder(reminder)
-	if err != nil {
-		return model.NewAppError("SetPostReminder", model.NoTranslation, nil, "", http.StatusInternalServerError).Wrap(err)
-	}
-
-	metadata, err := a.Srv().Store().Post().GetPostReminderMetadata(postID)
+	err = a.Srv().Store().Post().SetPostReminder(reminder)
 	if err != nil {
 		return model.NewAppError("SetPostReminder", model.NoTranslation, nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -2751,7 +2760,7 @@ func (a *App) SetPostReminder(rctx request.CTX, postID, userID string, targetTim
 		Id:        model.NewId(),
 		CreateAt:  model.GetMillis(),
 		UserId:    userID,
-		RootId:    postID,
+		RootId:    ephemeralRootID,
 		ChannelId: metadata.ChannelID,
 		// It's okay to keep this non-translated. This is just a fallback.
 		// The webapp will parse the timestamp and show that in user's local timezone.

--- a/server/channels/app/remote_cluster.go
+++ b/server/channels/app/remote_cluster.go
@@ -144,10 +144,86 @@ func (a *App) UpdateRemoteCluster(rc *model.RemoteCluster) (*model.RemoteCluster
 	return rc, nil
 }
 
+const sharedChannelRemotesPageSize = 10000
+
+// sharedChannelIDsWithActiveRemotesForRemote returns channel IDs that have a non-deleted
+// SharedChannelRemote row for the given remote cluster.
+func (a *App) sharedChannelIDsWithActiveRemotesForRemote(remoteClusterID string) ([]string, error) {
+	ss := a.Srv().Store()
+	var channelIDs []string
+	offset := 0
+	for {
+		remotes, err := ss.SharedChannel().GetRemotes(offset, sharedChannelRemotesPageSize, model.SharedChannelRemoteFilterOpts{
+			RemoteId:           remoteClusterID,
+			IncludeUnconfirmed: true,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range remotes {
+			channelIDs = append(channelIDs, r.ChannelId)
+		}
+		if len(remotes) < sharedChannelRemotesPageSize {
+			break
+		}
+		offset += sharedChannelRemotesPageSize
+	}
+	return channelIDs, nil
+}
+
+// unshareSharedChannelsIfNoRemotes unshares each channel in channelIDs that has no remaining
+// SharedChannelRemote rows. The check matches sharedchannel.Service.unshareChannelIfNoActiveRemotes
+// (GetRemotes with IncludeUnconfirmed: true). If the shared channel sync service is not
+// running, the shared channel row is removed via the store instead of UnshareChannel.
+func (a *App) unshareSharedChannelsIfNoRemotes(channelIDs []string) {
+	ss := a.Srv().Store()
+	scService := a.Srv().GetSharedChannelSyncService()
+
+	for _, channelID := range channelIDs {
+		remotes, err := ss.SharedChannel().GetRemotes(0, 1, model.SharedChannelRemoteFilterOpts{ChannelId: channelID, IncludeUnconfirmed: true})
+		if err != nil {
+			a.Log().Error("Failed to check remaining shared channel remotes after remote cluster delete",
+				mlog.String("channel_id", channelID),
+				mlog.Err(err),
+			)
+			continue
+		}
+		if len(remotes) > 0 {
+			continue
+		}
+		if scService != nil {
+			if _, err := scService.UnshareChannel(channelID); err != nil {
+				a.Log().Error("Failed to unshare channel with no remaining remotes",
+					mlog.String("channel_id", channelID),
+					mlog.Err(err),
+				)
+			}
+			continue
+		}
+		if _, err := ss.SharedChannel().Delete(channelID); err != nil {
+			a.Log().Error("Failed to unshare channel via store after remote cluster delete",
+				mlog.String("channel_id", channelID),
+				mlog.Err(err),
+			)
+		}
+	}
+}
+
 func (a *App) DeleteRemoteCluster(remoteClusterId string) (bool, *model.AppError) {
+	affectedChannelIDs, listErr := a.sharedChannelIDsWithActiveRemotesForRemote(remoteClusterId)
+	if listErr != nil {
+		a.Log().Warn("Could not list shared channel remotes before deleting remote cluster; skipping orphan shared-channel cleanup",
+			mlog.String("remote_id", remoteClusterId),
+			mlog.Err(listErr),
+		)
+	}
+
 	deleted, err := a.Srv().Store().RemoteCluster().Delete(remoteClusterId)
 	if err != nil {
 		return false, model.NewAppError("DeleteRemoteCluster", "api.remote_cluster.delete.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	if deleted && listErr == nil {
+		a.unshareSharedChannelsIfNoRemotes(affectedChannelIDs)
 	}
 	return deleted, nil
 }

--- a/server/enterprise/elasticsearch/common/indexing_job.go
+++ b/server/enterprise/elasticsearch/common/indexing_job.go
@@ -44,7 +44,7 @@ func NewIndexerWorker(name string,
 	licenseFn func() *model.License,
 	createBulkProcessorFn func() error,
 	addItemToBulkProcessorFn func(indexName string, indexOp string, docID string, body io.ReadSeeker) error,
-	closeBulkProcessorFn func() error,
+	closeBulkProcessorFn func() (int64, error),
 ) *IndexerWorker {
 	return &IndexerWorker{
 		name:                   name,
@@ -79,7 +79,7 @@ type IndexerWorker struct {
 	license func() *model.License
 
 	createBulkProcessor    func() error
-	closeBulkProcessor     func() error
+	closeBulkProcessor     func() (int64, error)
 	addItemToBulkProcessor func(indexName, indexOp, docID string, body io.ReadSeeker) error
 }
 
@@ -239,9 +239,27 @@ func (worker *IndexerWorker) DoJob(job *model.Job) {
 
 	err := worker.createBulkProcessor()
 	if err != nil {
-		worker.logger.Error("Worker: Failed to setup bulk processor", mlog.Err(err))
+		logger.Error("Worker: Failed to setup bulk processor", mlog.Err(err))
+		appErr := model.NewAppError("IndexerWorker", "ent.elasticsearch.indexer.do_job.create_bulk_processor.error", nil, "", http.StatusInternalServerError).Wrap(err)
+		if err2 := worker.jobServer.SetJobError(job, appErr); err2 != nil {
+			logger.Error("Worker: Failed to set job error", mlog.Err(err2), mlog.NamedErr("set_error", appErr))
+		}
 		return
 	}
+
+	// closeOnce ensures the bulk processor is flushed and closed exactly once
+	// regardless of which exit path is taken. numFailed is set by the first call
+	// and read by the success path; logging is handled by closeBulkProcessor itself.
+	var (
+		closeOnce sync.Once
+		numFailed int64
+	)
+	doClose := func() {
+		closeOnce.Do(func() {
+			numFailed, _ = worker.closeBulkProcessor()
+		})
+	}
+	defer doClose()
 
 	worker.initEntitiesToIndex(job)
 	progress, err := initProgress(logger, worker.jobServer, job, worker.backend)
@@ -254,14 +272,7 @@ func (worker *IndexerWorker) DoJob(job *model.Job) {
 	cancelWatcherChan := make(chan struct{}, 1)
 	cancelContext = cancelContext.WithContext(cancelCtx)
 	go worker.jobServer.CancellationWatcher(cancelContext, job.Id, cancelWatcherChan)
-
-	defer func() {
-		cancelCancelWatcher()
-		err := worker.closeBulkProcessor()
-		if err != nil {
-			logger.Warn("Error while closing the bulk indexer", mlog.Err(err), mlog.String("job_id", job.Id))
-		}
-	}()
+	defer cancelCancelWatcher()
 
 	for {
 		select {
@@ -321,6 +332,19 @@ func (worker *IndexerWorker) DoJob(job *model.Job) {
 			}
 
 			if progress.IsDone(job) {
+				doClose()
+				if numFailed > 0 {
+					logger.Error("Worker: Indexing job finished with bulk write failures; some documents were not indexed",
+						mlog.Int("num_failed", numFailed),
+						mlog.Int("done_posts_count", progress.DonePostsCount),
+					)
+					appErr := model.NewAppError("IndexerWorker", "ent.elasticsearch.indexer.do_job.bulk_failures.error",
+						map[string]any{"NumFailed": numFailed}, "", http.StatusInternalServerError)
+					if err2 := worker.jobServer.SetJobError(job, appErr); err2 != nil {
+						logger.Error("Worker: Failed to set job error", mlog.Err(err2), mlog.NamedErr("set_error", appErr))
+					}
+					return
+				}
 				if err := worker.jobServer.SetJobSuccess(job); err != nil {
 					logger.Error("Worker: Failed to set success for job", mlog.Err(err))
 					if err2 := worker.jobServer.SetJobError(job, err); err2 != nil {

--- a/server/enterprise/elasticsearch/common/logger.go
+++ b/server/enterprise/elasticsearch/common/logger.go
@@ -69,7 +69,7 @@ func (l *Logger) LogRoundTrip(req *http.Request, res *http.Response, err error, 
 func (l *Logger) RequestBodyEnabled() bool { return l.trace }
 
 // ResponseBodyEnabled makes the client pass response body to logger
-func (l *Logger) ResponseBodyEnabled() bool { return false }
+func (l *Logger) ResponseBodyEnabled() bool { return l.trace }
 
 func NewBulkIndexerLogger(mlogger mlog.LoggerIFace, name string) BulkIndexerDebugLogger {
 	return BulkIndexerDebugLogger{

--- a/server/enterprise/elasticsearch/elasticsearch/indexing_job.go
+++ b/server/enterprise/elasticsearch/elasticsearch/indexing_job.go
@@ -63,10 +63,33 @@ func (esi *ElasticsearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 				Action:     indexOp,
 				DocumentID: docID,
 				Body:       body,
+				OnFailure: func(_ context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem, err error) {
+					logger.Error("Bulk indexer: failed to index document",
+						mlog.String("index", item.Index),
+						mlog.String("doc_id", item.DocumentID),
+						mlog.String("action", item.Action),
+						mlog.String("error_type", resp.Error.Type),
+						mlog.String("error_reason", resp.Error.Reason),
+						mlog.Err(err),
+					)
+				},
 			})
 		},
-		// Closing the bulk processor.
-		func() error {
-			return esi.bulkProcessor.Close(context.Background())
+		// Closing the bulk processor and returning the number of failed items.
+		func() (int64, error) {
+			err := esi.bulkProcessor.Close(context.Background())
+			stats := esi.bulkProcessor.Stats()
+			fields := []mlog.Field{
+				mlog.Uint("num_indexed", stats.NumIndexed),
+				mlog.Uint("num_failed", stats.NumFailed),
+				mlog.Uint("num_added", stats.NumAdded),
+				mlog.Uint("num_flushed", stats.NumFlushed),
+			}
+			if err != nil {
+				logger.Warn("Bulk indexer closed with error", append(fields, mlog.Err(err))...)
+			} else {
+				logger.Info("Bulk indexer closed", fields...)
+			}
+			return int64(stats.NumFailed), err
 		})
 }

--- a/server/enterprise/elasticsearch/elasticsearch/indexing_job_test.go
+++ b/server/enterprise/elasticsearch/elasticsearch/indexing_job_test.go
@@ -4,7 +4,10 @@
 package elasticsearch
 
 import (
+	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,6 +58,98 @@ func TestElasticSearchIndexerJobIsEnabled(t *testing.T) {
 
 		assert.Equal(t, result, false)
 	})
+}
+
+// TestElasticsearchIndexerBulkWriteFailures verifies that a reindex job is marked
+// as failed when Elasticsearch rejects bulk writes with per-item errors (e.g. a
+// write block on the index), rather than silently reporting success.
+//
+// Requires a running Elasticsearch instance (skipped otherwise).
+func TestElasticsearchIndexerBulkWriteFailures(t *testing.T) {
+	th := api4.SetupEnterprise(t).InitBasic(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ElasticsearchSettings.EnableIndexing = true
+		*cfg.ElasticsearchSettings.EnableSearching = true
+		*cfg.ElasticsearchSettings.EnableAutocomplete = true
+		*cfg.SqlSettings.DisableDatabaseSearch = true
+	})
+	th.App.Srv().SetLicense(model.NewTestLicense())
+
+	client := createTestClient(t, th.Context, th.App.Config(), th.App.FileBackend())
+	ctx := context.Background()
+
+	// Skip if Elasticsearch is not reachable.
+	_, err := client.Info().Do(ctx)
+	if err != nil {
+		t.Skipf("Elasticsearch not available at %s: %v", *th.App.Config().ElasticsearchSettings.ConnectionURL, err)
+	}
+
+	impl := ElasticsearchIndexerInterfaceImpl{Server: th.App.Srv()}
+	worker := impl.MakeWorker()
+	require.NotNil(t, worker)
+	th.Server.Jobs.RegisterJobType(model.JobTypeElasticsearchPostIndexing, worker, nil)
+
+	go worker.Run()
+	defer worker.Stop()
+
+	// Phase 1: clean reindex so the indices exist.
+	job, appErr := th.App.Srv().Jobs.CreateJob(th.Context, model.JobTypeElasticsearchPostIndexing, map[string]string{})
+	require.Nil(t, appErr)
+	worker.JobChannel() <- *job
+	job = waitForElasticsearchJob(t, th, job.Id, 60*time.Second)
+	require.Equal(t, model.JobStatusSuccess, job.Status, "initial reindex should succeed")
+
+	// Collect the indices that were created (skip internal dot-prefixed ones).
+	indexMap, err := client.Indices.Get("*").Do(ctx)
+	require.NoError(t, err)
+	var indexNames []string
+	for name := range indexMap {
+		if !strings.HasPrefix(name, ".") {
+			indexNames = append(indexNames, name)
+		}
+	}
+	require.NotEmpty(t, indexNames, "initial reindex should have created at least one index")
+
+	// Apply a write block to all Mattermost indices and remove it on cleanup.
+	setWriteBlock := func(blocked bool) {
+		body := `{"index.blocks.write":true}`
+		if !blocked {
+			body = `{"index.blocks.write":false}`
+		}
+		_, putErr := client.Indices.PutSettings().
+			Indices(strings.Join(indexNames, ",")).
+			Raw(strings.NewReader(body)).
+			Do(ctx)
+		require.NoError(t, putErr, "failed to set write block=%v", blocked)
+	}
+	setWriteBlock(true)
+	defer setWriteBlock(false)
+
+	// Phase 2: reindex against write-blocked indices — job must be marked as error.
+	job, appErr = th.App.Srv().Jobs.CreateJob(th.Context, model.JobTypeElasticsearchPostIndexing, map[string]string{})
+	require.Nil(t, appErr)
+	worker.JobChannel() <- *job
+	job = waitForElasticsearchJob(t, th, job.Id, 60*time.Second)
+	assert.Equal(t, model.JobStatusError, job.Status, "reindex against write-blocked indices should fail")
+}
+
+// waitForElasticsearchJob polls the job store until the job reaches a terminal
+// status or the timeout expires.
+func waitForElasticsearchJob(t *testing.T, th *api4.TestHelper, jobID string, timeout time.Duration) *model.Job {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		job, err := th.App.Srv().Store().Job().Get(th.Context, jobID)
+		require.NoError(t, err)
+		switch job.Status {
+		case model.JobStatusSuccess, model.JobStatusError, model.JobStatusCanceled:
+			return job
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("job %s did not reach a terminal status within %s", jobID, timeout)
+	return nil
 }
 
 func TestElasticSearchIndexerPending(t *testing.T) {

--- a/server/enterprise/elasticsearch/opensearch/indexing_job.go
+++ b/server/enterprise/elasticsearch/opensearch/indexing_job.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mattermost/mattermost/server/v8/enterprise/elasticsearch/common"
 
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchutil"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -64,10 +65,38 @@ func (esi *OpensearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 				Action:     indexOp,
 				DocumentID: docID,
 				Body:       body,
+				OnFailure: func(_ context.Context, item opensearchutil.BulkIndexerItem, resp opensearchapi.BulkRespItem, err error) {
+					var errType, errReason string
+					if resp.Error != nil {
+						errType = resp.Error.Type
+						errReason = resp.Error.Reason
+					}
+					logger.Error("Bulk indexer: failed to index document",
+						mlog.String("index", item.Index),
+						mlog.String("doc_id", item.DocumentID),
+						mlog.String("action", item.Action),
+						mlog.String("error_type", errType),
+						mlog.String("error_reason", errReason),
+						mlog.Err(err),
+					)
+				},
 			})
 		},
-		// Closing the bulk processor
-		func() error {
-			return esi.bulkProcessor.Close(context.Background())
+		// Closing the bulk processor and returning the number of failed items.
+		func() (int64, error) {
+			err := esi.bulkProcessor.Close(context.Background())
+			stats := esi.bulkProcessor.Stats()
+			fields := []mlog.Field{
+				mlog.Uint("num_indexed", stats.NumIndexed),
+				mlog.Uint("num_failed", stats.NumFailed),
+				mlog.Uint("num_added", stats.NumAdded),
+				mlog.Uint("num_flushed", stats.NumFlushed),
+			}
+			if err != nil {
+				logger.Warn("Bulk indexer closed with error", append(fields, mlog.Err(err))...)
+			} else {
+				logger.Info("Bulk indexer closed", fields...)
+			}
+			return int64(stats.NumFailed), err
 		})
 }

--- a/server/enterprise/elasticsearch/opensearch/indexing_job_test.go
+++ b/server/enterprise/elasticsearch/opensearch/indexing_job_test.go
@@ -4,8 +4,13 @@
 package opensearch
 
 import (
+	"context"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -55,6 +60,106 @@ func TestOpenSearchIndexerJobIsEnabled(t *testing.T) {
 
 		assert.Equal(t, result, false)
 	})
+}
+
+// TestOpenSearchIndexerBulkWriteFailures verifies that a reindex job is marked as
+// failed when OpenSearch rejects bulk writes with per-item errors (e.g. a write
+// block on the index), rather than silently reporting success.
+//
+// Requires a running OpenSearch instance (skipped otherwise).
+func TestOpenSearchIndexerBulkWriteFailures(t *testing.T) {
+	th := api4.SetupEnterprise(t).InitBasic(t)
+
+	connURL := "http://localhost:9201"
+	if os.Getenv("IS_CI") == "true" {
+		connURL = "http://opensearch:9201"
+	}
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ElasticsearchSettings.ConnectionURL = connURL
+		*cfg.ElasticsearchSettings.Backend = model.ElasticsearchSettingsOSBackend
+		*cfg.ElasticsearchSettings.EnableIndexing = true
+		*cfg.ElasticsearchSettings.EnableSearching = true
+		*cfg.ElasticsearchSettings.EnableAutocomplete = true
+		*cfg.SqlSettings.DisableDatabaseSearch = true
+	})
+	th.App.Srv().SetLicense(model.NewTestLicense())
+
+	client := createTestClient(t, th.Context, th.App.Config(), th.App.FileBackend())
+
+	// Skip if OpenSearch is not reachable.
+	_, err := client.Info(context.Background(), nil)
+	if err != nil {
+		t.Skipf("OpenSearch not available at %s: %v", connURL, err)
+	}
+
+	impl := OpensearchIndexerInterfaceImpl{Server: th.App.Srv()}
+	worker := impl.MakeWorker()
+	require.NotNil(t, worker)
+	th.Server.Jobs.RegisterJobType(model.JobTypeElasticsearchPostIndexing, worker, nil)
+
+	go worker.Run()
+	defer worker.Stop()
+
+	// Phase 1: clean reindex so the indices exist.
+	job, appErr := th.App.Srv().Jobs.CreateJob(th.Context, model.JobTypeElasticsearchPostIndexing, map[string]string{})
+	require.Nil(t, appErr)
+	worker.JobChannel() <- *job
+	job = waitForIndexingJob(t, th, job.Id, 60*time.Second)
+	require.Equal(t, model.JobStatusSuccess, job.Status, "initial reindex should succeed")
+
+	// Collect the indices that were created (skip internal dot-prefixed ones).
+	settingsResp, err := client.Indices.Settings.Get(context.Background(), &opensearchapi.SettingsGetReq{})
+	require.NoError(t, err)
+	var indexNames []string
+	for name := range settingsResp.Indices {
+		if !strings.HasPrefix(name, ".") {
+			indexNames = append(indexNames, name)
+		}
+	}
+	require.NotEmpty(t, indexNames, "initial reindex should have created at least one index")
+
+	// Apply a write block to all Mattermost indices and remove it on cleanup.
+	setWriteBlock := func(blocked bool) {
+		body := `{"index.blocks.write":true}`
+		if !blocked {
+			body = `{"index.blocks.write":false}`
+		}
+		for _, idx := range indexNames {
+			_, putErr := client.Indices.Settings.Put(context.Background(), opensearchapi.SettingsPutReq{
+				Indices: []string{idx},
+				Body:    strings.NewReader(body),
+			})
+			require.NoError(t, putErr, "failed to set write block=%v on index %s", blocked, idx)
+		}
+	}
+	setWriteBlock(true)
+	defer setWriteBlock(false)
+
+	// Phase 2: reindex against write-blocked indices — job must be marked as error.
+	job, appErr = th.App.Srv().Jobs.CreateJob(th.Context, model.JobTypeElasticsearchPostIndexing, map[string]string{})
+	require.Nil(t, appErr)
+	worker.JobChannel() <- *job
+	job = waitForIndexingJob(t, th, job.Id, 60*time.Second)
+	assert.Equal(t, model.JobStatusError, job.Status, "reindex against write-blocked indices should fail")
+}
+
+// waitForIndexingJob polls the job store until the job reaches a terminal status
+// or the timeout expires.
+func waitForIndexingJob(t *testing.T, th *api4.TestHelper, jobID string, timeout time.Duration) *model.Job {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		job, err := th.App.Srv().Store().Job().Get(th.Context, jobID)
+		require.NoError(t, err)
+		switch job.Status {
+		case model.JobStatusSuccess, model.JobStatusError, model.JobStatusCanceled:
+			return job
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("job %s did not reach a terminal status within %s", jobID, timeout)
+	return nil
 }
 
 func TestOpenSearchIndexerPending(t *testing.T) {

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9249,6 +9249,14 @@
     "translation": "Failed to index the user"
   },
   {
+    "id": "ent.elasticsearch.indexer.do_job.bulk_failures.error",
+    "translation": "Indexing job completed but {{.NumFailed}} document(s) were rejected by the search backend and not indexed"
+  },
+  {
+    "id": "ent.elasticsearch.indexer.do_job.create_bulk_processor.error",
+    "translation": "Indexing worker failed to initialise the bulk processor"
+  },
+  {
     "id": "ent.elasticsearch.indexer.do_job.get_oldest_entity.error",
     "translation": "The oldest entity (user, channel or post), could not be retrieved from the database"
   },

--- a/server/public/model/support_packet.go
+++ b/server/public/model/support_packet.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"time"
 )
 
 const (
@@ -25,18 +26,20 @@ type SupportPacketDiagnostics struct {
 	} `yaml:"license"`
 
 	Server struct {
-		OS                  string `yaml:"os"`
-		Architecture        string `yaml:"architecture"`
-		CPUCores            int    `yaml:"cpu_cores"`
-		TotalMemoryMB       uint64 `yaml:"total_memory_mb"`
-		OpenFileDescriptors int64  `yaml:"open_file_descriptors"`
-		MaxFileDescriptors  int64  `yaml:"max_file_descriptors"`
-		Hostname            string `yaml:"hostname"`
-		ProcessID           int    `yaml:"process_id"`
-		Version             string `yaml:"version"`
-		BuildHash           string `yaml:"build_hash"`
-		GoVersion           string `yaml:"go_version"`
-		InstallationType    string `yaml:"installation_type"`
+		OS                  string    `yaml:"os"`
+		Architecture        string    `yaml:"architecture"`
+		CPUCores            int       `yaml:"cpu_cores"`
+		TotalMemoryMB       uint64    `yaml:"total_memory_mb"`
+		OpenFileDescriptors int64     `yaml:"open_file_descriptors"`
+		MaxFileDescriptors  int64     `yaml:"max_file_descriptors"`
+		Hostname            string    `yaml:"hostname"`
+		ProcessID           int       `yaml:"process_id"`
+		StartedAt           time.Time `yaml:"started_at"`
+		HostStartedAt       time.Time `yaml:"host_started_at,omitempty"`
+		Version             string    `yaml:"version"`
+		BuildHash           string    `yaml:"build_hash"`
+		GoVersion           string    `yaml:"go_version"`
+		InstallationType    string    `yaml:"installation_type"`
 	} `yaml:"server"`
 
 	Config struct {

--- a/server/public/model/support_packet.go
+++ b/server/public/model/support_packet.go
@@ -30,6 +30,7 @@ type SupportPacketDiagnostics struct {
 		CPUCores         int    `yaml:"cpu_cores"`
 		TotalMemoryMB    uint64 `yaml:"total_memory_mb"`
 		Hostname         string `yaml:"hostname"`
+		ProcessID        int    `yaml:"process_id"`
 		Version          string `yaml:"version"`
 		BuildHash        string `yaml:"build_hash"`
 		InstallationType string `yaml:"installation_type"`

--- a/server/public/model/support_packet.go
+++ b/server/public/model/support_packet.go
@@ -33,6 +33,7 @@ type SupportPacketDiagnostics struct {
 		ProcessID        int    `yaml:"process_id"`
 		Version          string `yaml:"version"`
 		BuildHash        string `yaml:"build_hash"`
+		GoVersion        string `yaml:"go_version"`
 		InstallationType string `yaml:"installation_type"`
 	} `yaml:"server"`
 

--- a/server/public/model/support_packet.go
+++ b/server/public/model/support_packet.go
@@ -25,16 +25,18 @@ type SupportPacketDiagnostics struct {
 	} `yaml:"license"`
 
 	Server struct {
-		OS               string `yaml:"os"`
-		Architecture     string `yaml:"architecture"`
-		CPUCores         int    `yaml:"cpu_cores"`
-		TotalMemoryMB    uint64 `yaml:"total_memory_mb"`
-		Hostname         string `yaml:"hostname"`
-		ProcessID        int    `yaml:"process_id"`
-		Version          string `yaml:"version"`
-		BuildHash        string `yaml:"build_hash"`
-		GoVersion        string `yaml:"go_version"`
-		InstallationType string `yaml:"installation_type"`
+		OS                  string `yaml:"os"`
+		Architecture        string `yaml:"architecture"`
+		CPUCores            int    `yaml:"cpu_cores"`
+		TotalMemoryMB       uint64 `yaml:"total_memory_mb"`
+		OpenFileDescriptors int64  `yaml:"open_file_descriptors"`
+		MaxFileDescriptors  int64  `yaml:"max_file_descriptors"`
+		Hostname            string `yaml:"hostname"`
+		ProcessID           int    `yaml:"process_id"`
+		Version             string `yaml:"version"`
+		BuildHash           string `yaml:"build_hash"`
+		GoVersion           string `yaml:"go_version"`
+		InstallationType    string `yaml:"installation_type"`
 	} `yaml:"server"`
 
 	Config struct {

--- a/webapp/channels/src/components/at_mention/at_mention.test.tsx
+++ b/webapp/channels/src/components/at_mention/at_mention.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import {General} from 'mattermost-redux/constants';
 
-import {render} from 'tests/react_testing_utils';
+import {render, renderWithContext} from 'tests/react_testing_utils';
 import {TestHelper} from 'utils/test_helper';
 
 import AtMention from './at_mention';
@@ -174,7 +174,7 @@ describe('components/AtMention', () => {
     });
 
     test('should match snapshot when mentioning a group that is allowed reference', () => {
-        const {container} = render(
+        const {container} = renderWithContext(
             <AtMention
                 {...baseProps}
                 mentionName='developers'
@@ -214,7 +214,7 @@ describe('components/AtMention', () => {
     });
 
     test('should match snapshot when mentioning a group followed by punctuation', () => {
-        const {container} = render(
+        const {container} = renderWithContext(
             <AtMention
                 {...baseProps}
                 mentionName='developers.'

--- a/webapp/channels/src/components/channel_banner/style.scss
+++ b/webapp/channels/src/components/channel_banner/style.scss
@@ -5,8 +5,9 @@
     width: 100%;
     min-height: variables.$channel-banner-height;
     max-height: variables.$channel-banner-height;
+    align-items: center;
     justify-content: center;
-    padding-block: 5px;
+    padding-block: 2px;
     padding-inline: 24px;
     white-space: nowrap;
 
@@ -15,7 +16,7 @@
         overflow: hidden;
         max-width: 100%;
         font-size: 13px;
-        line-height: 13px;
+        line-height: 20px;
         text-align: center;
         text-overflow: ellipsis;
 
@@ -24,10 +25,22 @@
             text-decoration: underline;
         }
 
+        .emoticon {
+            width: 16px;
+            min-width: 16px;
+            height: 16px;
+            min-height: 16px;
+        }
+
+        .emoticon--unicode {
+            font-size: 16px;
+            line-height: 20px;
+        }
+
         .markdown__heading {
             overflow: hidden;
             margin: 2px;
-            font-size: 18px;
+            font-size: 16px;
             text-overflow: ellipsis;
         }
 

--- a/webapp/channels/src/components/user_group_popover/user_group_popover_controller.test.tsx
+++ b/webapp/channels/src/components/user_group_popover/user_group_popover_controller.test.tsx
@@ -1,0 +1,105 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import * as userActions from 'mattermost-redux/actions/users';
+
+import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
+import {TestHelper} from 'utils/test_helper';
+
+import {UserGroupPopoverController} from './user_group_popover_controller';
+
+jest.mock('mattermost-redux/actions/users', () => ({
+    ...jest.requireActual('mattermost-redux/actions/users'),
+    getProfilesInGroup: jest.fn(() => () => ({type: 'MOCK_GET_PROFILES_IN_GROUP'})),
+}));
+
+describe('UserGroupPopoverController', () => {
+    const group = TestHelper.getGroupMock({
+        id: 'group1',
+        name: 'test-group',
+        display_name: 'Test Group',
+        member_count: 5,
+    });
+
+    const initialState = {
+        entities: {
+            teams: {
+                currentTeamId: 'team_id1',
+                teams: {
+                    team_id1: {
+                        id: 'team_id1',
+                        name: 'team1',
+                    },
+                },
+            },
+            general: {
+                config: {},
+            },
+            users: {
+                profiles: {},
+                profilesInGroup: {},
+                statuses: {},
+            },
+            preferences: {
+                myPreferences: {},
+            },
+        },
+        views: {
+            modals: {
+                modalState: {},
+            },
+            search: {
+                popoverSearch: '',
+            },
+        },
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should fetch group members when popover opens on click', async () => {
+        renderWithContext(
+            <UserGroupPopoverController
+                group={group}
+                returnFocus={jest.fn()}
+            >
+                <span>{'@test-group'}</span>
+            </UserGroupPopoverController>,
+            initialState as any,
+        );
+
+        await userEvent.click(screen.getByText('@test-group'));
+
+        expect(userActions.getProfilesInGroup).toHaveBeenCalledWith(
+            'group1',
+            0,
+            100,
+            'display_name',
+        );
+    });
+
+    test('should not fetch additional group members when popover closes', async () => {
+        renderWithContext(
+            <UserGroupPopoverController
+                group={group}
+                returnFocus={jest.fn()}
+            >
+                <span>{'@test-group'}</span>
+            </UserGroupPopoverController>,
+            initialState as any,
+        );
+
+        await userEvent.click(screen.getByText('@test-group'));
+
+        const callCountAfterOpen = (userActions.getProfilesInGroup as jest.Mock).mock.calls.length;
+        expect(callCountAfterOpen).toBeGreaterThanOrEqual(1);
+
+        // Close by pressing Escape
+        await userEvent.keyboard('{Escape}');
+
+        expect(userActions.getProfilesInGroup).toHaveBeenCalledTimes(callCountAfterOpen);
+    });
+});

--- a/webapp/channels/src/components/user_group_popover/user_group_popover_controller.tsx
+++ b/webapp/channels/src/components/user_group_popover/user_group_popover_controller.tsx
@@ -16,8 +16,11 @@ import {
 } from '@floating-ui/react';
 import type {ReactNode} from 'react';
 import React, {useCallback, useState} from 'react';
+import {useDispatch} from 'react-redux';
 
 import type {Group} from '@mattermost/types/groups';
+
+import {getProfilesInGroup} from 'mattermost-redux/actions/users';
 
 import {A11yClassNames} from 'utils/constants';
 
@@ -40,10 +43,18 @@ interface Props {
 
 export function UserGroupPopoverController(props: Props) {
     const [isOpen, setOpen] = useState(false);
+    const dispatch = useDispatch();
+
+    const handleOpenChange = useCallback((open: boolean) => {
+        setOpen(open);
+        if (open) {
+            dispatch(getProfilesInGroup(props.group.id, 0, 100, 'display_name'));
+        }
+    }, [dispatch, props.group.id]);
 
     const {refs, floatingStyles, context: floatingContext} = useFloating({
         open: isOpen,
-        onOpenChange: setOpen,
+        onOpenChange: handleOpenChange,
         whileElementsMounted: autoUpdate,
         middleware: [autoPlacement()],
     });

--- a/webapp/channels/src/sass/components/_post-right.scss
+++ b/webapp/channels/src/sass/components/_post-right.scss
@@ -92,6 +92,15 @@
             }
         }
 
+        &.current--user {
+            &.other--root,
+            &.post--root {
+                .post__header-set-custom-status {
+                    display: none;
+                }
+            }
+        }
+
         &.post--comment {
             .post__body {
                 border-left: none;


### PR DESCRIPTION
2026-04-20 잔여 1건과 2026-04-21 12건을 전부 cherry-pick으로 반영했다.
adapt·exclude·spec 전환은 없다. 포크 고유 조정 1건(cron 비활성화)을 별도 커밋으로 덧붙였다.

남은 미반영 커밋 792 → 781. 마지막 반영 커밋 `2d7a71b0`.

## 반영 커밋

- ci: move FIPS and binary params tests to weekly schedule (#36036)
- ci: disable scheduled triggers for weekly and nightly server CI *(okrbest 고유)*
- MM-68259 Fixing text and emojis being clipped in channel banners (#36076)
- [MM-67981] Add process ID (PID) to support packet diagnostics (#35832)
- [MM-67977] Add Go runtime version to support packet diagnostics (#35833)
- Add server/AGENTS.md (#35903)
- [MM-67978] Add open file descriptor count to support packet diagnostics (#35834)
- [MM-67976] Add server uptime to support packet (#35838)
- [MM-68237] Unshare channels when remote is removed (#35997)
- MM-68047: Hide update status button in RHS post header (#36120)
- MM-67782: Fetch group members on popover open to fix empty member list (#36122)
- MM-68378: Fix silent bulk failures in OpenSearch/Elasticsearch indexers (#36189)
- MM-68160: Fix post reminder confirmation not appearing for replies in RHS (#36124)
- ci: fix startup_failure in nightly race and weekly workflows (#36198)

## Server CI가 이 PR에서 처음으로 실행될 수 있다

`2d7a71b0`이 `server-test-template.yml`에서 `id-token: write`를 제거한다. 이것이
okrbest `Server CI`가 여태 `startup_failure`(jobs 0개)로만 끝난 원인이었다 —
저장소 기본 워크플로 권한이 `read`인데 재사용 워크플로가 caller에 없는 권한을
요구해 잡 생성 전에 거부됐다.

이 PR에서 실제 동작을 관찰한다. `okrbest`는 free 플랜 조직이라
`ubuntu-latest-8-cores`(Team/Enterprise 전용)를 요구하는 잡 5개는 러너를
배정받지 못할 것으로 예상한다. 표준 `ubuntu-22.04` 잡 13개(check-style, vet,
마이그레이션 검사, 서버 빌드, mmctl 테스트)는 정상 실행될 전망이다.
러너 대응은 실측 후 별도 커밋으로 정한다.

## 검증

커밋 단위로 접촉 패키지 테스트를 실행했고 전부 통과했다.

- `channels/app/platform` — support packet 진단 14개, fd 2개, uptime 서브테스트 5개
- `channels/api4` — DeleteRemoteCluster 6개, PostReminder 2개(WS 통합)
- `enterprise/elasticsearch` — ES/OS 컨테이너를 띄워 신규 통합 테스트 2개 실주행 통과
- webapp — channel_banner 12개, user_group_popover·at_mention 25개(스냅샷 17개)
- e2e playwright — eslint·prettier·tsc 통과

기준선 대비 신규 실패 0건. `make check-style`와 webapp `check`/`check-types`는
master에서도 동일하게 실패한다(자체 커밋 d429d6f78의 `NotificationHistory`
storetest 목 미재생성 + 기존 eslint 302건). 별도 작업 대상.

## 후속

- **i18n**: `server/i18n/en.json`에 키 2개 추가, ko 미반영 —
  `ent.elasticsearch.indexer.do_job.bulk_failures.error`,
  `ent.elasticsearch.indexer.do_job.create_bulk_processor.error`
- **CODEOWNERS**: `server/enterprise/elasticsearch/**`와
  `.github/workflows/server-test-template.yml` 접촉 — code owner 리뷰 필요할 수 있음