### PR TITLE
upstream sync 2026-04-24 (picked 3, excluded 2)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,19 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-19 21:26
+- 갱신일: 2026-08-19 23:28
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 762개
+- 남은 커밋: 757개
 
-**마지막 반영 커밋:** `6ce4db65` | [Skip sqlstore DB setup during go test -list discovery (#36249)](https://github.com/mattermost/mattermost/commit/6ce4db65dc5d99248d42aa571fba0187b22669bb) | 2026-04-23
+**마지막 반영 커밋:** `9eb070b7` | [Reorder channel banner (#36268)](https://github.com/mattermost/mattermost/commit/9eb070b72bad03d9a2f599b101558e6fd4922636) | 2026-04-24
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 9c684e63 | [Property System v2 Generic APIs blacklist (#36171)](https://github.com/mattermost/mattermost/commit/9c684e6313b161d0e9cb07442235b962709b37cb) | 2026-04-24 |
-| 5817a6d6 | [Simplify PULL_REQUEST_TEMPLATE.md and document it in AGENTS.md (#36239)](https://github.com/mattermost/mattermost/commit/5817a6d687cc64ea3aa79c87c9eaebe317d69d1f) | 2026-04-24 |
-| 46624d1f | [\[MM-68231\] Tighten post info authorization (#36111)](https://github.com/mattermost/mattermost/commit/46624d1f47d9b70c6db940c5a4e7b3066edca895) | 2026-04-24 |
-| 1ed4d021 | [Fix FIPS test failures by using model.NewTestPassword() for short passwords (#36262)](https://github.com/mattermost/mattermost/commit/1ed4d0215a01bcd6520bc1e481918c1fdc3cc81d) | 2026-04-24 |
-| 9eb070b7 | [Reorder channel banner (#36268)](https://github.com/mattermost/mattermost/commit/9eb070b72bad03d9a2f599b101558e6fd4922636) | 2026-04-24 |
 | 5b4efbd2 | [Remove unused property fields index (#36279)](https://github.com/mattermost/mattermost/commit/5b4efbd28a90305ac4edb2e8e6bc809548977bea) | 2026-04-27 |
 | dda4bb12 | [Mm 68353 show placeholder for redacted files in preview (#36153)](https://github.com/mattermost/mattermost/commit/dda4bb129c6b778629cfa2cb40248917104d1499) | 2026-04-27 |
 | 24f9da39 | [Update docs-impact-review.yml (#36260)](https://github.com/mattermost/mattermost/commit/24f9da39cd6dae56de527cdf88b3af9253a857a2) | 2026-04-27 |
@@ -866,6 +861,10 @@
 | 7627784a | [Require sysadmin permission to create templates (#36217)](https://github.com/mattermost/mattermost/commit/7627784ae1288bdcc00f1459512ffce3613a60b1) | 제외한 48f2fd08(Integrated Boards MVP, #35796)의 property 시스템 v2 위에 얹힌 변경이라 반영할 토대가 없음 — 006f1027·3cb00848·01219efb·3fa87760에 이은 48f2fd08 계보 6번째. 유일한 변경 파일 server/channels/api4/properties.go가 okrbest에 아예 없다(ls 확인, merge-tree도 modify/delete CONFLICT). 내용은 createPropertyField에서 (1) ObjectType == PropertyFieldObjectTypeTemplate이면 target_type과 무관하게 manage_system을 강제하고 (2) 템플릿의 기본 PermissionField/Values/Options를 member가 아닌 sysadmin으로 두는 것인데, 필요한 선행 요소가 전부 우리 트리에 없다 — model.PropertyFieldObjectTypeTemplate 상수, PropertyField.ObjectType 필드(우리 구조체는 ID/GroupID/Name/Type/Attrs/TargetID/TargetType/CreateAt/UpdateAt/DeleteAt 10필드뿐), model.PermissionLevelMember/PermissionLevelSysadmin. 전부 48f2fd08의 마이그레이션 000160/000161/000165 소산이라 cherry-pick·adapt 모두 Go 컴파일 실패. 우리 Boards는 focalboard 기반 자체 플러그인(okrbest-plugin-boards, BlockProp 모델)이 담당하고 Mattermost property API를 호출하지 않는다. 향후 48f2fd08의 property 절반(api4/properties.go, 마이그레이션 000160~000165)을 분할 반영하게 되면 이 커밋도 함께 재검토 대상. |
 
 | 9d33d87e | [Fix Managed Category creatable input color on dark themes (#36242)](https://github.com/mattermost/mattermost/commit/9d33d87e0a92f44113af46a01ed9003f3cee9fa7) | 제외한 01219efb([MM-68037] Managed Sidebar Categories, #35935)의 후속 CSS 패치라 적용 대상이 없음 — 48f2fd08(Integrated Boards MVP) 계보 7번째. 유일한 변경 파일 webapp/channels/src/components/channel_settings_modal/managed_category_selector.scss가 우리 트리에 아예 없다(merge-tree도 modify/delete CONFLICT). 내용은 다크 테마에서 Managed Category creatable 입력창 글자색을 var(--center-channel-color)로 고정하는 5줄인데, 그 셀렉터를 쓰는 컴포넌트(managed_category_selector.tsx) 자체가 부재. 01219efb는 property 시스템 v2(48f2fd08 소산: api4/properties.go, PropertyField.ObjectType, 마이그레이션 000160~000165, property_values_updated WS 이벤트)를 전제로 해 제외했고, 그 전제가 풀리기 전엔 이 커밋도 반영할 실체가 없다. upstream 기준으로도 TeamSettings.EnableManagedChannelCategories 기본값 false에 Enterprise 라이선스 전용이라 제품 공백 아님. 향후 48f2fd08의 property 절반을 분할 반영하면 01219efb와 함께 재검토 대상. |
+
+| 9c684e63 | [Property System v2 Generic APIs blacklist (#36171)](https://github.com/mattermost/mattermost/commit/9c684e6313b161d0e9cb07442235b962709b37cb) | 제외한 48f2fd08(Integrated Boards MVP, #35796)의 property 시스템 v2 위에 얹힌 변경이라 반영할 토대가 없음 — 006f1027·3cb00848·01219efb·3fa87760·7627784a에 이은 48f2fd08 계보 8번째. PropertyGroup에 Version을 추가해 REST API가 v1 그룹 호출을 거부하게 하고 필드·그룹 버전 일치를 강제하는 작업인데, 필요한 선행 요소가 전부 우리 트리에 없다 — (1) 핵심 변경 파일 server/channels/api4/properties.go(63줄 수정)가 아예 부재(ls 확인, merge-tree도 modify/delete CONFLICT), (2) 우리 model.PropertyGroup은 ID·Name 2필드뿐이라 Version이 없고 sqlstore propertyGroupColumns도 {ID,Name}, (3) upstream이 RegisterPropertyGroup(name string)을 RegisterPropertyGroup(*model.PropertyGroup)으로 시그니처 변경 — 우리는 구 시그니처, (4) PropertyField.ObjectType·IsPSAv1 grep 0건, (5) 이 커밋이 수정하는 doSetupManagedCategoryProperties가 grep 0건(제외한 01219efb 소산), (6) 마이그레이션 000170_add_property_groups_version을 얹는데 우리 최신은 000164라 165~169가 비어 morph 시퀀스에 구멍이 생긴다. 규모도 33파일 +1071/-309에 DB 마이그레이션·보호 경로(migrations.list) 포함. 강행 시 Go 컴파일 실패, 통과해도 없는 컬럼 SELECT로 런타임 SQL 오류. 우리 Boards는 focalboard 기반 자체 플러그인(okrbest-plugin-boards)이 담당하고 Mattermost property API를 호출하지 않는다. 향후 48f2fd08의 property 절반(api4/properties.go, 마이그레이션 000160~000165)을 분할 반영하게 되면 이 커밋도 함께 재검토 대상. |
+
+| 5817a6d6 | [Simplify PULL_REQUEST_TEMPLATE.md and document it in AGENTS.md (#36239)](https://github.com/mattermost/mattermost/commit/5817a6d687cc64ea3aa79c87c9eaebe317d69d1f) | 두 변경 파일 모두 우리가 자체적으로 대체해 upstream 원문과 공통 기반이 없음(merge-tree 양쪽 다 content CONFLICT). (1) .github/PULL_REQUEST_TEMPLATE.md — 우리는 9609b9a89d·b0398f4fb3(Change brand PR Template)에서 전문을 한국어로 번역하고 OKR.BEST로 리브랜드했다(developers.okrbest.com, github.com/okrbest/okrbest). upstream 변경은 영문 원문을 59줄에서 30줄로 줄이면서 mattermost.atlassian.net·github.com/mattermost/mattermost 링크를 남기는 것이라, 그대로 반영하면 리브랜드가 되돌아간다(constitution 원칙 IV). (2) AGENTS.md — upstream 것은 make bump-enterprise/enterprise.pin 안내 11줄짜리 파일이고 우리 것은 spec-kit + superpowers 워크플로 문서로 내용이 전혀 다르다. 우리 AGENTS.md에 bump-enterprise가 grep 0건이라 upstream이 새 '## Pull Requests' 절을 덧붙이는 위치 자체가 존재하지 않는다. 순수 문서 변경이라 기능 공백도 없다. 우리 PR 템플릿 간소화가 필요해지면 upstream 문안을 따르지 않고 우리 문체 규칙(constitution 원칙 VIII)에 맞춰 별도로 진행한다. |
 
 ## spec 전환 커밋
 

--- a/server/channels/api4/post.go
+++ b/server/channels/api4/post.go
@@ -1733,24 +1733,12 @@ func getPostInfo(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hasPermissionToAccessChannel := false
-	hasJoinedChannel := false
+	hasPermissionToAccessChannel, hasJoinedChannel := c.App.SessionHasPermissionToReadChannel(c.AppContext, *c.AppContext.Session(), channel)
 
-	_, channelMemberErr := c.App.GetChannelMember(c.AppContext, channel.Id, userID)
-
-	if channelMemberErr == nil {
-		hasPermissionToAccessChannel = true
-		hasJoinedChannel = true
-	}
-
-	if !hasPermissionToAccessChannel {
-		if channel.Type == model.ChannelTypeOpen {
-			hasPermissionToAccessChannel = true
-		} else if channel.Type == model.ChannelTypePrivate {
-			hasPermissionToAccessChannel, _ = c.App.HasPermissionToChannel(c.AppContext, userID, channel.Id, model.PermissionManagePrivateChannelMembers)
-		} else if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
-			hasPermissionToAccessChannel, _ = c.App.HasPermissionToReadChannel(c.AppContext, userID, channel)
-		}
+	if !hasPermissionToAccessChannel && channel.Type == model.ChannelTypeOpen && !*c.App.Config().ComplianceSettings.Enable {
+		canJoinOpenChannel := c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), channel.TeamId, model.PermissionJoinPublicChannels)
+		canJoinOpenTeam := team != nil && team.AllowOpenInvite && c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionJoinPublicTeams)
+		hasPermissionToAccessChannel = canJoinOpenChannel || canJoinOpenTeam
 	}
 
 	if !hasPermissionToAccessChannel {

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -5431,6 +5431,8 @@ func TestPostGetInfo(t *testing.T) {
 	mainHelper.Parallel(t)
 
 	th := Setup(t).InitBasic(t)
+	th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterprise))
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.GuestAccountsSettings.Enable = true })
 
 	defaultPerms := th.SaveDefaultRolePermissions(t)
 	defer th.RestoreDefaultRolePermissions(t, defaultPerms)
@@ -5439,8 +5441,16 @@ func TestPostGetInfo(t *testing.T) {
 	th.RemovePermissionFromRole(t, model.PermissionManagePrivateChannelMembers.Id, model.TeamUserRoleId)
 
 	client := th.Client
+	guestUser, guestClient := th.CreateGuestAndClient(t)
+	otherTeamMemberClient := th.CreateClient()
+	_, _, err := otherTeamMemberClient.Login(context.Background(), th.BasicUser2.Username, th.BasicUser2.Password)
+	require.NoError(t, err)
+	outsiderUser := th.CreateUser(t)
+	outsiderClient := th.CreateClient()
+	_, _, err = outsiderClient.Login(context.Background(), outsiderUser.Username, outsiderUser.Password)
+	require.NoError(t, err)
 	sysadminClient := th.SystemAdminClient
-	_, _, err := sysadminClient.AddTeamMember(context.Background(), th.BasicTeam.Id, th.SystemAdminUser.Id)
+	_, _, err = sysadminClient.AddTeamMember(context.Background(), th.BasicTeam.Id, th.SystemAdminUser.Id)
 	require.NoError(t, err)
 
 	openChannel, _, err := client.CreateChannel(context.Background(), &model.Channel{TeamId: th.BasicTeam.Id, Type: model.ChannelTypeOpen, Name: "open-channel", DisplayName: "Open Channel"})
@@ -5501,6 +5511,7 @@ func TestPostGetInfo(t *testing.T) {
 		hasJoinedChannel bool
 		post             *model.Post
 		client           *model.Client4
+		assertSetup      func(t *testing.T)
 		hasAccess        bool
 	}{
 		// Open channel - Current Team
@@ -5523,6 +5534,25 @@ func TestPostGetInfo(t *testing.T) {
 			post:             openPost,
 			client:           sysadminClient,
 			hasAccess:        true,
+		},
+		{
+			name:             "Open post - Current team - Guest user outside channel",
+			team:             th.BasicTeam,
+			hasJoinedTeam:    true,
+			channel:          openChannel,
+			hasJoinedChannel: false,
+			post:             openPost,
+			client:           guestClient,
+			assertSetup: func(t *testing.T) {
+				t.Helper()
+
+				_, appErr := th.App.GetTeamMember(th.Context, th.BasicTeam.Id, guestUser.Id)
+				require.Nil(t, appErr)
+
+				_, appErr = th.App.GetChannelMember(th.Context, openChannel.Id, guestUser.Id)
+				require.NotNil(t, appErr)
+			},
+			hasAccess: false,
 		},
 
 		// Private channel - Current Team
@@ -5657,6 +5687,38 @@ func TestPostGetInfo(t *testing.T) {
 			hasAccess: false,
 		},
 		{
+			name:             "Open post - Invite team - Basic user with join private teams permission",
+			team:             inviteTeam,
+			hasJoinedTeam:    false,
+			channel:          inviteTeamOpenChannel,
+			hasJoinedChannel: false,
+			post:             inviteTeamOpenPost,
+			client:           client,
+			assertSetup: func(t *testing.T) {
+				t.Helper()
+
+				_, appErr := th.App.GetTeamMember(th.Context, inviteTeam.Id, th.BasicUser.Id)
+				require.NotNil(t, appErr)
+
+				_, appErr = th.App.GetChannelMember(th.Context, inviteTeamOpenChannel.Id, th.BasicUser.Id)
+				require.NotNil(t, appErr)
+
+				require.False(t, th.App.HasPermissionToTeam(th.Context, th.BasicUser.Id, inviteTeam.Id, model.PermissionJoinPrivateTeams))
+				require.False(t, th.App.HasPermissionToTeam(th.Context, th.BasicUser.Id, inviteTeam.Id, model.PermissionJoinPublicChannels))
+
+				th.AddPermissionToRole(t, model.PermissionJoinPrivateTeams.Id, model.SystemUserRoleId)
+				th.AddPermissionToRole(t, model.PermissionJoinPublicChannels.Id, model.SystemUserRoleId)
+				t.Cleanup(func() {
+					th.RemovePermissionFromRole(t, model.PermissionJoinPublicChannels.Id, model.SystemUserRoleId)
+					th.RemovePermissionFromRole(t, model.PermissionJoinPrivateTeams.Id, model.SystemUserRoleId)
+				})
+
+				require.True(t, th.App.HasPermissionToTeam(th.Context, th.BasicUser.Id, inviteTeam.Id, model.PermissionJoinPrivateTeams))
+				require.True(t, th.App.HasPermissionToTeam(th.Context, th.BasicUser.Id, inviteTeam.Id, model.PermissionJoinPublicChannels))
+			},
+			hasAccess: true,
+		},
+		{
 			name:             "Open post - Invite team - Sysadmin user",
 			team:             inviteTeam,
 			hasJoinedTeam:    true,
@@ -5670,6 +5732,10 @@ func TestPostGetInfo(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.assertSetup != nil {
+				tc.assertSetup(t)
+			}
+
 			info, resp, err := tc.client.GetPostInfo(context.Background(), tc.post.Id)
 			if !tc.hasAccess {
 				require.Error(t, err)
@@ -5695,6 +5761,97 @@ func TestPostGetInfo(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("Open post - Current team - Non-member denied when compliance is enabled", func(t *testing.T) {
+		info, resp, err := otherTeamMemberClient.GetPostInfo(context.Background(), openPost.Id)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.Equal(t, openChannel.Id, info.ChannelId)
+		require.True(t, info.HasJoinedTeam)
+		require.False(t, info.HasJoinedChannel)
+
+		originalComplianceEnabled := *th.App.Config().ComplianceSettings.Enable
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ComplianceSettings.Enable = true
+		})
+		t.Cleanup(func() {
+			th.App.UpdateConfig(func(cfg *model.Config) {
+				*cfg.ComplianceSettings.Enable = originalComplianceEnabled
+			})
+		})
+
+		_, resp, err = otherTeamMemberClient.GetPostInfo(context.Background(), openPost.Id)
+		require.Error(t, err)
+		CheckNotFoundStatus(t, resp)
+	})
+
+	t.Run("Open post - Open team - Non-member denied when compliance is enabled", func(t *testing.T) {
+		_, appErr := th.App.GetTeamMember(th.Context, openTeam.Id, th.BasicUser.Id)
+		require.NotNil(t, appErr)
+
+		_, appErr = th.App.GetChannelMember(th.Context, openTeamOpenChannel.Id, th.BasicUser.Id)
+		require.NotNil(t, appErr)
+
+		info, resp, err := client.GetPostInfo(context.Background(), openTeamOpenPost.Id)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.Equal(t, openTeamOpenChannel.Id, info.ChannelId)
+		require.False(t, info.HasJoinedTeam)
+		require.False(t, info.HasJoinedChannel)
+
+		originalComplianceEnabled := *th.App.Config().ComplianceSettings.Enable
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ComplianceSettings.Enable = true
+		})
+		t.Cleanup(func() {
+			th.App.UpdateConfig(func(cfg *model.Config) {
+				*cfg.ComplianceSettings.Enable = originalComplianceEnabled
+			})
+		})
+
+		_, resp, err = client.GetPostInfo(context.Background(), openTeamOpenPost.Id)
+		require.Error(t, err)
+		CheckNotFoundStatus(t, resp)
+	})
+
+	t.Run("Private post - Same-team non-member with manage members permission is denied", func(t *testing.T) {
+		_, appErr := th.App.GetTeamMember(th.Context, th.BasicTeam.Id, th.BasicUser2.Id)
+		require.Nil(t, appErr)
+
+		_, appErr = th.App.GetChannelMember(th.Context, privateChannelBasicUser.Id, th.BasicUser2.Id)
+		require.NotNil(t, appErr)
+
+		th.AddPermissionToRole(t, model.PermissionManagePrivateChannelMembers.Id, model.TeamUserRoleId)
+		t.Cleanup(func() {
+			th.RemovePermissionFromRole(t, model.PermissionManagePrivateChannelMembers.Id, model.TeamUserRoleId)
+		})
+
+		hasPermission, isMember := th.App.HasPermissionToChannel(th.Context, th.BasicUser2.Id, privateChannelBasicUser.Id, model.PermissionManagePrivateChannelMembers)
+		require.True(t, hasPermission)
+		require.False(t, isMember)
+
+		_, resp, err := otherTeamMemberClient.GetPostInfo(context.Background(), privatePostBasicUser.Id)
+		require.Error(t, err)
+		CheckNotFoundStatus(t, resp)
+	})
+
+	t.Run("DM post - Outsider is denied", func(t *testing.T) {
+		_, appErr := th.App.GetChannelMember(th.Context, dmChannel.Id, outsiderUser.Id)
+		require.NotNil(t, appErr)
+
+		_, resp, err := outsiderClient.GetPostInfo(context.Background(), dmPost.Id)
+		require.Error(t, err)
+		CheckNotFoundStatus(t, resp)
+	})
+
+	t.Run("GM post - Outsider is denied", func(t *testing.T) {
+		_, appErr := th.App.GetChannelMember(th.Context, gmChannel.Id, outsiderUser.Id)
+		require.NotNil(t, appErr)
+
+		_, resp, err := outsiderClient.GetPostInfo(context.Background(), gmPost.Id)
+		require.Error(t, err)
+		CheckNotFoundStatus(t, resp)
+	})
 }
 
 func TestAcknowledgePost(t *testing.T) {

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -3977,6 +3977,7 @@ func TestResetPassword(t *testing.T) {
 		return tokenErr == nil
 	}, 10*time.Second, 500*time.Millisecond, "Recovery token not found (%s)", recoveryTokenString)
 
+	newPwd := model.NewTestPassword()
 	resp, err := th.Client.ResetPassword(context.Background(), recoveryToken.Token, "")
 	require.Error(t, err)
 	CheckBadRequestStatus(t, resp)
@@ -3993,16 +3994,16 @@ func TestResetPassword(t *testing.T) {
 	for range model.TokenSize {
 		code.WriteString("a")
 	}
-	resp, err = th.Client.ResetPassword(context.Background(), code.String(), "newpasswd")
+	resp, err = th.Client.ResetPassword(context.Background(), code.String(), newPwd)
 	require.Error(t, err)
 	CheckBadRequestStatus(t, resp)
-	_, err = th.Client.ResetPassword(context.Background(), recoveryToken.Token, "newpasswd")
+	_, err = th.Client.ResetPassword(context.Background(), recoveryToken.Token, newPwd)
 	require.NoError(t, err)
-	_, _, err = th.Client.Login(context.Background(), user.Email, "newpasswd")
+	_, _, err = th.Client.Login(context.Background(), user.Email, newPwd)
 	require.NoError(t, err)
 	_, err = th.Client.Logout(context.Background())
 	require.NoError(t, err)
-	resp, err = th.Client.ResetPassword(context.Background(), recoveryToken.Token, "newpasswd")
+	resp, err = th.Client.ResetPassword(context.Background(), recoveryToken.Token, newPwd)
 	require.Error(t, err)
 	CheckBadRequestStatus(t, resp)
 	authData := model.NewId()
@@ -4032,7 +4033,7 @@ func TestResetPasswordAuditDoesNotLeakToken(t *testing.T) {
 		_ = th.App.Srv().Store().Token().Delete(token.Token)
 	}()
 
-	_, err = th.Client.ResetPassword(context.Background(), token.Token, "newPassword1!")
+	_, err = th.Client.ResetPassword(context.Background(), token.Token, model.NewTestPassword())
 	require.NoError(t, err)
 
 	audits, appErr := th.App.GetAudits(request.EmptyContext(th.TestLogger), "", 100)

--- a/server/channels/app/shared_channel_test.go
+++ b/server/channels/app/shared_channel_test.go
@@ -1334,7 +1334,7 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsg(t *testing.T) {
 		remoteUser := &model.User{
 			Email:    model.NewId() + "@remote.test",
 			Username: "remote-attach-" + model.NewId()[:8],
-			Password: "Password1!",
+			Password: model.NewTestPassword(),
 			RemoteId: model.NewPointer(rc.RemoteId),
 		}
 		remoteUser, appErr := th.App.CreateUser(th.Context, remoteUser)
@@ -1409,7 +1409,7 @@ func TestPluginAPIReceiveSharedChannelProfileImageSyncMsg(t *testing.T) {
 		remoteUser := &model.User{
 			Email:    model.NewId() + "@remote.test",
 			Username: "remote-img-" + model.NewId()[:8],
-			Password: "Password1!",
+			Password: model.NewTestPassword(),
 			RemoteId: model.NewPointer(rc.RemoteId),
 		}
 		remoteUser, appErr := th.App.CreateUser(th.Context, remoteUser)

--- a/webapp/channels/src/components/channel_view/channel_view.tsx
+++ b/webapp/channels/src/components/channel_view/channel_view.tsx
@@ -219,8 +219,8 @@ export default class ChannelView extends React.PureComponent<Props, State> {
                     id={DropOverlayIdCenterChannel}
                 />
                 <ChannelHeader/>
-                {this.props.isChannelBookmarksEnabled && <ChannelBookmarks channelId={this.props.channelId}/>}
                 <ChannelBanner channelId={this.props.channelId}/>
+                {this.props.isChannelBookmarksEnabled && <ChannelBookmarks channelId={this.props.channelId}/>}
                 <DeferredPostView
                     channelId={this.props.channelId}
                     focusedPostId={this.state.focusedPostId}


### PR DESCRIPTION
2026-04-24 upstream 커밋 5건을 선별 반영했다. 04-24 항목은 전부 소진됐다.

## 반영 커밋

- [MM-68231] Tighten post info authorization (#36111) — 보안 수정
- Fix FIPS test failures by using model.NewTestPassword() for short passwords (#36262)
- Reorder channel banner (#36268)

`getPostInfo`가 직접 짠 권한 로직(공개 채널이면 무조건 허용, 비공개는 `manage_private_channel_members`로 판정)을 표준 읽기 경로 `SessionHasPermissionToReadChannel`로 교체한다. 공개 채널 발견성은 유지하되 컴플라이언스 모드가 켜져 있으면 미가입 공개 채널의 게시물 정보 노출을 차단하고, 팀 가입 권한(`join_public_channels`/`join_public_teams`)을 실제로 확인한다.

## 제외

- `9c684e63` Property System v2 Generic APIs blacklist (#36171) — 제외한 48f2fd08(Integrated Boards MVP)의 property 시스템 v2 위에 얹힌 변경. 핵심 파일 `server/channels/api4/properties.go`가 부재하고, 우리 `model.PropertyGroup`은 `ID`·`Name` 2필드뿐이라 `Version`이 없다. `RegisterPropertyGroup` 시그니처도 다르고(`name string` vs `*model.PropertyGroup`), 마이그레이션 000170을 얹는데 우리 최신은 000164라 165~169가 빈다. 48f2fd08 계보 8번째.
- `5817a6d6` Simplify PULL_REQUEST_TEMPLATE.md and document it in AGENTS.md (#36239) — 두 파일 모두 우리가 자체 대체했다. PR 템플릿은 9609b9a89d·b0398f4fb3에서 한국어로 번역하고 OKR.BEST로 리브랜드했으므로 upstream 영문 문안을 그대로 넣으면 리브랜드가 되돌아간다(constitution 원칙 IV). AGENTS.md는 upstream 것이 `make bump-enterprise` 안내 11줄인 반면 우리 것은 spec-kit + superpowers 워크플로 문서라 새 절을 덧붙일 위치 자체가 없다.

## 검증

품질 게이트는 모두 master 기준선과 실패 목록이 동일하다(신규 실패 0건).

| 게이트 | master | 이 브랜치 |
|---|---|---|
| `server make check-style` | 16건 | 16건 |
| `webapp npm run check` | 46개 파일 | 46개 파일 |
| `webapp npm run check-types` | 29건 | 29건 |
| `webapp i18n-check-empty` | 통과 | 통과 |

커밋 단위 테스트 — `TestPostGetInfo` 23개 서브테스트 통과(신규 회귀 테스트 5건 포함: 컴플라이언스 모드 거부 2건, 비공개 채널 권한 경계, DM/GM 외부인 거부), 공유 채널 플러그인 API 2건, `channel_view` 5건 통과.

미반영 커밋 757건 남음. 마지막 반영 커밋은 `9eb070b7`(2026-04-24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)