### PR TITLE
upstream sync 2026-04-28 (picked 7, adapted 2, excluded 1)

### DIFF
--- a/docs/upstream-master-unmerged-commits.md
+++ b/docs/upstream-master-unmerged-commits.md
@@ -3,24 +3,14 @@
 `HEAD`에 반영되지 않은 `upstream-master`(mattermost/mattermost) 커밋 목록 (오래된 순).
 `/speckit-sync` 스킬이 이 목록을 갱신·소비한다. 반영 완료된 커밋은 목록에서 제거된다.
 
-- 갱신일: 2026-08-20 12:25
+- 갱신일: 2026-08-20 14:23
 - 기준: `git log HEAD..upstream-master` − 처리 완료(cherry-pick/adapt 커밋 본문의 upstream 참조, 하단 부록의 제외·spec 전환)
-- 남은 커밋: 750개
+- 남은 커밋: 740개
 
-**마지막 반영 커밋:** `016e2fd6` | [ci: compile mmctl e2e tests with requirefips when FIPS_ENABLED=true (#36267)](https://github.com/mattermost/mattermost/commit/016e2fd6fbfea9b8f13cc62d3c6b088bc8d2bb79) | 2026-04-27
+**마지막 반영 커밋:** `85dc0851` | [\[MM-68535\] Invalidate channel cache after policy assignment (#36292)](https://github.com/mattermost/mattermost/commit/85dc0851972483cff74fd0c01c64a922b31cf25e) | 2026-04-28
 
 | 커밋 해시 | 커밋 제목 | 커밋 일자 |
 |---|---|---|
-| 45ec78b5 | [\[MM-68457\] Expose audit logging API via pluginapi.Client (#36232)](https://github.com/mattermost/mattermost/commit/45ec78b595427a115dcfbd19fe00ca50ede9d18c) | 2026-04-28 |
-| 81d4fe37 | [MM-68339: Add XML struct tags and multi-remote registration for shared channels plugin API  (#36126)](https://github.com/mattermost/mattermost/commit/81d4fe37938436d8e971aaa418c0b71519acd54f) | 2026-04-28 |
-| 2283b51b | [MM-67974: Add disk space info to Support Packet for local file store (#36300)](https://github.com/mattermost/mattermost/commit/2283b51b0e1f625c825706b30de7f94af2013c9e) | 2026-04-28 |
-| 5c43e4b1 | [\[MM-68459\] Implement dictionary style end user indicators for membership policies (#36240)](https://github.com/mattermost/mattermost/commit/5c43e4b15fbac964ee2301ee94f7acbca1369e58) | 2026-04-28 |
-| c85601dc | [\[MM-67979\] \[MM-67980\] Add SMTP and push proxy connectivity status to support packet diagnostics (#35837)](https://github.com/mattermost/mattermost/commit/c85601dc7fcad9ded56ee490b5c71dc5ab454cc6) | 2026-04-28 |
-| bd8fc922 | [MM-68526: Harden remote cluster patch response (#36288)](https://github.com/mattermost/mattermost/commit/bd8fc92226726da06c8fabaef568cc9ebaee1cb8) | 2026-04-28 |
-| c79c3831 | [MM-68264: return error on bot username conflict (#36064)](https://github.com/mattermost/mattermost/commit/c79c3831061a0880c0962c7d567c9e24dd35f44c) | 2026-04-28 |
-| fdaea9de | [MM-68339: slugify RemoteCluster.Name in plugin registration (#36309)](https://github.com/mattermost/mattermost/commit/fdaea9dec316d6a10014b7010f3558675e300490) | 2026-04-28 |
-| 2b7b398a | [\[MM-68102\] Add Classification Markings admin console page (#35934)](https://github.com/mattermost/mattermost/commit/2b7b398a2225d166cfe6eb7b6796d037c0dcef87) | 2026-04-28 |
-| 85dc0851 | [\[MM-68535\] Invalidate channel cache after policy assignment (#36292)](https://github.com/mattermost/mattermost/commit/85dc0851972483cff74fd0c01c64a922b31cf25e) | 2026-04-28 |
 | 320383d8 | [MM-67326 - add channel settings abac e2e (#36277)](https://github.com/mattermost/mattermost/commit/320383d8947691196695b88cbe5da3118dd17794) | 2026-04-29 |
 | f275a339 | [MM-67913: fix white flash on product navigation by centralizing app__body ownership (#36186)](https://github.com/mattermost/mattermost/commit/f275a339676ec8d19c914bba24fc649a1c858ee8) | 2026-04-29 |
 | 641d5a4e | [\[MM-68538\] Wrap incoming query from the CEL -> SQL conversion with parentheses (#36293)](https://github.com/mattermost/mattermost/commit/641d5a4eb7faa8037f9050b926800a875e8927e0) | 2026-04-29 |
@@ -866,6 +856,8 @@
 | 1af7d823 | [Remove AGENTS.CLOUD.md (#36286)](https://github.com/mattermost/mattermost/commit/1af7d823ded361df5ace499e2dc55ce2de8f3bce) | 도입 커밋 5ddd76ec(Development environment setup #35513)를 이미 제외했으므로 삭제 커밋도 대칭 제외 — okrbest는 AGENTS.CLOUD.md를 가진 적이 없어 지울 대상이 없다(ls 확인, 우리 히스토리에 해당 파일 추가·삭제 기록 0건). merge-tree가 CLEAN으로 나오는 것은 '이미 삭제된 상태'라 충돌이 없다는 뜻이고, cherry-pick하면 빈 커밋이 된다. 원본 파일은 Mattermost Inc. 내부 Cursor Cloud 전용 개발 환경 문서로 비공개 mattermost/enterprise·mattermost-plugin-agents 저장소와 CURSOR_GH_TOKEN/TEST_LICENSE 내부 시크릿을 전제로 해 적용 불가였고, 5ddd76ec 제외 사유에 '후속 커밋 1af7d823(#36286)에서 upstream이 스스로 제거함'을 이미 근거로 기록해 뒀다. 같은 계열 ac9d99bd(#35534, agent-browser 스킬)도 제외 상태. 우리 트리 상태(파일 없음)가 이미 upstream 최종 상태와 동일하다. |
 
 | 6103e95b | [ci: resolve enterprise branch from mattermost merge-base time (#36245)](https://github.com/mattermost/mattermost/commit/6103e95b79a51bc4e52857d09c5a279e7a9ab978) | upstream 자신의 revert 커밋인데 되돌릴 대상을 우리가 이미 제외해 적용할 내용이 0이다 — 이 커밋은 23ab604b(#35957 ci: pin enterprise repo to explicit commit hash)와 b63e3205(#36200 docs: document enterprise.pin workflow in root AGENTS.md)를 revert하고 enterprise 브랜치를 mattermost merge-base 시각으로 해석하는 방식으로 선회하는 것인데, 그 두 커밋 모두 이미 제외 상태(ledger 850·860·899행). 세 변경 전부 대상 부재 — (1) enterprise.pin 파일 없음(ls 실패), (2) server/Makefile에 bump-enterprise grep 0건이고 .PHONY도 all·bump-enterprise 없이 build로 시작, (3) 우리 AGENTS.md에 enterprise.pin 절 없음. AGENTS.md는 merge-tree content CONFLICT — 우리 것은 spec-kit + superpowers 결합 워크플로 문서라 upstream 원문(enterprise.pin 안내 + Pull Requests 절)과 공통 기반이 없다. 같은 사유로 5817a6d6(#36239)도 제외 상태(ledger 868행). cherry-pick 강행 시 우리 자체 AGENTS.md가 upstream 문서로 오염된다. 우리 트리 상태가 이미 upstream의 revert 후 상태와 동일하다. 도입 커밋 제외 → 삭제 커밋도 대칭 제외로, 1af7d823(AGENTS.CLOUD.md 삭제)과 같은 구조. 향후 okrbest가 자체 비공개 모듈 저장소와 핀 고정 체계를 갖추면 23ab604b와 함께 재검토한다. |
+
+| 2b7b398a | [\[MM-68102\] Add Classification Markings admin console page (#35934)](https://github.com/mattermost/mattermost/commit/2b7b398a2225d166cfe6eb7b6796d037c0dcef87) | 제외한 48f2fd08(Integrated Boards MVP, #35796)의 property 시스템 v2 위에 얹힌 신규 기능이라 반영할 토대가 없음 — 006f1027·3cb00848·01219efb·3fa87760·7627784a·9d33d87e·9c684e63·5b4efbd2에 이은 48f2fd08 계보 10번째. 시스템 콘솔에 분류 표시(Classification Markings) 관리 페이지를 신설해 보안 등급을 이름·색상·프리셋으로 관리하는 기능인데, 등급 데이터를 PropertyField/PropertyValue로 저장하므로 property 시스템 v2가 전제다. 필요한 선행 요소가 전부 부재 — (1) 핵심 파일 server/channels/api4/properties.go와 properties_test.go가 우리 트리에 아예 없음(ls 실패, merge-tree modify/delete CONFLICT 2건), (2) 이 커밋의 서버 변경 2줄이 property CRUD 라우트 게이트를 FeatureFlags.IntegratedBoards → IntegratedBoards \|\| ClassificationMarkings로 넓히는 것인데 우리에겐 그 라우트 자체가 없음, (3) 우리 webapp PropertyField 타입은 id/group_id/name/type/attrs/target_id/target_type/create_at/update_at/delete_at 10필드뿐이라 upstream이 쓰는 object_type이 없고 이 커밋이 추가하는 linked_field_id는 제외한 3fa87760(Linked Properties) 소산, (4) 커밋이 호출하는 client4의 createPropertyField/patchPropertyField/deletePropertyField가 전부 objectType 인자를 받는 v2 시그니처라 client4.ts content CONFLICT. 규모도 32파일 +2845/-10에 i18n 신규 키 28개, 신규 feature flag ClassificationMarkings 포함. 강행 시 서버는 없는 파일 수정 실패, 웹앱은 object_type 미정의로 타입 체크 실패, 런타임엔 없는 엔드포인트 404. upstream 기준으로도 ClassificationMarkings 플래그 뒤에 숨어 기본 비활성이라 당장의 제품 공백 아님. 우리 Boards는 focalboard 기반 자체 플러그인(okrbest-plugin-boards, BlockProp 모델)이 담당하고 Mattermost property API를 호출하지 않는다. 분류 표시 기능이 필요해지면 48f2fd08의 property 절반(api4/properties.go, PropertyField.object_type, 마이그레이션 000160~000165) 분할 반영을 선행 과제로 두고 그때 spec으로 여는 것이 맞다. |
 
 ## spec 전환 커밋
 

--- a/server/channels/api4/access_control_test.go
+++ b/server/channels/api4/access_control_test.go
@@ -435,6 +435,15 @@ func TestDeleteAccessControlPolicy(t *testing.T) {
 
 		mockAccessControlService := &mocks.AccessControlServiceInterface{}
 		th.App.Srv().Channels().AccessControl = mockAccessControlService
+		// DeleteAccessControlPolicy resolves the policy first to decide
+		// whether to broadcast a channel access control update; return a
+		// parent policy so the channel-update path is not exercised here.
+		parentPolicy := &model.AccessControlPolicy{
+			ID:      samplePolicyID,
+			Type:    model.AccessControlPolicyTypeParent,
+			Version: model.AccessControlPolicyVersionV0_3,
+		}
+		mockAccessControlService.On("GetPolicy", mock.AnythingOfType("*request.Context"), samplePolicyID).Return(parentPolicy, nil).Times(1)
 		mockAccessControlService.On("DeletePolicy", mock.AnythingOfType("*request.Context"), samplePolicyID).Return(nil).Times(1)
 
 		th.App.UpdateConfig(func(cfg *model.Config) {

--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -2951,7 +2951,11 @@ func getChannelAccessControlAttributes(c *Context, w http.ResponseWriter, r *htt
 		return
 	}
 
-	attributes, err := c.App.GetAccessControlPolicyAttributes(c.AppContext, c.Params.ChannelId, "*")
+	// Channel banners care about the membership rule — the attributes that
+	// determine who can be in the channel. Since the v0.3 migration stores the
+	// action as "membership" rather than "*", ask for it explicitly; the
+	// wildcard fallback in GetRule still covers older policies that kept "*".
+	attributes, err := c.App.GetAccessControlPolicyAttributes(c.AppContext, c.Params.ChannelId, model.AccessControlPolicyActionMembership)
 	if err != nil {
 		c.Err = err
 		return

--- a/server/channels/api4/remote_cluster.go
+++ b/server/channels/api4/remote_cluster.go
@@ -660,6 +660,8 @@ func patchRemoteCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	updatedRC.Sanitize()
+
 	auditRec.Success()
 	auditRec.AddEventResultState(updatedRC)
 

--- a/server/channels/api4/remote_cluster_test.go
+++ b/server/channels/api4/remote_cluster_test.go
@@ -545,9 +545,10 @@ func TestGenerateRemoteClusterInvite(t *testing.T) {
 func TestGetRemoteCluster(t *testing.T) {
 	mainHelper.Parallel(t)
 	newRC := &model.RemoteCluster{
-		Name:    "remotecluster",
-		SiteURL: "http://example.com",
-		Token:   model.NewId(),
+		Name:        "remotecluster",
+		SiteURL:     "http://example.com",
+		Token:       model.NewId(),
+		RemoteToken: model.NewId(),
 	}
 
 	t.Run("Should not work if the remote cluster service is not enabled", func(t *testing.T) {
@@ -596,6 +597,7 @@ func TestGetRemoteCluster(t *testing.T) {
 		require.Equal(t, rc.RemoteId, fetchedRC.RemoteId)
 		require.Equal(t, th.BasicTeam.Id, fetchedRC.DefaultTeamId)
 		require.Empty(t, fetchedRC.Token)
+		require.Empty(t, fetchedRC.RemoteToken)
 	})
 }
 
@@ -646,6 +648,7 @@ func TestPatchRemoteCluster(t *testing.T) {
 		DisplayName: "initialvalue",
 		SiteURL:     "http://example.com",
 		Token:       model.NewId(),
+		RemoteToken: model.NewId(),
 	}
 
 	rcp := &model.RemoteClusterPatch{DisplayName: model.NewPointer("different value")}
@@ -699,6 +702,8 @@ func TestPatchRemoteCluster(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "patched!", patchedRC.DisplayName)
 		require.Equal(t, newTeamId, patchedRC.DefaultTeamId)
+		require.Empty(t, patchedRC.Token)
+		require.Empty(t, patchedRC.RemoteToken)
 	})
 }
 

--- a/server/channels/app/access_control.go
+++ b/server/channels/app/access_control.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"slices"
@@ -16,6 +17,7 @@ import (
 )
 
 const attributeViewRefreshInterval = 30 * time.Second
+const accessControlChildPolicySearchLimit = 1000
 
 func (a *App) GetChannelsForPolicy(rctx request.CTX, policyID string, cursor model.AccessControlPolicyCursor, limit int) ([]*model.ChannelWithTeamData, int64, *model.AppError) {
 	policy, appErr := a.GetAccessControlPolicy(rctx, policyID)
@@ -99,6 +101,13 @@ func (a *App) CreateOrUpdateAccessControlPolicy(rctx request.CTX, policy *model.
 		return nil, appErr
 	}
 
+	switch policy.Type {
+	case model.AccessControlPolicyTypeChannel:
+		a.publishChannelPolicyEnforcedUpdate(rctx, policy.ID)
+	case model.AccessControlPolicyTypeParent:
+		a.publishChannelPolicyEnforcedForChannelPoliciesWithImport(rctx, policy.ID)
+	}
+
 	return policy, nil
 }
 
@@ -108,9 +117,27 @@ func (a *App) DeleteAccessControlPolicy(rctx request.CTX, id string) *model.AppE
 		return model.NewAppError("DeleteAccessControlPolicy", "app.pap.delete_access_control_policy.app_error", nil, "Policy Administration Point is not initialized", http.StatusNotImplemented)
 	}
 
-	appErr := acs.DeletePolicy(rctx, id)
+	// Resolve the policy first so we know whether to broadcast a channel
+	// access control update after deletion (channel-type policies share the
+	// channel's ID, so we can use the policy ID as the channel ID).
+	policy, appErr := acs.GetPolicy(rctx, id)
 	if appErr != nil {
 		return appErr
+	}
+
+	var affectedChannelIDs []string
+	if policy != nil && policy.Type != model.AccessControlPolicyTypeChannel {
+		affectedChannelIDs = a.channelPolicyIDsWithImport(rctx, id)
+	}
+
+	if appErr := acs.DeletePolicy(rctx, id); appErr != nil {
+		return appErr
+	}
+
+	if policy != nil && policy.Type == model.AccessControlPolicyTypeChannel {
+		a.publishChannelPolicyEnforcedUpdate(rctx, id)
+	} else if policy.Type == model.AccessControlPolicyTypeParent {
+		a.publishChannelPolicyEnforcedUpdatesForChannels(rctx, affectedChannelIDs)
 	}
 
 	return nil
@@ -194,6 +221,7 @@ func (a *App) AssignAccessControlPolicyToChannels(rctx request.CTX, parentID str
 		if appErr != nil {
 			return nil, appErr
 		}
+		a.publishChannelPolicyEnforcedUpdate(rctx, child.ID)
 		policies = append(policies, child)
 	}
 
@@ -239,14 +267,15 @@ func (a *App) UnassignPoliciesFromChannels(rctx request.CTX, policyID string, ch
 			if err := acs.DeletePolicy(rctx, child.ID); err != nil {
 				return model.NewAppError("UnassignPoliciesFromChannels", "app.pap.unassign_access_control_policy_from_channels.app_error", nil, err.Error(), http.StatusInternalServerError)
 			}
-			// invalidate the channel cache
-			a.Srv().Store().Channel().InvalidateChannel(channelID)
+			// invalidate the channel cache and broadcast the policy change
+			a.publishChannelPolicyEnforcedUpdate(rctx, channelID)
 			continue
 		}
 		_, appErr = acs.SavePolicy(rctx, child)
 		if appErr != nil {
 			return model.NewAppError("UnassignPoliciesFromChannels", "app.pap.unassign_access_control_policy_from_channels.app_error", nil, appErr.Error(), http.StatusInternalServerError)
 		}
+		a.publishChannelPolicyEnforcedUpdate(rctx, channelID)
 	}
 
 	return nil
@@ -325,6 +354,14 @@ func (a *App) UpdateAccessControlPoliciesActive(rctx request.CTX, updates []mode
 	if err != nil {
 		return nil, model.NewAppError("UpdateAccessControlPoliciesActive", "app.pap.update_access_control_policies_active.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
+
+	for _, policy := range policies {
+		// only channel policies use the active state
+		if policy.Type == model.AccessControlPolicyTypeChannel {
+			a.publishChannelPolicyEnforcedUpdate(rctx, policy.ID)
+		}
+	}
+
 	return policies, nil
 }
 
@@ -340,6 +377,90 @@ func (a *App) ExpressionToVisualAST(rctx request.CTX, expression string) (*model
 	}
 
 	return visualAST, nil
+}
+
+// publishChannelPolicyEnforcedForChannelPoliciesWithImport broadcasts
+// channel_access_control_updated for every channel-type policy that lists
+// importID in its imports. Call only after the imported policy (parent,
+// permission, etc.) is persisted.
+func (a *App) publishChannelPolicyEnforcedForChannelPoliciesWithImport(rctx request.CTX, importID string) {
+	a.publishChannelPolicyEnforcedUpdatesForChannels(rctx, a.channelPolicyIDsWithImport(rctx, importID))
+}
+
+func (a *App) publishChannelPolicyEnforcedUpdatesForChannels(rctx request.CTX, channelIDs []string) {
+	seen := make(map[string]struct{}, len(channelIDs))
+	for _, channelID := range channelIDs {
+		if channelID == "" {
+			continue
+		}
+		if _, ok := seen[channelID]; ok {
+			continue
+		}
+		seen[channelID] = struct{}{}
+		a.publishChannelPolicyEnforcedUpdate(rctx, channelID)
+	}
+}
+
+func (a *App) channelPolicyIDsWithImport(rctx request.CTX, importID string) []string {
+	channelIDs := []string{}
+	var cursor model.AccessControlPolicyCursor
+	for {
+		children, _, err := a.Srv().Store().AccessControlPolicy().SearchPolicies(rctx, model.AccessControlPolicySearch{
+			Type:     model.AccessControlPolicyTypeChannel,
+			ParentID: importID,
+			Cursor:   cursor,
+			Limit:    accessControlChildPolicySearchLimit,
+		})
+		if err != nil {
+			rctx.Logger().Warn("Failed to list channel policies that import a policy; skipping channel access control fan-out",
+				mlog.String("imported_policy_id", importID),
+				mlog.Err(err),
+			)
+			return channelIDs
+		}
+		for _, child := range children {
+			channelIDs = append(channelIDs, child.ID)
+		}
+		if len(children) < accessControlChildPolicySearchLimit {
+			break
+		}
+		cursor.ID = children[len(children)-1].ID
+	}
+	return channelIDs
+}
+
+// publishChannelPolicyEnforcedUpdate invalidates the channel cache for the
+// given channel ID and broadcasts a channel_access_control_updated websocket
+// event so that connected clients can refresh their view of the channel's
+// access control state (e.g. the policy_enforced flag and the set of
+// attributes used by the policy). A dedicated event is used rather than
+// channel_updated because this is fired on every policy mutation and clients
+// only need to refresh access control state — not run the full
+// channel_updated reducer/router pipeline.
+func (a *App) publishChannelPolicyEnforcedUpdate(rctx request.CTX, channelID string) {
+	a.Srv().Store().Channel().InvalidateChannel(channelID)
+
+	channel, appErr := a.GetChannel(rctx, channelID)
+	if appErr != nil {
+		rctx.Logger().Warn("Failed to load channel after access control policy change",
+			mlog.String("channel_id", channelID),
+			mlog.Err(appErr),
+		)
+		return
+	}
+
+	channelJSON, jsonErr := json.Marshal(channel)
+	if jsonErr != nil {
+		rctx.Logger().Warn("Failed to marshal channel after access control policy change",
+			mlog.String("channel_id", channelID),
+			mlog.Err(jsonErr),
+		)
+		return
+	}
+
+	messageWs := model.NewWebSocketEvent(model.WebsocketEventChannelAccessControlUpdated, "", channel.Id, "", nil, "")
+	messageWs.Add("channel", string(channelJSON))
+	a.Publish(messageWs)
 }
 
 // ValidateChannelEligibilityForAccessControl checks that a channel is eligible for

--- a/server/channels/app/access_control_test.go
+++ b/server/channels/app/access_control_test.go
@@ -105,6 +105,213 @@ func TestCreateOrUpdateAccessControlPolicy(t *testing.T) {
 		require.NotNil(t, result)
 		mockAccessControl.AssertExpectations(t)
 	})
+
+	t.Run("Channel-type policy broadcasts policy enforced update", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+
+		channelID := model.NewId()
+		channelPolicy := &model.AccessControlPolicy{
+			ID:   channelID,
+			Type: model.AccessControlPolicyTypeChannel,
+			Rules: []model.AccessControlPolicyRule{
+				{Actions: []string{model.AccessControlPolicyActionMembership}, Expression: "true"},
+			},
+		}
+
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore)
+		// publishChannelPolicyEnforcedUpdate is expected to invalidate the
+		// channel cache and reload the channel for the WS payload.
+		mockChannelStore.On("InvalidateChannel", channelID).Once()
+		mockChannelStore.On("Get", channelID, true).Return(&model.Channel{Id: channelID, Type: model.ChannelTypePrivate}, nil).Once()
+
+		mockAccessControl := &mocks.AccessControlServiceInterface{}
+		thMock.App.Srv().ch.AccessControl = mockAccessControl
+		mockAccessControl.On("SavePolicy", thMock.Context, mock.MatchedBy(func(p *model.AccessControlPolicy) bool {
+			return p.ID == channelID && p.Type == model.AccessControlPolicyTypeChannel
+		})).Return(channelPolicy, nil).Once()
+
+		result, err := thMock.App.CreateOrUpdateAccessControlPolicy(thMock.Context, channelPolicy)
+		require.Nil(t, err)
+		require.NotNil(t, result)
+
+		mockAccessControl.AssertExpectations(t)
+		mockChannelStore.AssertCalled(t, "InvalidateChannel", channelID)
+		mockChannelStore.AssertCalled(t, "Get", channelID, true)
+	})
+
+	t.Run("Parent-type policy does not broadcast channel-only update", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+
+		parentID := model.NewId()
+		parentPolicy := &model.AccessControlPolicy{
+			ID:   parentID,
+			Type: model.AccessControlPolicyTypeParent,
+			Name: "parent-no-broadcast",
+			Rules: []model.AccessControlPolicyRule{
+				{Actions: []string{model.AccessControlPolicyActionMembership}, Expression: "true"},
+			},
+		}
+
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore).Maybe()
+
+		// publishChannelPolicyEnforcedForChannelPoliciesWithImport iterates
+		// over child channel policies; with no children there is no fan-out
+		// to channel cache invalidation.
+		mockACPStore := storemocks.AccessControlPolicyStore{}
+		mockStore.On("AccessControlPolicy").Return(&mockACPStore)
+		mockACPStore.On("SearchPolicies", thMock.Context, mock.MatchedBy(func(s model.AccessControlPolicySearch) bool {
+			return s.Type == model.AccessControlPolicyTypeChannel && s.ParentID == parentID
+		})).Return([]*model.AccessControlPolicy{}, int64(0), nil)
+
+		mockAccessControl := &mocks.AccessControlServiceInterface{}
+		thMock.App.Srv().ch.AccessControl = mockAccessControl
+		mockAccessControl.On("SavePolicy", thMock.Context, mock.Anything).Return(parentPolicy, nil).Once()
+
+		result, err := thMock.App.CreateOrUpdateAccessControlPolicy(thMock.Context, parentPolicy)
+		require.Nil(t, err)
+		require.NotNil(t, result)
+
+		mockChannelStore.AssertNotCalled(t, "InvalidateChannel", mock.Anything)
+		mockChannelStore.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
+	})
+}
+
+func TestDeleteAccessControlPolicy(t *testing.T) {
+	t.Run("Feature not enabled", func(t *testing.T) {
+		th := Setup(t).InitBasic(t)
+		th.App.Srv().ch.AccessControl = nil
+
+		appErr := th.App.DeleteAccessControlPolicy(th.Context, model.NewId())
+		require.NotNil(t, appErr)
+		require.Equal(t, http.StatusNotImplemented, appErr.StatusCode)
+	})
+
+	t.Run("GetPolicy error is propagated", func(t *testing.T) {
+		th := Setup(t).InitBasic(t)
+
+		policyID := model.NewId()
+		mockAccessControl := &mocks.AccessControlServiceInterface{}
+		th.App.Srv().ch.AccessControl = mockAccessControl
+		expectedErr := model.NewAppError("GetPolicy", "app.pap.get_policy.app_error", nil, "boom", http.StatusInternalServerError)
+		mockAccessControl.On("GetPolicy", th.Context, policyID).Return(nil, expectedErr).Once()
+
+		appErr := th.App.DeleteAccessControlPolicy(th.Context, policyID)
+		require.NotNil(t, appErr)
+		require.Equal(t, expectedErr.Id, appErr.Id)
+		mockAccessControl.AssertNotCalled(t, "DeletePolicy", mock.Anything, mock.Anything)
+	})
+
+	t.Run("Channel-type policy invalidates cache and broadcasts update", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+
+		channelID := model.NewId()
+		channelPolicy := &model.AccessControlPolicy{
+			ID:      channelID,
+			Type:    model.AccessControlPolicyTypeChannel,
+			Version: model.AccessControlPolicyVersionV0_3,
+			Rules: []model.AccessControlPolicyRule{
+				{Actions: []string{model.AccessControlPolicyActionMembership}, Expression: "true"},
+			},
+		}
+
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore)
+		// publishChannelPolicyEnforcedUpdate must invalidate the channel
+		// cache and reload the channel for the WS payload.
+		mockChannelStore.On("InvalidateChannel", channelID).Once()
+		mockChannelStore.On("Get", channelID, true).Return(&model.Channel{Id: channelID, Type: model.ChannelTypePrivate}, nil).Once()
+
+		// channel-type policies must NOT trigger a parent fan-out search.
+		mockACPStore := storemocks.AccessControlPolicyStore{}
+		mockStore.On("AccessControlPolicy").Return(&mockACPStore).Maybe()
+
+		mockAccessControl := &mocks.AccessControlServiceInterface{}
+		thMock.App.Srv().ch.AccessControl = mockAccessControl
+		mockAccessControl.On("GetPolicy", thMock.Context, channelID).Return(channelPolicy, nil).Once()
+		mockAccessControl.On("DeletePolicy", thMock.Context, channelID).Return(nil).Once()
+
+		appErr := thMock.App.DeleteAccessControlPolicy(thMock.Context, channelID)
+		require.Nil(t, appErr)
+
+		mockAccessControl.AssertExpectations(t)
+		mockChannelStore.AssertCalled(t, "InvalidateChannel", channelID)
+		mockChannelStore.AssertCalled(t, "Get", channelID, true)
+		mockACPStore.AssertNotCalled(t, "SearchPolicies", mock.Anything, mock.Anything)
+	})
+
+	t.Run("Parent-type policy fans out to all child channels", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+
+		parentID := model.NewId()
+		childChannelID := model.NewId()
+
+		parentPolicy := &model.AccessControlPolicy{
+			ID:      parentID,
+			Type:    model.AccessControlPolicyTypeParent,
+			Name:    "parent-broadcast",
+			Version: model.AccessControlPolicyVersionV0_3,
+		}
+
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore)
+		// One affected child channel must have its cache invalidated and be reloaded.
+		mockChannelStore.On("InvalidateChannel", childChannelID).Once()
+		mockChannelStore.On("Get", childChannelID, true).Return(&model.Channel{Id: childChannelID, Type: model.ChannelTypePrivate}, nil).Once()
+
+		mockACPStore := storemocks.AccessControlPolicyStore{}
+		mockStore.On("AccessControlPolicy").Return(&mockACPStore)
+		// channelPolicyIDsWithImport (called pre-delete) returns one child.
+		mockACPStore.On("SearchPolicies", thMock.Context, mock.MatchedBy(func(s model.AccessControlPolicySearch) bool {
+			return s.Type == model.AccessControlPolicyTypeChannel && s.ParentID == parentID
+		})).Return([]*model.AccessControlPolicy{{ID: childChannelID, Type: model.AccessControlPolicyTypeChannel}}, int64(1), nil).Once()
+
+		mockAccessControl := &mocks.AccessControlServiceInterface{}
+		thMock.App.Srv().ch.AccessControl = mockAccessControl
+		mockAccessControl.On("GetPolicy", thMock.Context, parentID).Return(parentPolicy, nil).Once()
+		mockAccessControl.On("DeletePolicy", thMock.Context, parentID).Return(nil).Once()
+
+		appErr := thMock.App.DeleteAccessControlPolicy(thMock.Context, parentID)
+		require.Nil(t, appErr)
+
+		mockAccessControl.AssertExpectations(t)
+		mockChannelStore.AssertCalled(t, "InvalidateChannel", childChannelID)
+		mockChannelStore.AssertCalled(t, "Get", childChannelID, true)
+	})
+
+	t.Run("Channel-type policy: DeletePolicy error short-circuits broadcast", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+
+		channelID := model.NewId()
+		channelPolicy := &model.AccessControlPolicy{
+			ID:      channelID,
+			Type:    model.AccessControlPolicyTypeChannel,
+			Version: model.AccessControlPolicyVersionV0_3,
+		}
+
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore).Maybe()
+
+		mockAccessControl := &mocks.AccessControlServiceInterface{}
+		thMock.App.Srv().ch.AccessControl = mockAccessControl
+		mockAccessControl.On("GetPolicy", thMock.Context, channelID).Return(channelPolicy, nil).Once()
+		expectedErr := model.NewAppError("DeletePolicy", "app.pap.delete.app_error", nil, "delete failed", http.StatusInternalServerError)
+		mockAccessControl.On("DeletePolicy", thMock.Context, channelID).Return(expectedErr).Once()
+
+		appErr := thMock.App.DeleteAccessControlPolicy(thMock.Context, channelID)
+		require.NotNil(t, appErr)
+		require.Equal(t, expectedErr.Id, appErr.Id)
+
+		// Broadcast must not happen if deletion failed.
+		mockChannelStore.AssertNotCalled(t, "InvalidateChannel", mock.Anything)
+		mockChannelStore.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
+	})
 }
 
 func TestGetChannelsForPolicy(t *testing.T) {
@@ -606,6 +813,9 @@ func TestUnassignPoliciesFromChannels(t *testing.T) {
 		mockStore.On("Channel").Return(&mockChannelStore)
 		// Expect InvalidateChannel to be called
 		mockChannelStore.On("InvalidateChannel", channelID).Once()
+		// publishChannelPolicyEnforcedUpdate calls Channel().Get(...) to load
+		// the fresh channel (with PolicyEnforced computed) for the WS payload.
+		mockChannelStore.On("Get", channelID, true).Return(&model.Channel{Id: channelID, Type: model.ChannelTypePrivate}, nil).Once()
 
 		mockAccessControl := &mocks.AccessControlServiceInterface{}
 		thMock.App.Srv().ch.AccessControl = mockAccessControl

--- a/server/channels/app/bot.go
+++ b/server/channels/app/bot.go
@@ -65,18 +65,19 @@ func (a *App) EnsureBot(rctx request.CTX, pluginID string, bot *model.Bot) (stri
 			if appErr := a.SetPluginKey(pluginID, botUserKey, []byte(user.Id)); appErr != nil {
 				return "", fmt.Errorf("failed to set plugin key: %w", appErr)
 			}
-		} else {
-			rctx.Logger().Error("Plugin attempted to use an account that already exists. Convert user to a bot "+
-				"account in the CLI by running 'mattermost user convert <username> --bot'. If the user is an "+
-				"existing user account you want to preserve, change its username and restart the Mattermost server, "+
-				"after which the plugin will create a bot account with that name. For more information about bot "+
-				"accounts, see https://mattermost.com/pl/default-bot-accounts", mlog.String("username",
-				bot.Username),
-				mlog.String("user_id",
-					user.Id),
-			)
+			return user.Id, nil
 		}
-		return user.Id, nil
+
+		rctx.Logger().Error("Plugin attempted to use an account that already exists. Convert user to a bot "+
+			"account in the CLI by running 'mattermost user convert <username> --bot'. If the user is an "+
+			"existing user account you want to preserve, change its username and restart the Mattermost server, "+
+			"after which the plugin will create a bot account with that name. For more information about bot "+
+			"accounts, see https://mattermost.com/pl/default-bot-accounts", mlog.String("username",
+			bot.Username),
+			mlog.String("user_id",
+				user.Id),
+		)
+		return "", fmt.Errorf("username %q is already taken by a non-bot user", bot.Username)
 	}
 
 	createdBot, err := a.CreateBot(rctx, bot)

--- a/server/channels/app/bot_test.go
+++ b/server/channels/app/bot_test.go
@@ -147,6 +147,22 @@ func TestEnsureBot(t *testing.T) {
 		assert.Equal(t, "another bot", bot.Description)
 	})
 
+	t.Run("ensure bot should fail if username belongs to a non-bot user", func(t *testing.T) {
+		th := Setup(t).InitBasic(t)
+
+		pluginId := "pluginId"
+
+		// th.BasicUser is a regular (non-bot) user created by InitBasic.
+		// EnsureBot must return an error — not the human user's ID.
+		botID, err := th.App.EnsureBot(th.Context, pluginId, &model.Bot{
+			Username:    th.BasicUser.Username,
+			Description: "a bot",
+			OwnerId:     th.BasicUser.Id,
+		})
+		require.Error(t, err)
+		assert.Empty(t, botID)
+	})
+
 	t.Run("ensure bot should pass even after delete bot user", func(t *testing.T) {
 		th := Setup(t).InitBasic(t)
 

--- a/server/channels/app/platform/disk_darwin.go
+++ b/server/channels/app/platform/disk_darwin.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build darwin
+
+package platform
+
+import (
+	"errors"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+type diskInfo struct {
+	TotalMB        uint64
+	AvailableMB    uint64
+	FilesystemType string
+}
+
+var errDiskInfoTimeout = errors.New("timed out getting disk space info")
+
+func getDiskInfo(path string) (diskInfo, error) {
+	type result struct {
+		info diskInfo
+		err  error
+	}
+
+	ch := make(chan result, 1)
+	go func() {
+		var stat unix.Statfs_t
+		if err := unix.Statfs(path, &stat); err != nil {
+			ch <- result{err: err}
+			return
+		}
+		bsize := uint64(stat.Bsize)
+		fsType := unix.ByteSliceToString(stat.Fstypename[:])
+		ch <- result{info: diskInfo{
+			TotalMB:        stat.Blocks * bsize / (1024 * 1024),
+			AvailableMB:    stat.Bavail * bsize / (1024 * 1024),
+			FilesystemType: fsType,
+		}}
+	}()
+
+	select {
+	case r := <-ch:
+		return r.info, r.err
+	case <-time.After(5 * time.Second):
+		return diskInfo{}, errDiskInfoTimeout
+	}
+}

--- a/server/channels/app/platform/disk_linux.go
+++ b/server/channels/app/platform/disk_linux.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build linux
+
+package platform
+
+import (
+	"errors"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+type diskInfo struct {
+	TotalMB        uint64
+	AvailableMB    uint64
+	FilesystemType string
+}
+
+var errDiskInfoTimeout = errors.New("timed out getting disk space info")
+
+func getDiskInfo(path string) (diskInfo, error) {
+	type result struct {
+		info diskInfo
+		err  error
+	}
+
+	ch := make(chan result, 1)
+	go func() {
+		var stat syscall.Statfs_t
+		if err := syscall.Statfs(path, &stat); err != nil {
+			ch <- result{err: err}
+			return
+		}
+		bsize := uint64(stat.Bsize)
+		ch <- result{info: diskInfo{
+			TotalMB:        stat.Blocks * bsize / (1024 * 1024),
+			AvailableMB:    stat.Bavail * bsize / (1024 * 1024),
+			FilesystemType: fsTypeToString(stat.Type),
+		}}
+	}()
+
+	select {
+	case r := <-ch:
+		return r.info, r.err
+	case <-time.After(5 * time.Second):
+		return diskInfo{}, errDiskInfoTimeout
+	}
+}
+
+func fsTypeToString(fsType int64) string {
+	switch fsType {
+	case unix.EXT4_SUPER_MAGIC:
+		return "ext4"
+	case unix.XFS_SUPER_MAGIC:
+		return "xfs"
+	case unix.NFS_SUPER_MAGIC:
+		return "nfs"
+	case unix.BTRFS_SUPER_MAGIC:
+		return "btrfs"
+	case unix.TMPFS_MAGIC:
+		return "tmpfs"
+	case unix.SMB_SUPER_MAGIC:
+		return "smb"
+	case unix.FUSE_SUPER_MAGIC:
+		return "fuse"
+	case unix.OVERLAYFS_SUPER_MAGIC:
+		return "overlay"
+	default:
+		return "unknown"
+	}
+}

--- a/server/channels/app/platform/disk_other.go
+++ b/server/channels/app/platform/disk_other.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build !linux && !darwin
+
+package platform
+
+import "errors"
+
+// ErrDiskSpaceUnsupportedPlatform is returned when disk space detection is not supported on the current platform.
+var ErrDiskSpaceUnsupportedPlatform = errors.New("disk space detection not supported on this platform")
+
+type diskInfo struct {
+	TotalMB        uint64
+	AvailableMB    uint64
+	FilesystemType string
+}
+
+func getDiskInfo(_ string) (diskInfo, error) {
+	return diskInfo{}, ErrDiskSpaceUnsupportedPlatform
+}

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -166,6 +166,20 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 		d.FileStore.Error = err.Error()
 	}
 	d.FileStore.Driver = ps.FileBackend().DriverName()
+	if d.FileStore.Driver == model.ImageDriverLocal {
+		dir := model.SafeDereference(ps.Config().FileSettings.Directory)
+		if dir == "" {
+			dir = model.FileSettingsDefaultDirectory
+		}
+		di, diskErr := getDiskInfo(dir)
+		if diskErr != nil {
+			rErr = multierror.Append(errors.Wrap(diskErr, "error while getting disk space info"))
+		} else {
+			d.FileStore.FilesystemType = di.FilesystemType
+			d.FileStore.TotalMB = di.TotalMB
+			d.FileStore.AvailableMB = di.AvailableMB
+		}
+	}
 
 	/* Websockets */
 	d.Websocket.Connections = ps.TotalWebsocketConnections()

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -5,7 +5,11 @@ package platform
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
 	"os"
 	"runtime"
 	rpprof "runtime/pprof"
@@ -19,6 +23,8 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/public/shared/request"
+	"github.com/mattermost/mattermost/server/v8/channels/utils"
+	"github.com/mattermost/mattermost/server/v8/platform/shared/mail"
 )
 
 const (
@@ -221,6 +227,8 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 		}
 		d.LDAP.ServerName = severName
 		d.LDAP.ServerVersion = serverVersion
+	} else {
+		d.LDAP.Status = model.StatusDisabled
 	}
 
 	/* SAML */
@@ -231,14 +239,64 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 	/* Elastic Search */
 	if se := ps.SearchEngine.ElasticsearchEngine; se != nil {
 		d.ElasticSearch.Backend = *ps.Config().ElasticsearchSettings.Backend
+		d.ElasticSearch.ServerVersion = se.GetFullVersion()
+		d.ElasticSearch.ServerPlugins = se.GetPlugins()
 		if *ps.Config().ElasticsearchSettings.EnableIndexing {
 			appErr := se.TestConfig(rctx, ps.Config())
 			if appErr != nil {
+				d.ElasticSearch.Status = model.StatusFail
 				d.ElasticSearch.Error = appErr.Error()
+			} else {
+				d.ElasticSearch.Status = model.StatusOk
 			}
+		} else {
+			d.ElasticSearch.Status = model.StatusDisabled
 		}
-		d.ElasticSearch.ServerVersion = se.GetFullVersion()
-		d.ElasticSearch.ServerPlugins = se.GetPlugins()
+	} else {
+		d.ElasticSearch.Status = model.StatusDisabled
+	}
+
+	/* Email Notifications */
+	if model.SafeDereference(ps.Config().EmailSettings.SendEmailNotifications) {
+		emailSettings := ps.Config().EmailSettings
+		hostname := utils.GetHostnameFromSiteURL(model.SafeDereference(ps.Config().ServiceSettings.SiteURL))
+		mailCfg := &mail.SMTPConfig{
+			Hostname:                          hostname,
+			ConnectionSecurity:                model.SafeDereference(emailSettings.ConnectionSecurity),
+			SkipServerCertificateVerification: model.SafeDereference(emailSettings.SkipServerCertificateVerification),
+			ServerName:                        model.SafeDereference(emailSettings.SMTPServer),
+			Server:                            model.SafeDereference(emailSettings.SMTPServer),
+			Port:                              model.SafeDereference(emailSettings.SMTPPort),
+			ServerTimeout:                     model.SafeDereference(emailSettings.SMTPServerTimeout),
+			Username:                          model.SafeDereference(emailSettings.SMTPUsername),
+			Password:                          model.SafeDereference(emailSettings.SMTPPassword),
+			EnableSMTPAuth:                    model.SafeDereference(emailSettings.EnableSMTPAuth),
+			SendEmailNotifications:            true,
+			FeedbackName:                      model.SafeDereference(emailSettings.FeedbackName),
+			FeedbackEmail:                     model.SafeDereference(emailSettings.FeedbackEmail),
+			ReplyToAddress:                    model.SafeDereference(emailSettings.ReplyToAddress),
+		}
+		if smtpErr := mail.TestConnection(mailCfg); smtpErr != nil {
+			d.Notifications.Email.Status = model.StatusFail
+			d.Notifications.Email.Error = smtpErr.Error()
+		} else {
+			d.Notifications.Email.Status = model.StatusOk
+		}
+	} else {
+		d.Notifications.Email.Status = model.StatusDisabled
+	}
+
+	/* Push Notifications */
+	if model.SafeDereference(ps.Config().EmailSettings.SendPushNotifications) {
+		pushServerURL := model.SafeDereference(ps.Config().EmailSettings.PushNotificationServer)
+		if pushErr := testPushProxyConnection(rctx.Context(), pushServerURL); pushErr != nil {
+			d.Notifications.Push.Status = model.StatusFail
+			d.Notifications.Push.Error = pushErr.Error()
+		} else {
+			d.Notifications.Push.Status = model.StatusOk
+		}
+	} else {
+		d.Notifications.Push.Status = model.StatusDisabled
 	}
 
 	b, err := yaml.Marshal(&d)
@@ -251,6 +309,29 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 		Body:     b,
 	}
 	return fileData, rErr.ErrorOrNil()
+}
+
+// TODO: move this into its own push proxy package once one exists (see also pushNotificationClient in server.go)
+func testPushProxyConnection(ctx context.Context, serverURL string) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	versionURL, err := url.JoinPath(serverURL, "version")
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, versionURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("push proxy returned unexpected status %d", resp.StatusCode)
+	}
+	return nil
 }
 
 func (ps *PlatformService) getSanitizedConfigFile(rctx request.CTX) (*model.FileData, error) {

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -4,12 +4,18 @@
 package platform
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path"
 	"runtime"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/goccy/go-yaml"
@@ -255,7 +261,7 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		assert.Zero(t, d.Cluster.NumberOfNodes)
 
 		/* LDAP */
-		assert.Empty(t, d.LDAP.Status)
+		assert.Equal(t, model.StatusDisabled, d.LDAP.Status)
 		assert.Empty(t, d.LDAP.Error)
 		assert.Empty(t, d.LDAP.ServerName)
 		assert.Empty(t, d.LDAP.ServerVersion)
@@ -264,6 +270,7 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		assert.Empty(t, d.SAML.ProviderType)
 
 		/* Elastic Search */
+		assert.Equal(t, model.StatusDisabled, d.ElasticSearch.Status)
 		assert.Empty(t, d.ElasticSearch.ServerVersion)
 		assert.Empty(t, d.ElasticSearch.ServerPlugins)
 	})
@@ -314,6 +321,7 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 
 		packet := getDiagnostics(t)
 
+		assert.Equal(t, model.StatusDisabled, packet.LDAP.Status)
 		assert.Equal(t, "", packet.LDAP.ServerName)
 		assert.Equal(t, "", packet.LDAP.ServerVersion)
 	})
@@ -475,6 +483,7 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 
 		packet := getDiagnostics(t)
 
+		assert.Equal(t, model.StatusDisabled, packet.ElasticSearch.Status)
 		assert.Equal(t, model.ElasticsearchSettingsESBackend, packet.ElasticSearch.Backend)
 		assert.Equal(t, "7.10.0", packet.ElasticSearch.ServerVersion)
 		assert.Equal(t, []string{"plugin1", "plugin2"}, packet.ElasticSearch.ServerPlugins)
@@ -499,6 +508,7 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 
 		packet := getDiagnostics(t)
 
+		assert.Equal(t, model.StatusOk, packet.ElasticSearch.Status)
 		assert.Equal(t, model.ElasticsearchSettingsOSBackend, packet.ElasticSearch.Backend)
 		assert.Equal(t, "2.5.0", packet.ElasticSearch.ServerVersion)
 		assert.Equal(t, []string{"opensearch-plugin"}, packet.ElasticSearch.ServerPlugins)
@@ -524,10 +534,169 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 
 		packet := getDiagnostics(t)
 
+		assert.Equal(t, model.StatusFail, packet.ElasticSearch.Status)
 		assert.Equal(t, model.ElasticsearchSettingsESBackend, packet.ElasticSearch.Backend)
 		assert.Equal(t, "7.10.0", packet.ElasticSearch.ServerVersion)
 		assert.Equal(t, []string{"plugin1", "plugin2"}, packet.ElasticSearch.ServerPlugins)
 		assert.Equal(t, "TestConfig: ent.elasticsearch.test_config.connection_failed, connection refused", packet.ElasticSearch.Error)
+	})
+
+	t.Run("push notifications disabled", func(t *testing.T) {
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.EmailSettings.SendPushNotifications = model.NewPointer(false)
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.EmailSettings.SendPushNotifications = model.NewPointer(true)
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusDisabled, packet.Notifications.Push.Status)
+		assert.Empty(t, packet.Notifications.Push.Error)
+	})
+
+	t.Run("push notifications reachable", func(t *testing.T) {
+		pushServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/version", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer pushServer.Close()
+
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.EmailSettings.SendPushNotifications = model.NewPointer(true)
+			cfg.EmailSettings.PushNotificationServer = model.NewPointer(pushServer.URL)
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.EmailSettings.SendPushNotifications = model.NewPointer(true)
+				cfg.EmailSettings.PushNotificationServer = model.NewPointer(model.GenericNotificationServer)
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusOk, packet.Notifications.Push.Status)
+		assert.Empty(t, packet.Notifications.Push.Error)
+	})
+
+	t.Run("push notifications unreachable", func(t *testing.T) {
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.EmailSettings.SendPushNotifications = model.NewPointer(true)
+			cfg.EmailSettings.PushNotificationServer = model.NewPointer("http://localhost:1")
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.EmailSettings.SendPushNotifications = model.NewPointer(true)
+				cfg.EmailSettings.PushNotificationServer = model.NewPointer(model.GenericNotificationServer)
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusFail, packet.Notifications.Push.Status)
+		assert.NotEmpty(t, packet.Notifications.Push.Error)
+	})
+
+	t.Run("email notifications disabled", func(t *testing.T) {
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.EmailSettings.SendEmailNotifications = model.NewPointer(false)
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.EmailSettings.SendEmailNotifications = model.NewPointer(true)
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusDisabled, packet.Notifications.Email.Status)
+		assert.Empty(t, packet.Notifications.Email.Error)
+	})
+
+	t.Run("email notifications reachable", func(t *testing.T) {
+		l, listenErr := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, listenErr)
+		defer l.Close()
+
+		go func() {
+			for {
+				conn, err := l.Accept()
+				if err != nil {
+					return
+				}
+				go func(c net.Conn) {
+					defer c.Close()
+					rw := bufio.NewReadWriter(bufio.NewReader(c), bufio.NewWriter(c))
+					_, _ = rw.WriteString("220 localhost ESMTP Test\r\n")
+					rw.Flush()
+					for {
+						line, err := rw.ReadString('\n')
+						if err != nil {
+							return
+						}
+						if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(line)), "QUIT") {
+							_, _ = rw.WriteString("221 Bye\r\n")
+							rw.Flush()
+							return
+						}
+						_, _ = rw.WriteString("250 OK\r\n")
+						rw.Flush()
+					}
+				}(conn)
+			}
+		}()
+
+		tcpAddr := l.Addr().(*net.TCPAddr)
+		smtpPort := strconv.Itoa(tcpAddr.Port)
+
+		// MM_EMAILSETTINGS_SMTPSERVER may be set in CI and would override UpdateConfig.
+		// Use t.Setenv so the env var is updated before UpdateConfig calls Store.Set(),
+		// which re-reads GetEnvironment() (os.Environ()) and applies overrides.
+		t.Setenv("MM_EMAILSETTINGS_SMTPSERVER", "127.0.0.1")
+
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.EmailSettings.SendEmailNotifications = model.NewPointer(true)
+			cfg.EmailSettings.SMTPServer = model.NewPointer("127.0.0.1")
+			cfg.EmailSettings.SMTPPort = model.NewPointer(smtpPort)
+			cfg.EmailSettings.EnableSMTPAuth = model.NewPointer(false)
+			cfg.EmailSettings.ConnectionSecurity = model.NewPointer("")
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.EmailSettings.SendEmailNotifications = model.NewPointer(true)
+				cfg.EmailSettings.SMTPServer = model.NewPointer(model.EmailSMTPDefaultServer)
+				cfg.EmailSettings.SMTPPort = model.NewPointer(model.EmailSMTPDefaultPort)
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusOk, packet.Notifications.Email.Status)
+		assert.Empty(t, packet.Notifications.Email.Error)
+	})
+
+	t.Run("email notifications unreachable", func(t *testing.T) {
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.EmailSettings.SendEmailNotifications = model.NewPointer(true)
+			cfg.EmailSettings.SMTPServer = model.NewPointer("localhost")
+			cfg.EmailSettings.SMTPPort = model.NewPointer("1")
+			cfg.EmailSettings.SMTPServerTimeout = model.NewPointer(1)
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.EmailSettings.SendEmailNotifications = model.NewPointer(true)
+				cfg.EmailSettings.SMTPServer = model.NewPointer(model.EmailSMTPDefaultServer)
+				cfg.EmailSettings.SMTPPort = model.NewPointer(model.EmailSMTPDefaultPort)
+				cfg.EmailSettings.SMTPServerTimeout = model.NewPointer(10)
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusFail, packet.Notifications.Email.Status)
+		assert.NotEmpty(t, packet.Notifications.Email.Error)
 	})
 }
 

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -237,6 +237,15 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		assert.Equal(t, "OK", d.FileStore.Status)
 		assert.Empty(t, d.FileStore.Error)
 		assert.Equal(t, "local", d.FileStore.Driver)
+		if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+			assert.NotEmpty(t, d.FileStore.FilesystemType, "FilesystemType should not be empty on supported platforms")
+			assert.Positive(t, d.FileStore.TotalMB, "TotalMB should be positive on supported platforms")
+			assert.Positive(t, d.FileStore.AvailableMB, "AvailableMB should be positive on supported platforms")
+		} else {
+			assert.Empty(t, d.FileStore.FilesystemType)
+			assert.Zero(t, d.FileStore.TotalMB)
+			assert.Zero(t, d.FileStore.AvailableMB)
+		}
 
 		/* Websockets */
 		assert.Zero(t, d.Websocket.Connections)
@@ -271,6 +280,28 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		assert.Equal(t, "FAIL", packet.FileStore.Status)
 		assert.Equal(t, "all broken", packet.FileStore.Error)
 		assert.Equal(t, "mock", packet.FileStore.Driver)
+	})
+
+	t.Run("s3 driver omits disk space fields", func(t *testing.T) {
+		orig := th.Service.filestore
+		t.Cleanup(func() {
+			err := SetFileStore(orig)(th.Service)
+			require.NoError(t, err)
+		})
+
+		fb := &fmocks.FileBackend{}
+		err := SetFileStore(fb)(th.Service)
+		require.NoError(t, err)
+		fb.On("DriverName").Return("amazons3")
+		fb.On("TestConnection").Return(nil)
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, "OK", packet.FileStore.Status)
+		assert.Equal(t, "amazons3", packet.FileStore.Driver)
+		assert.Empty(t, packet.FileStore.FilesystemType)
+		assert.Zero(t, packet.FileStore.TotalMB)
+		assert.Zero(t, packet.FileStore.AvailableMB)
 	})
 
 	t.Run("no LDAP info if LDAP sync is disabled", func(t *testing.T) {

--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -1481,6 +1481,10 @@ func (api *PluginAPI) UnregisterPluginForSharedChannels(pluginID string) error {
 	return api.app.UnregisterPluginForSharedChannels(pluginID)
 }
 
+func (api *PluginAPI) UnregisterPluginRemoteForSharedChannels(remoteID string) error {
+	return api.app.UnregisterPluginRemoteForSharedChannels(api.id, remoteID)
+}
+
 func (api *PluginAPI) ShareChannel(sc *model.SharedChannel) (*model.SharedChannel, error) {
 	scShared, err := api.app.ShareChannel(api.ctx, sc)
 	if errors.Is(err, model.ErrChannelAlreadyShared) {

--- a/server/channels/app/remote_cluster.go
+++ b/server/channels/app/remote_cluster.go
@@ -62,9 +62,11 @@ func (a *App) RegisterPluginForSharedChannels(rctx request.CTX, opts model.Regis
 		return rc.RemoteId, nil
 	}
 
-	// New connection.
+	// New connection. Name must satisfy the slug-style regex enforced by
+	// RemoteCluster.IsValid, so derive it from Displayname; the original
+	// human-readable label is preserved on DisplayName.
 	rc = &model.RemoteCluster{
-		Name:        opts.Displayname,
+		Name:        model.CleanRemoteName(opts.Displayname),
 		DisplayName: opts.Displayname,
 		SiteURL:     opts.SiteURL,
 		Token:       model.NewId(),

--- a/server/channels/app/remote_cluster.go
+++ b/server/channels/app/remote_cluster.go
@@ -6,6 +6,7 @@ package app
 import (
 	"database/sql"
 	"encoding/base64"
+	"fmt"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -19,24 +20,31 @@ import (
 )
 
 func (a *App) RegisterPluginForSharedChannels(rctx request.CTX, opts model.RegisterPluginOpts) (remoteID string, err error) {
-	// check for pluginID already registered
-	rc, err := a.Srv().Store().RemoteCluster().GetByPluginID(opts.PluginID)
-	if err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			// anything other than not_found is unrecoverable
-			return "", err
-		}
+	// When SiteURL is empty, fall back to the legacy single-remote behavior
+	// using the "plugin_" prefix. This preserves compatibility for older plugins
+	// that haven't been updated to provide a SiteURL.
+	if opts.SiteURL == "" {
+		opts.SiteURL = model.SiteURLPlugin + opts.PluginID
 	}
 
-	// if plugin is already registered then treat this as an update.
+	// Check if this SiteURL is already registered.
+	rc, err := a.Srv().Store().RemoteCluster().GetBySiteURL(opts.SiteURL)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return "", err
+	}
+
 	if rc != nil {
-		// plugin was deleted at some point
+		// SiteURL exists. Verify it belongs to this plugin.
+		if rc.PluginID != opts.PluginID {
+			return "", fmt.Errorf("SiteURL %q is already in use by remote %s (plugin %q)", opts.SiteURL, rc.RemoteId, rc.PluginID)
+		}
+
+		// Same plugin, same SiteURL: idempotent re-registration.
 		if rc.DeleteAt != 0 {
 			rctx.Logger().Debug("Restoring plugin registration for Shared Channels",
 				mlog.String("plugin_id", opts.PluginID),
 				mlog.String("remote_id", rc.RemoteId),
 			)
-
 			rc.DeleteAt = 0
 		} else {
 			rctx.Logger().Debug("Plugin already registered for Shared Channels",
@@ -54,10 +62,11 @@ func (a *App) RegisterPluginForSharedChannels(rctx request.CTX, opts model.Regis
 		return rc.RemoteId, nil
 	}
 
+	// New connection.
 	rc = &model.RemoteCluster{
 		Name:        opts.Displayname,
 		DisplayName: opts.Displayname,
-		SiteURL:     model.SiteURLPlugin + opts.PluginID, // require a unique siteurl
+		SiteURL:     opts.SiteURL,
 		Token:       model.NewId(),
 		CreatorId:   opts.CreatorID,
 		PluginID:    opts.PluginID,
@@ -72,9 +81,10 @@ func (a *App) RegisterPluginForSharedChannels(rctx request.CTX, opts model.Regis
 	rctx.Logger().Debug("Registered new plugin for Shared Channels",
 		mlog.String("plugin_id", opts.PluginID),
 		mlog.String("remote_id", rcSaved.RemoteId),
+		mlog.String("site_url", opts.SiteURL),
 	)
 
-	// ping the plugin remote immediately if the service is running
+	// Ping the plugin remote immediately if the service is running.
 	// If the service is not available the ping will happen once the
 	// service starts. This is expected since plugins start before the
 	// service.
@@ -86,14 +96,36 @@ func (a *App) RegisterPluginForSharedChannels(rctx request.CTX, opts model.Regis
 	return rcSaved.RemoteId, nil
 }
 
+// UnregisterPluginForSharedChannels unregisters all remotes for the specified plugin.
+// Used in OnDeactivate for bulk cleanup.
 func (a *App) UnregisterPluginForSharedChannels(pluginID string) error {
-	rc, err := a.Srv().Store().RemoteCluster().GetByPluginID(pluginID)
+	remotes, err := a.Srv().Store().RemoteCluster().GetAllByPluginID(pluginID)
 	if err != nil {
 		return err
 	}
 
+	for _, rc := range remotes {
+		if _, appErr := a.DeleteRemoteCluster(rc.RemoteId); appErr != nil {
+			return appErr
+		}
+	}
+	return nil
+}
+
+// UnregisterPluginRemoteForSharedChannels unregisters a specific remote by its remoteID.
+// The pluginID is validated against the remote's PluginID to ensure a plugin can only
+// unregister its own remotes.
+func (a *App) UnregisterPluginRemoteForSharedChannels(pluginID, remoteID string) error {
+	rc, err := a.Srv().Store().RemoteCluster().Get(remoteID, true)
+	if err != nil {
+		return err
+	}
+
+	if rc.PluginID != pluginID {
+		return fmt.Errorf("remote %s does not belong to plugin %s", remoteID, pluginID)
+	}
+
 	if rc.DeleteAt != 0 {
-		// plugin already unregistered, nothing to do
 		return nil
 	}
 

--- a/server/channels/app/remote_cluster_test.go
+++ b/server/channels/app/remote_cluster_test.go
@@ -14,6 +14,7 @@ import (
 func setupRemoteCluster(tb testing.TB) *TestHelper {
 	return SetupConfig(tb, func(cfg *model.Config) {
 		*cfg.ConnectedWorkspacesSettings.EnableRemoteClusterService = true
+		*cfg.ConnectedWorkspacesSettings.EnableSharedChannels = true
 	})
 }
 
@@ -104,4 +105,167 @@ func TestUpdateRemoteCluster(t *testing.T) {
 		_, err = th.App.UpdateRemoteCluster(anotherExistingRemoteClustered)
 		require.Nil(t, err, "Updating remote cluster should work fine")
 	})
+}
+
+func TestRegisterPluginForSharedChannels(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := setupRemoteCluster(t).InitBasic(t)
+
+	t.Run("empty SiteURL defaults to plugin prefix", func(t *testing.T) {
+		pluginID := "com.test.legacy-" + model.NewId()
+		remoteID, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "legacy plugin",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+		})
+		require.NoError(t, err)
+
+		rc, err := th.App.Srv().Store().RemoteCluster().Get(remoteID, false)
+		require.NoError(t, err)
+		require.Equal(t, "plugin_"+pluginID, rc.SiteURL)
+	})
+
+	t.Run("cross-plugin SiteURL collision returns error", func(t *testing.T) {
+		siteURL := "nats://shared-" + model.NewId()
+
+		_, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "plugin A",
+			PluginID:    "com.test.pluginA-" + model.NewId(),
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     siteURL,
+		})
+		require.NoError(t, err)
+
+		_, err = th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "plugin B",
+			PluginID:    "com.test.pluginB-" + model.NewId(),
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     siteURL,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "already in use")
+	})
+
+	t.Run("idempotent re-registration returns same remoteID", func(t *testing.T) {
+		pluginID := "com.test.idempotent-" + model.NewId()
+		siteURL := "nats://idempotent-" + model.NewId()
+
+		id1, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "first call",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     siteURL,
+		})
+		require.NoError(t, err)
+
+		id2, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "second call",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     siteURL,
+		})
+		require.NoError(t, err)
+		require.Equal(t, id1, id2)
+	})
+
+	t.Run("multi-remote registration returns distinct remoteIDs", func(t *testing.T) {
+		pluginID := "com.test.multi-" + model.NewId()
+
+		id1, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "remote 1",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     "nats://remote1-" + model.NewId(),
+		})
+		require.NoError(t, err)
+
+		id2, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "remote 2",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     "nats://remote2-" + model.NewId(),
+		})
+		require.NoError(t, err)
+		require.NotEqual(t, id1, id2)
+	})
+}
+
+func TestUnregisterPluginRemoteForSharedChannels(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := setupRemoteCluster(t).InitBasic(t)
+
+	t.Run("successful removal of own remote", func(t *testing.T) {
+		pluginID := "com.test.unregister-" + model.NewId()
+		remoteID, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "my remote",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     "nats://unregister-" + model.NewId(),
+		})
+		require.NoError(t, err)
+
+		err = th.App.UnregisterPluginRemoteForSharedChannels(pluginID, remoteID)
+		require.NoError(t, err)
+
+		// Verify the remote is actually deleted
+		rc, storeErr := th.App.Srv().Store().RemoteCluster().Get(remoteID, false)
+		require.Error(t, storeErr, "deleted remote should not be found with includeDeleted=false")
+		require.Nil(t, rc)
+
+		// Second call should be a no-op (idempotent)
+		err = th.App.UnregisterPluginRemoteForSharedChannels(pluginID, remoteID)
+		require.NoError(t, err)
+	})
+
+	t.Run("removing another plugins remote returns error", func(t *testing.T) {
+		pluginID := "com.test.owner-" + model.NewId()
+		remoteID, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "owned remote",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     "nats://owner-" + model.NewId(),
+		})
+		require.NoError(t, err)
+
+		err = th.App.UnregisterPluginRemoteForSharedChannels("com.test.other-plugin", remoteID)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not belong to plugin")
+	})
+
+	t.Run("removing non-existent remoteID returns error", func(t *testing.T) {
+		err := th.App.UnregisterPluginRemoteForSharedChannels("com.test.any", model.NewId())
+		require.Error(t, err)
+	})
+}
+
+func TestUnregisterPluginForSharedChannelsBulk(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := setupRemoteCluster(t).InitBasic(t)
+
+	pluginID := "com.test.bulk-" + model.NewId()
+
+	id1, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+		Displayname: "bulk remote 1",
+		PluginID:    pluginID,
+		CreatorID:   th.BasicUser.Id,
+		SiteURL:     "nats://bulk1-" + model.NewId(),
+	})
+	require.NoError(t, err)
+
+	id2, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+		Displayname: "bulk remote 2",
+		PluginID:    pluginID,
+		CreatorID:   th.BasicUser.Id,
+		SiteURL:     "nats://bulk2-" + model.NewId(),
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, id1, id2)
+
+	err = th.App.UnregisterPluginForSharedChannels(pluginID)
+	require.NoError(t, err)
+
+	// Both should be deleted
+	remotes, err := th.App.Srv().Store().RemoteCluster().GetAllByPluginID(pluginID)
+	require.NoError(t, err)
+	require.Empty(t, remotes)
 }

--- a/server/channels/app/session_test.go
+++ b/server/channels/app/session_test.go
@@ -374,6 +374,7 @@ func TestGetRemoteClusterSession(t *testing.T) {
 	rc := model.RemoteCluster{
 		RemoteId:  remoteID,
 		Name:      "test",
+		SiteURL:   "https://test.example.com",
 		Token:     token,
 		CreatorId: model.NewId(),
 	}

--- a/server/channels/app/shared_channel_test.go
+++ b/server/channels/app/shared_channel_test.go
@@ -1131,6 +1131,7 @@ func registerPluginRemoteForTest(t *testing.T, th *TestHelper, pluginID string, 
 		Displayname: "test-plugin-remote",
 		PluginID:    pluginID,
 		CreatorID:   th.BasicUser.Id,
+		SiteURL:     "plugin://" + pluginID,
 	})
 	require.NoError(t, err)
 
@@ -1148,7 +1149,7 @@ func registerPluginRemoteForTest(t *testing.T, th *TestHelper, pluginID string, 
 	err = th.App.InviteRemoteToChannel(channel.Id, remoteID, th.BasicUser.Id, false)
 	require.NoError(t, err)
 
-	rc, err := th.App.Srv().Store().RemoteCluster().GetByPluginID(pluginID)
+	rc, err := th.App.Srv().Store().RemoteCluster().Get(remoteID, false)
 	require.NoError(t, err)
 	return rc
 }

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -780,8 +780,7 @@ func (a *App) GetUsersNotInAbacChannel(rctx request.CTX, teamID string, channelI
 		return nil, model.NewAppError("GetUsersNotInAbacChannel", "api.user.get_users_not_in_abac_channel.access_control_unavailable.app_error", nil, "", http.StatusInternalServerError)
 	}
 
-	// Use cursor-based pagination for ABAC channels
-	users, _, appErr := acs.QueryUsersForResource(rctx, channelID, "*", model.SubjectSearchOptions{
+	users, _, appErr := acs.QueryUsersForResource(rctx, channelID, model.AccessControlPolicyActionMembership, model.SubjectSearchOptions{
 		TeamID: teamID,
 		Limit:  limit,
 		Cursor: model.SubjectCursor{
@@ -2330,7 +2329,7 @@ func (a *App) SearchUsersNotInChannel(teamID string, channelID string, term stri
 	} else if ok {
 		acs := a.Srv().Channels().AccessControl
 		if acs != nil {
-			users, _, appErr := acs.QueryUsersForResource(rctx, channelID, "*", model.SubjectSearchOptions{
+			users, _, appErr := acs.QueryUsersForResource(rctx, channelID, model.AccessControlPolicyActionMembership, model.SubjectSearchOptions{
 				Term:   term,
 				TeamID: teamID,
 				Limit:  options.Limit,
@@ -2339,7 +2338,7 @@ func (a *App) SearchUsersNotInChannel(teamID string, channelID string, term stri
 				return nil, appErr
 			}
 
-			return users, nil
+			return a.sanitizeProfiles(users, options.IsAdmin), nil
 		}
 	}
 
@@ -2348,11 +2347,7 @@ func (a *App) SearchUsersNotInChannel(teamID string, channelID string, term stri
 		return nil, model.NewAppError("SearchUsersNotInChannel", "app.user.search.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	for _, user := range users {
-		a.SanitizeProfile(user, options.IsAdmin)
-	}
-
-	return users, nil
+	return a.sanitizeProfiles(users, options.IsAdmin), nil
 }
 
 func (a *App) SearchUsersInTeam(rctx request.CTX, teamID, term string, options *model.UserSearchOptions) ([]*model.User, *model.AppError) {

--- a/server/channels/app/user_test.go
+++ b/server/channels/app/user_test.go
@@ -996,7 +996,7 @@ func TestGetUsersNotInAbacChannel(t *testing.T) {
 		mockAccessControl.On("QueryUsersForResource",
 			mock.Anything,
 			abacChannel.Id,
-			"*",
+			model.AccessControlPolicyActionMembership,
 			mock.MatchedBy(func(opts model.SubjectSearchOptions) bool {
 				return opts.TeamID == th.BasicTeam.Id &&
 					opts.Limit == 50 &&
@@ -1027,7 +1027,7 @@ func TestGetUsersNotInAbacChannel(t *testing.T) {
 		mockAccessControl.On("QueryUsersForResource",
 			mock.Anything,
 			abacChannel.Id,
-			"*",
+			model.AccessControlPolicyActionMembership,
 			mock.MatchedBy(func(opts model.SubjectSearchOptions) bool {
 				return opts.TeamID == th.BasicTeam.Id &&
 					opts.Limit == 25 &&

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -11021,11 +11021,53 @@ func (s *RetryLayerRemoteClusterStore) GetAll(offset int, limit int, filter mode
 
 }
 
+func (s *RetryLayerRemoteClusterStore) GetAllByPluginID(pluginID string) ([]*model.RemoteCluster, error) {
+
+	tries := 0
+	for {
+		result, err := s.RemoteClusterStore.GetAllByPluginID(pluginID)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerRemoteClusterStore) GetByPluginID(pluginID string) (*model.RemoteCluster, error) {
 
 	tries := 0
 	for {
 		result, err := s.RemoteClusterStore.GetByPluginID(pluginID)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
+func (s *RetryLayerRemoteClusterStore) GetBySiteURL(siteURL string) (*model.RemoteCluster, error) {
+
+	tries := 0
+	for {
+		result, err := s.RemoteClusterStore.GetBySiteURL(siteURL)
 		if err == nil {
 			return result, nil
 		}

--- a/server/channels/store/sqlstore/remote_cluster_store.go
+++ b/server/channels/store/sqlstore/remote_cluster_store.go
@@ -54,16 +54,26 @@ func (s sqlRemoteClusterStore) Save(remoteCluster *model.RemoteCluster) (*model.
 		return nil, err
 	}
 
-	// check for pluginID collisions - on collision treat as idempotent
+	// For plugin remotes, check for SiteURL collisions and treat as idempotent.
+	// Non-plugin remotes skip this check and rely on the DB unique constraint
+	// so that AddRemoteCluster can report a proper conflict error.
+	// This reads from master to avoid race conditions on lagging replicas.
 	if remoteCluster.PluginID != "" {
-		rc, err := s.GetByPluginID(remoteCluster.PluginID)
-		if err == nil {
-			// if this plugin id already exists, just return it
-			return rc, nil
+		lookupQuery := s.getQueryBuilder().
+			Select(remoteClusterFields("")...).
+			From("RemoteClusters").
+			Where(sq.Eq{"SiteURL": remoteCluster.SiteURL})
+
+		lookupSQL, args, err := lookupQuery.ToSql()
+		if err != nil {
+			return nil, errors.Wrap(err, "remote_cluster_save_lookup_tosql")
 		}
-		if !errors.Is(err, sql.ErrNoRows) {
-			// anything other than NotFound is unexpected
-			return nil, errors.Wrapf(err, "failed to lookup RemoteCluster by pluginID %s", remoteCluster.PluginID)
+
+		var existing model.RemoteCluster
+		if err := s.GetMaster().Get(&existing, lookupSQL, args...); err == nil {
+			return &existing, nil
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.Wrapf(err, "failed to lookup RemoteCluster by SiteURL %s", remoteCluster.SiteURL)
 		}
 	}
 
@@ -183,6 +193,8 @@ func (s sqlRemoteClusterStore) Get(remoteId string, includeDeleted bool) (*model
 	return &rc, nil
 }
 
+// Deprecated: GetByPluginID returns a single remote for the plugin. Only correct
+// when the plugin has one registration. Use GetAllByPluginID instead.
 func (s sqlRemoteClusterStore) GetByPluginID(pluginID string) (*model.RemoteCluster, error) {
 	query := s.getQueryBuilder().
 		Select(remoteClusterFields("")...).
@@ -197,6 +209,43 @@ func (s sqlRemoteClusterStore) GetByPluginID(pluginID string) (*model.RemoteClus
 	var rc model.RemoteCluster
 	if err := s.GetReplica().Get(&rc, queryString, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to find RemoteCluster by plugin_id")
+	}
+	return &rc, nil
+}
+
+func (s sqlRemoteClusterStore) GetAllByPluginID(pluginID string) ([]*model.RemoteCluster, error) {
+	query := s.getQueryBuilder().
+		Select(remoteClusterFields("")...).
+		From("RemoteClusters").
+		Where(sq.Eq{"PluginID": pluginID}).
+		Where(sq.Eq{"DeleteAt": 0})
+
+	queryString, args, err := query.ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "remote_cluster_get_all_by_pluginid_tosql")
+	}
+
+	var list []*model.RemoteCluster
+	if err := s.GetReplica().Select(&list, queryString, args...); err != nil {
+		return nil, errors.Wrap(err, "failed to find RemoteClusters by plugin_id")
+	}
+	return list, nil
+}
+
+func (s sqlRemoteClusterStore) GetBySiteURL(siteURL string) (*model.RemoteCluster, error) {
+	query := s.getQueryBuilder().
+		Select(remoteClusterFields("")...).
+		From("RemoteClusters").
+		Where(sq.Eq{"SiteURL": siteURL})
+
+	queryString, args, err := query.ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "remote_cluster_get_by_siteurl_tosql")
+	}
+
+	var rc model.RemoteCluster
+	if err := s.GetReplica().Get(&rc, queryString, args...); err != nil {
+		return nil, errors.Wrap(err, "failed to find RemoteCluster by SiteURL")
 	}
 	return &rc, nil
 }

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -573,7 +573,13 @@ type RemoteClusterStore interface {
 	Update(rc *model.RemoteCluster) (*model.RemoteCluster, error)
 	Delete(remoteClusterID string) (bool, error)
 	Get(remoteClusterID string, includeDeleted bool) (*model.RemoteCluster, error)
+	// Deprecated: GetByPluginID returns a single remote for the plugin. Only correct
+	// when the plugin has one registration. Use GetAllByPluginID instead.
 	GetByPluginID(pluginID string) (*model.RemoteCluster, error)
+	// GetAllByPluginID returns all remotes registered by the specified plugin.
+	GetAllByPluginID(pluginID string) ([]*model.RemoteCluster, error)
+	// GetBySiteURL returns the remote cluster with the given SiteURL, or an error if not found.
+	GetBySiteURL(siteURL string) (*model.RemoteCluster, error)
 	GetAll(offset, limit int, filter model.RemoteClusterQueryFilter) ([]*model.RemoteCluster, error)
 	UpdateTopics(remoteClusterID string, topics string) (*model.RemoteCluster, error)
 	SetLastPingAt(remoteClusterID string) error

--- a/server/channels/store/storetest/mocks/RemoteClusterStore.go
+++ b/server/channels/store/storetest/mocks/RemoteClusterStore.go
@@ -102,6 +102,36 @@ func (_m *RemoteClusterStore) GetAll(offset int, limit int, filter model.RemoteC
 	return r0, r1
 }
 
+// GetAllByPluginID provides a mock function with given fields: pluginID
+func (_m *RemoteClusterStore) GetAllByPluginID(pluginID string) ([]*model.RemoteCluster, error) {
+	ret := _m.Called(pluginID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllByPluginID")
+	}
+
+	var r0 []*model.RemoteCluster
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) ([]*model.RemoteCluster, error)); ok {
+		return rf(pluginID)
+	}
+	if rf, ok := ret.Get(0).(func(string) []*model.RemoteCluster); ok {
+		r0 = rf(pluginID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.RemoteCluster)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(pluginID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetByPluginID provides a mock function with given fields: pluginID
 func (_m *RemoteClusterStore) GetByPluginID(pluginID string) (*model.RemoteCluster, error) {
 	ret := _m.Called(pluginID)
@@ -125,6 +155,36 @@ func (_m *RemoteClusterStore) GetByPluginID(pluginID string) (*model.RemoteClust
 
 	if rf, ok := ret.Get(1).(func(string) error); ok {
 		r1 = rf(pluginID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetBySiteURL provides a mock function with given fields: siteURL
+func (_m *RemoteClusterStore) GetBySiteURL(siteURL string) (*model.RemoteCluster, error) {
+	ret := _m.Called(siteURL)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBySiteURL")
+	}
+
+	var r0 *model.RemoteCluster
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (*model.RemoteCluster, error)); ok {
+		return rf(siteURL)
+	}
+	if rf, ok := ret.Get(0).(func(string) *model.RemoteCluster); ok {
+		r0 = rf(siteURL)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.RemoteCluster)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(siteURL)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/storetest/remote_cluster_store.go
+++ b/server/channels/store/storetest/remote_cluster_store.go
@@ -22,6 +22,8 @@ func TestRemoteClusterStore(t *testing.T, rctx request.CTX, ss store.Store) {
 	t.Run("RemoteClusterDelete", func(t *testing.T) { testRemoteClusterDelete(t, rctx, ss) })
 	t.Run("RemoteClusterGet", func(t *testing.T) { testRemoteClusterGet(t, rctx, ss) })
 	t.Run("RemoteClusterGetByPluginID", func(t *testing.T) { testRemoteClusterGetByPluginID(t, rctx, ss) })
+	t.Run("RemoteClusterGetAllByPluginID", func(t *testing.T) { testRemoteClusterGetAllByPluginID(t, rctx, ss) })
+	t.Run("RemoteClusterGetBySiteURL", func(t *testing.T) { testRemoteClusterGetBySiteURL(t, rctx, ss) })
 	t.Run("RemoteClusterGetAll", func(t *testing.T) { testRemoteClusterGetAll(t, rctx, ss) })
 	t.Run("RemoteClusterGetByTopic", func(t *testing.T) { testRemoteClusterGetByTopic(t, rctx, ss) })
 	t.Run("RemoteClusterUpdateTopics", func(t *testing.T) { testRemoteClusterUpdateTopics(t, rctx, ss) })
@@ -68,34 +70,60 @@ func testRemoteClusterSave(t *testing.T, _ request.CTX, ss store.Store) {
 		require.Error(t, err)
 	})
 
-	t.Run("Save pluginID collision", func(t *testing.T) {
-		const testPluginID = "com.example.collision"
+	t.Run("Save plugin SiteURL collision is idempotent", func(t *testing.T) {
+		siteURL := makeSiteURL()
 
 		rc := &model.RemoteCluster{
 			Name:      "some_remote",
-			SiteURL:   makeSiteURL(),
+			SiteURL:   siteURL,
 			CreatorId: model.NewId(),
-			PluginID:  testPluginID,
+			PluginID:  model.NewId(),
 		}
 		_, err := ss.RemoteCluster().Save(rc)
 		require.NoError(t, err)
 
 		rc2 := &model.RemoteCluster{
 			Name:      "another_remote",
-			SiteURL:   makeSiteURL(),
+			SiteURL:   siteURL,
 			CreatorId: model.NewId(),
-			PluginID:  testPluginID,
+			PluginID:  model.NewId(),
 		}
 
 		rcSaved, err := ss.RemoteCluster().Save(rc2)
 		require.NoError(t, err)
 		require.NotNil(t, rcSaved)
 
-		// original remotecluster should be returned
+		// original remotecluster should be returned (idempotent save by SiteURL for plugins)
 		require.Equal(t, rc.Name, rcSaved.Name)
 		require.Equal(t, rc.SiteURL, rcSaved.SiteURL)
 		require.Greater(t, rc.CreateAt, int64(0))
-		require.Equal(t, rc.PluginID, rcSaved.PluginID)
+	})
+
+	t.Run("Save same pluginID different SiteURLs", func(t *testing.T) {
+		pluginID := model.NewId()
+
+		rc1 := &model.RemoteCluster{
+			Name:      "remote_1",
+			SiteURL:   makeSiteURL(),
+			CreatorId: model.NewId(),
+			PluginID:  pluginID,
+		}
+		saved1, err := ss.RemoteCluster().Save(rc1)
+		require.NoError(t, err)
+
+		rc2 := &model.RemoteCluster{
+			Name:      "remote_2",
+			SiteURL:   makeSiteURL(),
+			CreatorId: model.NewId(),
+			PluginID:  pluginID,
+		}
+		saved2, err := ss.RemoteCluster().Save(rc2)
+		require.NoError(t, err)
+
+		// Both should be saved with different RemoteIds
+		require.NotEqual(t, saved1.RemoteId, saved2.RemoteId)
+		require.Equal(t, pluginID, saved1.PluginID)
+		require.Equal(t, pluginID, saved2.PluginID)
 	})
 
 	t.Run("Save multiple with blank pluginID", func(t *testing.T) {
@@ -303,10 +331,10 @@ func testRemoteClusterGetAll(t *testing.T, _ request.CTX, ss store.Store) {
 		{Name: "some_online_remote", CreatorId: userId, SiteURL: makeSiteURL(), LastPingAt: now, Topics: " shared incident "},
 		{Name: "another_online_remote", CreatorId: model.NewId(), SiteURL: makeSiteURL(), LastPingAt: now, Topics: ""},
 		{Name: "another_offline_remote", CreatorId: model.NewId(), SiteURL: makeSiteURL(), LastPingAt: pingLongAgo, Topics: " shared "},
-		{Name: "brand_new_offline_remote", CreatorId: userId, SiteURL: "", LastPingAt: 0, Topics: " bogus shared stuff "},
+		{Name: "brand_new_offline_remote", CreatorId: userId, SiteURL: makeSiteURL(), LastPingAt: 0, Topics: " bogus shared stuff "},
 		{Name: "offline_plugin_remote", CreatorId: model.NewId(), SiteURL: makeSiteURL(), PluginID: model.NewId(), LastPingAt: 0, Topics: " pluginshare "},
 		{Name: "online_plugin_remote", CreatorId: model.NewId(), SiteURL: makeSiteURL(), PluginID: model.NewId(), LastPingAt: now, Topics: " pluginshare "},
-		{Name: "deleted_remote", CreatorId: model.NewId(), SiteURL: "", LastPingAt: 0, DeleteAt: 123},
+		{Name: "deleted_remote", CreatorId: model.NewId(), SiteURL: makeSiteURL(), LastPingAt: 0, DeleteAt: 123},
 	}
 
 	idsAll := make([]string, 0)
@@ -809,4 +837,99 @@ func testRemoteClusterUpdateTopics(t *testing.T, _ request.CTX, ss store.Store) 
 
 		require.Equal(t, tt.expected, rcUpdated.Topics)
 	}
+}
+
+func testRemoteClusterGetAllByPluginID(t *testing.T, _ request.CTX, ss store.Store) {
+	pluginID := "com.test.multi-remote-" + model.NewId()
+
+	t.Run("GetAllByPluginID returns multiple remotes", func(t *testing.T) {
+		rc1 := &model.RemoteCluster{
+			Name:      "remote_a",
+			SiteURL:   makeSiteURL(),
+			CreatorId: model.NewId(),
+			PluginID:  pluginID,
+		}
+		saved1, err := ss.RemoteCluster().Save(rc1)
+		require.NoError(t, err)
+
+		rc2 := &model.RemoteCluster{
+			Name:      "remote_b",
+			SiteURL:   makeSiteURL(),
+			CreatorId: model.NewId(),
+			PluginID:  pluginID,
+		}
+		saved2, err := ss.RemoteCluster().Save(rc2)
+		require.NoError(t, err)
+
+		results, err := ss.RemoteCluster().GetAllByPluginID(pluginID)
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+
+		ids := getIds(results)
+		assert.Contains(t, ids, saved1.RemoteId)
+		assert.Contains(t, ids, saved2.RemoteId)
+	})
+
+	t.Run("GetAllByPluginID excludes deleted", func(t *testing.T) {
+		results, err := ss.RemoteCluster().GetAllByPluginID(pluginID)
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+
+		// Delete one
+		_, err = ss.RemoteCluster().Delete(results[0].RemoteId)
+		require.NoError(t, err)
+
+		results, err = ss.RemoteCluster().GetAllByPluginID(pluginID)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+	})
+
+	t.Run("GetAllByPluginID not found", func(t *testing.T) {
+		results, err := ss.RemoteCluster().GetAllByPluginID("com.nonexistent.plugin")
+		require.NoError(t, err)
+		require.Empty(t, results)
+	})
+}
+
+func testRemoteClusterGetBySiteURL(t *testing.T, _ request.CTX, ss store.Store) {
+	t.Run("GetBySiteURL found", func(t *testing.T) {
+		siteURL := makeSiteURL()
+		rc := &model.RemoteCluster{
+			Name:      "siteurl_test",
+			SiteURL:   siteURL,
+			CreatorId: model.NewId(),
+			PluginID:  model.NewId(),
+		}
+		saved, err := ss.RemoteCluster().Save(rc)
+		require.NoError(t, err)
+
+		result, err := ss.RemoteCluster().GetBySiteURL(siteURL)
+		require.NoError(t, err)
+		require.Equal(t, saved.RemoteId, result.RemoteId)
+		require.Equal(t, siteURL, result.SiteURL)
+	})
+
+	t.Run("GetBySiteURL not found", func(t *testing.T) {
+		_, err := ss.RemoteCluster().GetBySiteURL("https://nonexistent.example.com")
+		require.Error(t, err)
+	})
+
+	t.Run("GetBySiteURL includes deleted", func(t *testing.T) {
+		siteURL := makeSiteURL()
+		rc := &model.RemoteCluster{
+			Name:      "deleted_siteurl_test",
+			SiteURL:   siteURL,
+			CreatorId: model.NewId(),
+		}
+		saved, err := ss.RemoteCluster().Save(rc)
+		require.NoError(t, err)
+
+		_, err = ss.RemoteCluster().Delete(saved.RemoteId)
+		require.NoError(t, err)
+
+		result, err := ss.RemoteCluster().GetBySiteURL(siteURL)
+		require.NoError(t, err)
+		require.Equal(t, saved.RemoteId, result.RemoteId)
+		require.NotZero(t, result.DeleteAt)
+	})
 }

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -8769,6 +8769,22 @@ func (s *TimerLayerRemoteClusterStore) GetAll(offset int, limit int, filter mode
 	return result, err
 }
 
+func (s *TimerLayerRemoteClusterStore) GetAllByPluginID(pluginID string) ([]*model.RemoteCluster, error) {
+	start := time.Now()
+
+	result, err := s.RemoteClusterStore.GetAllByPluginID(pluginID)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RemoteClusterStore.GetAllByPluginID", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerRemoteClusterStore) GetByPluginID(pluginID string) (*model.RemoteCluster, error) {
 	start := time.Now()
 
@@ -8781,6 +8797,22 @@ func (s *TimerLayerRemoteClusterStore) GetByPluginID(pluginID string) (*model.Re
 			success = "true"
 		}
 		s.Root.Metrics.ObserveStoreMethodDuration("RemoteClusterStore.GetByPluginID", success, elapsed)
+	}
+	return result, err
+}
+
+func (s *TimerLayerRemoteClusterStore) GetBySiteURL(siteURL string) (*model.RemoteCluster, error) {
+	start := time.Now()
+
+	result, err := s.RemoteClusterStore.GetBySiteURL(siteURL)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RemoteClusterStore.GetBySiteURL", success, elapsed)
 	}
 	return result, err
 }

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10317,6 +10317,10 @@
     "translation": "ClusterName must be set."
   },
   {
+    "id": "model.cluster.is_valid.site_url.app_error",
+    "translation": "SiteURL must be set."
+  },
+  {
     "id": "model.cluster.is_valid.type.app_error",
     "translation": "Type must be set."
   },

--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -45,6 +45,7 @@ const (
 	STATUS                          = "status"
 	StatusOk                        = "OK"
 	StatusFail                      = "FAIL"
+	StatusDisabled                  = "disabled"
 	StatusUnhealthy                 = "UNHEALTHY"
 	StatusRemove                    = "REMOVE"
 	ConnectionId                    = "Connection-Id"

--- a/server/public/model/file_info.go
+++ b/server/public/model/file_info.go
@@ -54,31 +54,31 @@ type GetFileInfosOptions struct {
 }
 
 type FileInfo struct {
-	Id        string `json:"id"`
-	CreatorId string `json:"user_id"`
-	PostId    string `json:"post_id,omitempty"`
+	Id        string `json:"id" xml:"Id"`
+	CreatorId string `json:"user_id" xml:"CreatorId"`
+	PostId    string `json:"post_id,omitempty" xml:"PostId,omitempty"`
 	// ChannelId is the denormalized value from the corresponding post. Note that this value is
 	// potentially distinct from the ChannelId provided when the file is first uploaded and
 	// used to organize the directories in the file store, since in theory that same file
 	// could be attached to a post from a different channel (or not attached to a post at all).
-	ChannelId       string  `json:"channel_id"`
-	CreateAt        int64   `json:"create_at"`
-	UpdateAt        int64   `json:"update_at"`
-	DeleteAt        int64   `json:"delete_at"`
-	Path            string  `json:"-"` // not sent back to the client
-	ThumbnailPath   string  `json:"-"` // not sent back to the client
-	PreviewPath     string  `json:"-"` // not sent back to the client
-	Name            string  `json:"name"`
-	Extension       string  `json:"extension"`
-	Size            int64   `json:"size"`
-	MimeType        string  `json:"mime_type"`
-	Width           int     `json:"width,omitempty"`
-	Height          int     `json:"height,omitempty"`
-	HasPreviewImage bool    `json:"has_preview_image,omitempty"`
-	MiniPreview     *[]byte `json:"mini_preview"` // pointer to distinguish NULL (no preview) from empty data
-	Content         string  `json:"-"`
-	RemoteId        *string `json:"remote_id"`
-	Archived        bool    `json:"archived"`
+	ChannelId       string  `json:"channel_id" xml:"ChannelId"`
+	CreateAt        int64   `json:"create_at" xml:"CreateAt"`
+	UpdateAt        int64   `json:"update_at" xml:"UpdateAt"`
+	DeleteAt        int64   `json:"delete_at" xml:"DeleteAt"`
+	Path            string  `json:"-" xml:"-"` // not sent back to the client
+	ThumbnailPath   string  `json:"-" xml:"-"` // not sent back to the client
+	PreviewPath     string  `json:"-" xml:"-"` // not sent back to the client
+	Name            string  `json:"name" xml:"Name"`
+	Extension       string  `json:"extension" xml:"Extension"`
+	Size            int64   `json:"size" xml:"Size"`
+	MimeType        string  `json:"mime_type" xml:"MimeType"`
+	Width           int     `json:"width,omitempty" xml:"Width,omitempty"`
+	Height          int     `json:"height,omitempty" xml:"Height,omitempty"`
+	HasPreviewImage bool    `json:"has_preview_image,omitempty" xml:"HasPreviewImage,omitempty"`
+	MiniPreview     *[]byte `json:"mini_preview" xml:"-"` // pointer to distinguish NULL (no preview) from empty data
+	Content         string  `json:"-" xml:"-"`
+	RemoteId        *string `json:"remote_id" xml:"RemoteId"`
+	Archived        bool    `json:"archived" xml:"Archived"`
 }
 
 func (fi *FileInfo) Auditable() map[string]any {

--- a/server/public/model/post.go
+++ b/server/public/model/post.go
@@ -111,39 +111,39 @@ const (
 )
 
 type Post struct {
-	Id         string `json:"id"`
-	CreateAt   int64  `json:"create_at"`
-	UpdateAt   int64  `json:"update_at"`
-	EditAt     int64  `json:"edit_at"`
-	DeleteAt   int64  `json:"delete_at"`
-	IsPinned   bool   `json:"is_pinned"`
-	UserId     string `json:"user_id"`
-	ChannelId  string `json:"channel_id"`
-	RootId     string `json:"root_id"`
-	OriginalId string `json:"original_id"`
+	Id         string `json:"id" xml:"Id"`
+	CreateAt   int64  `json:"create_at" xml:"CreateAt"`
+	UpdateAt   int64  `json:"update_at" xml:"UpdateAt"`
+	EditAt     int64  `json:"edit_at" xml:"EditAt"`
+	DeleteAt   int64  `json:"delete_at" xml:"DeleteAt"`
+	IsPinned   bool   `json:"is_pinned" xml:"IsPinned"`
+	UserId     string `json:"user_id" xml:"UserId"`
+	ChannelId  string `json:"channel_id" xml:"ChannelId"`
+	RootId     string `json:"root_id" xml:"RootId"`
+	OriginalId string `json:"original_id" xml:"OriginalId"`
 
-	Message string `json:"message"`
+	Message string `json:"message" xml:"Message"`
 	// MessageSource will contain the message as submitted by the user if Message has been modified
 	// by Mattermost for presentation (e.g if an image proxy is being used). It should be used to
 	// populate edit boxes if present.
-	MessageSource string `json:"message_source,omitempty"`
+	MessageSource string `json:"message_source,omitempty" xml:"MessageSource,omitempty"`
 
-	Type          string          `json:"type"`
-	propsMu       sync.RWMutex    `db:"-"`       // Unexported mutex used to guard Post.Props.
-	Props         StringInterface `json:"props"` // Deprecated: use GetProps()
-	Hashtags      string          `json:"hashtags"`
-	Filenames     StringArray     `json:"-"` // Deprecated, do not use this field any more
-	FileIds       StringArray     `json:"file_ids"`
-	PendingPostId string          `json:"pending_post_id"`
-	HasReactions  bool            `json:"has_reactions,omitempty"`
-	RemoteId      *string         `json:"remote_id,omitempty"`
+	Type          string          `json:"type" xml:"Type"`
+	propsMu       sync.RWMutex    `db:"-"`                   // Unexported mutex used to guard Post.Props.
+	Props         StringInterface `json:"props" xml:"Props"` // Deprecated: use GetProps()
+	Hashtags      string          `json:"hashtags" xml:"Hashtags"`
+	Filenames     StringArray     `json:"-" xml:"-"` // Deprecated, do not use this field any more
+	FileIds       StringArray     `json:"file_ids" xml:"FileIds>Id"`
+	PendingPostId string          `json:"pending_post_id" xml:"PendingPostId"`
+	HasReactions  bool            `json:"has_reactions,omitempty" xml:"HasReactions,omitempty"`
+	RemoteId      *string         `json:"remote_id,omitempty" xml:"RemoteId,omitempty"`
 
 	// Transient data populated before sending a post to the client
-	ReplyCount   int64         `json:"reply_count"`
-	LastReplyAt  int64         `json:"last_reply_at"`
-	Participants []*User       `json:"participants"`
-	IsFollowing  *bool         `json:"is_following,omitempty"` // for root posts in collapsed thread mode indicates if the current user is following this thread
-	Metadata     *PostMetadata `json:"metadata,omitempty"`
+	ReplyCount   int64         `json:"reply_count" xml:"ReplyCount"`
+	LastReplyAt  int64         `json:"last_reply_at" xml:"LastReplyAt"`
+	Participants []*User       `json:"participants" xml:"Participants>User"`
+	IsFollowing  *bool         `json:"is_following,omitempty" xml:"IsFollowing,omitempty"` // for root posts in collapsed thread mode indicates if the current user is following this thread
+	Metadata     *PostMetadata `json:"metadata,omitempty" xml:"-"`
 }
 
 func (o *Post) Auditable() map[string]any {

--- a/server/public/model/post_acknowledgement.go
+++ b/server/public/model/post_acknowledgement.go
@@ -6,11 +6,11 @@ package model
 import "net/http"
 
 type PostAcknowledgement struct {
-	UserId         string  `json:"user_id"`
-	PostId         string  `json:"post_id"`
-	AcknowledgedAt int64   `json:"acknowledged_at"`
-	ChannelId      string  `json:"channel_id"`
-	RemoteId       *string `json:"remote_id,omitempty"`
+	UserId         string  `json:"user_id" xml:"UserId"`
+	PostId         string  `json:"post_id" xml:"PostId"`
+	AcknowledgedAt int64   `json:"acknowledged_at" xml:"AcknowledgedAt"`
+	ChannelId      string  `json:"channel_id" xml:"ChannelId"`
+	RemoteId       *string `json:"remote_id,omitempty" xml:"RemoteId,omitempty"`
 }
 
 func (o *PostAcknowledgement) IsValid() *AppError {

--- a/server/public/model/reaction.go
+++ b/server/public/model/reaction.go
@@ -9,14 +9,14 @@ import (
 )
 
 type Reaction struct {
-	UserId    string  `json:"user_id"`
-	PostId    string  `json:"post_id"`
-	EmojiName string  `json:"emoji_name"`
-	CreateAt  int64   `json:"create_at"`
-	UpdateAt  int64   `json:"update_at"`
-	DeleteAt  int64   `json:"delete_at"`
-	RemoteId  *string `json:"remote_id"`
-	ChannelId string  `json:"channel_id"`
+	UserId    string  `json:"user_id" xml:"UserId"`
+	PostId    string  `json:"post_id" xml:"PostId"`
+	EmojiName string  `json:"emoji_name" xml:"EmojiName"`
+	CreateAt  int64   `json:"create_at" xml:"CreateAt"`
+	UpdateAt  int64   `json:"update_at" xml:"UpdateAt"`
+	DeleteAt  int64   `json:"delete_at" xml:"DeleteAt"`
+	RemoteId  *string `json:"remote_id" xml:"RemoteId"`
+	ChannelId string  `json:"channel_id" xml:"ChannelId"`
 }
 
 func (o *Reaction) IsValid() *AppError {

--- a/server/public/model/remote_cluster.go
+++ b/server/public/model/remote_cluster.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -199,6 +200,35 @@ func IsValidRemoteName(s string) bool {
 		return false
 	}
 	return validRemoteNameChars.MatchString(s)
+}
+
+// CleanRemoteName converts an arbitrary string into a slug compatible with
+// IsValidRemoteName: lowercased, with spaces and other disallowed characters
+// replaced by hyphens. The result is truncated to RemoteNameMaxLength. If
+// the cleaned value is still invalid (e.g. empty input), a new ID is
+// substituted so the caller always receives a valid name.
+func CleanRemoteName(s string) string {
+	s = strings.ToLower(strings.ReplaceAll(s, " ", "-"))
+	s = strings.TrimSpace(s)
+
+	for _, c := range s {
+		char := fmt.Sprintf("%c", c)
+		if !validRemoteNameChars.MatchString(char) {
+			s = strings.ReplaceAll(s, char, "-")
+		}
+	}
+
+	s = strings.Trim(s, "-")
+
+	if len(s) > RemoteNameMaxLength {
+		s = strings.Trim(s[:RemoteNameMaxLength], "-")
+	}
+
+	if !IsValidRemoteName(s) {
+		s = NewId()
+	}
+
+	return s
 }
 
 func (rc *RemoteCluster) PreUpdate() {

--- a/server/public/model/remote_cluster.go
+++ b/server/public/model/remote_cluster.go
@@ -9,7 +9,6 @@ import (
 	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha256"
-	"encoding/base32"
 	"encoding/json"
 	"errors"
 	"io"
@@ -27,7 +26,11 @@ const (
 	RemoteNameMaxLength      = 64
 
 	SiteURLPending = "pending_"
-	SiteURLPlugin  = "plugin_"
+
+	// Deprecated: SiteURLPlugin was used as a prefix for plugin-based remote SiteURLs.
+	// New registrations store the plugin-provided SiteURL directly. Use PluginID field
+	// to identify plugin-based remotes.
+	SiteURLPlugin = "plugin_"
 
 	BitflagOptionAutoShareDMs Bitmask = 1 << iota // Any new DM/GM is automatically shared
 	BitflagOptionAutoInvited                      // Remote is automatically invited to all shared channels
@@ -92,11 +95,7 @@ func (rc *RemoteCluster) Auditable() map[string]any {
 
 func (rc *RemoteCluster) PreSave() {
 	if rc.RemoteId == "" {
-		if rc.PluginID != "" {
-			rc.RemoteId = newIDFromBytes([]byte(rc.PluginID))
-		} else {
-			rc.RemoteId = NewId()
-		}
+		rc.RemoteId = NewId()
 	}
 
 	if rc.DisplayName == "" {
@@ -132,6 +131,10 @@ func (rc *RemoteCluster) IsValid() *AppError {
 
 	if !IsValidId(rc.CreatorId) {
 		return NewAppError("RemoteCluster.IsValid", "model.cluster.is_valid.id.app_error", nil, "creator_id="+rc.CreatorId, http.StatusBadRequest)
+	}
+
+	if rc.SiteURL == "" {
+		return NewAppError("RemoteCluster.IsValid", "model.cluster.is_valid.site_url.app_error", nil, "site_url is empty", http.StatusBadRequest)
 	}
 
 	if rc.DefaultTeamId != "" && !IsValidId(rc.DefaultTeamId) {
@@ -177,16 +180,6 @@ type RemoteClusterWithInvite struct {
 	RemoteCluster *RemoteCluster `json:"remote_cluster"`
 	Invite        string         `json:"invite"`
 	Password      string         `json:"password,omitempty"`
-}
-
-func newIDFromBytes(b []byte) string {
-	hash := sha256.New()
-	_, _ = hash.Write(b)
-	buf := hash.Sum(nil)
-
-	encoding := base32.NewEncoding("ybndrfg8ejkmcpqxot1uwisza345h769").WithPadding(base32.NoPadding)
-	id := encoding.EncodeToString(buf)
-	return id[:26]
 }
 
 func (rc *RemoteCluster) IsOptionFlagSet(flag Bitmask) bool {
@@ -235,10 +228,7 @@ func (rc *RemoteCluster) IsConfirmed() bool {
 }
 
 func (rc *RemoteCluster) IsPlugin() bool {
-	if rc.PluginID != "" || strings.HasPrefix(rc.SiteURL, SiteURLPlugin) {
-		return true // local plugins are automatically confirmed
-	}
-	return false
+	return rc.PluginID != ""
 }
 
 func (rc *RemoteCluster) GetSiteURL() string {

--- a/server/public/model/remote_cluster_test.go
+++ b/server/public/model/remote_cluster_test.go
@@ -24,6 +24,7 @@ func TestRemoteClusterIsValid(t *testing.T) {
 		{name: "Zero value", rc: &RemoteCluster{}, valid: false},
 		{name: "Missing cluster_name", rc: &RemoteCluster{RemoteId: id}, valid: false},
 		{name: "Missing host_name", rc: &RemoteCluster{RemoteId: id, Name: NewId()}, valid: false},
+		{name: "Missing site_url", rc: &RemoteCluster{RemoteId: id, Name: NewId(), CreatorId: creator, CreateAt: now}, valid: false},
 		{name: "Missing create_at", rc: &RemoteCluster{RemoteId: id, Name: NewId(), SiteURL: "example.com"}, valid: false},
 		{name: "Missing last_ping_at", rc: &RemoteCluster{RemoteId: id, Name: NewId(), SiteURL: "example.com", CreatorId: creator, CreateAt: now}, valid: true},
 		{name: "Missing creator", rc: &RemoteCluster{RemoteId: id, Name: NewId(), SiteURL: "example.com", CreateAt: now, LastPingAt: now}, valid: false},
@@ -240,24 +241,19 @@ func TestRemoteClusterToRemoteClusterInfo(t *testing.T) {
 	assert.Equal(t, rc.SiteURL, info.SiteURL)
 }
 
-func TestNewIDFromBytes(t *testing.T) {
-	tests := []struct {
-		name string
-		ss   string
-	}{
-		{name: "empty", ss: ""},
-		{name: "very short", ss: "x"},
-		{name: "normal", ss: "com.mattermost.msteams-sync"},
-		{name: "long", ss: "com.mattermost.msteams-synccom.mattermost.msteams-synccom.mattermost.msteams-synccom.mattermost.msteams-sync"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got1 := newIDFromBytes([]byte(tt.ss))
+func TestRemoteClusterIsPlugin(t *testing.T) {
+	t.Run("PluginID set returns true", func(t *testing.T) {
+		rc := &RemoteCluster{PluginID: "com.example.plugin", SiteURL: "https://example.com"}
+		assert.True(t, rc.IsPlugin())
+	})
 
-			assert.True(t, IsValidId(got1), "not a valid id")
+	t.Run("empty PluginID returns false", func(t *testing.T) {
+		rc := &RemoteCluster{SiteURL: "https://example.com"}
+		assert.False(t, rc.IsPlugin())
+	})
 
-			got2 := newIDFromBytes([]byte(tt.ss))
-			assert.Equal(t, got1, got2, "newIDFromBytes must generate same id for same inputs")
-		})
-	}
+	t.Run("plugin_ SiteURL prefix with empty PluginID returns false", func(t *testing.T) {
+		rc := &RemoteCluster{SiteURL: SiteURLPlugin + "com.example.plugin"}
+		assert.False(t, rc.IsPlugin(), "IsPlugin should only check PluginID, not SiteURL prefix")
+	})
 }

--- a/server/public/model/remote_cluster_test.go
+++ b/server/public/model/remote_cluster_test.go
@@ -6,6 +6,7 @@ package model
 import (
 	"crypto/rand"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -255,5 +256,46 @@ func TestRemoteClusterIsPlugin(t *testing.T) {
 	t.Run("plugin_ SiteURL prefix with empty PluginID returns false", func(t *testing.T) {
 		rc := &RemoteCluster{SiteURL: SiteURLPlugin + "com.example.plugin"}
 		assert.False(t, rc.IsPlugin(), "IsPlugin should only check PluginID, not SiteURL prefix")
+	})
+}
+
+func TestCleanRemoteName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "single space", in: "legacy plugin", want: "legacy-plugin"},
+		{name: "multiple spaces", in: "remote 1 plugin", want: "remote-1-plugin"},
+		{name: "uppercase", in: "Plugin A", want: "plugin-a"},
+		{name: "preserves dot, hyphen, underscore", in: "com.example_plugin-1", want: "com.example_plugin-1"},
+		{name: "trims separators", in: "  ---my remote---  ", want: "my-remote"},
+		{name: "punctuation collapses", in: "plugin@home!", want: "plugin-home"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CleanRemoteName(tc.in)
+			assert.Equal(t, tc.want, got)
+			assert.True(t, IsValidRemoteName(got), "CleanRemoteName must produce a valid name")
+		})
+	}
+
+	t.Run("empty input falls back to NewId", func(t *testing.T) {
+		got := CleanRemoteName("")
+		assert.True(t, IsValidRemoteName(got))
+		assert.Len(t, got, 26)
+	})
+
+	t.Run("only invalid characters falls back to NewId", func(t *testing.T) {
+		got := CleanRemoteName("@@@ !!! ???")
+		assert.True(t, IsValidRemoteName(got))
+		assert.Len(t, got, 26)
+	})
+
+	t.Run("over-length input is truncated", func(t *testing.T) {
+		in := strings.Repeat("a", RemoteNameMaxLength+10)
+		got := CleanRemoteName(in)
+		assert.True(t, IsValidRemoteName(got))
+		assert.LessOrEqual(t, len(got), RemoteNameMaxLength)
 	})
 }

--- a/server/public/model/shared_channel.go
+++ b/server/public/model/shared_channel.go
@@ -5,7 +5,9 @@ package model
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"net/http"
+	"sort"
 	"unicode/utf8"
 
 	"github.com/pkg/errors"
@@ -277,11 +279,11 @@ type SharedChannelRemoteFilterOpts struct {
 
 // MembershipChangeMsg represents a change in channel membership
 type MembershipChangeMsg struct {
-	ChannelId  string `json:"channel_id"`
-	UserId     string `json:"user_id"`
-	IsAdd      bool   `json:"is_add"`
-	RemoteId   string `json:"remote_id"`
-	ChangeTime int64  `json:"change_time"`
+	ChannelId  string `json:"channel_id" xml:"ChannelId"`
+	UserId     string `json:"user_id" xml:"UserId"`
+	IsAdd      bool   `json:"is_add" xml:"IsAdd"`
+	RemoteId   string `json:"remote_id" xml:"RemoteId"`
+	ChangeTime int64  `json:"change_time" xml:"ChangeTime"`
 }
 
 // SyncMsg represents a change in content (post add/edit/delete, reaction add/remove, users).
@@ -321,24 +323,223 @@ func (sm *SyncMsg) String() string {
 	return string(json)
 }
 
+// xmlSyncMsgFields contains the non-map fields of SyncMsg for XML serialization.
+type xmlSyncMsgFields struct {
+	Id                string                 `xml:"Id"`
+	ChannelId         string                 `xml:"ChannelId"`
+	Posts             []*Post                `xml:"Posts>Post,omitempty"`
+	Reactions         []*Reaction            `xml:"Reactions>Reaction,omitempty"`
+	Statuses          []*Status              `xml:"Statuses>Status,omitempty"`
+	MembershipChanges []*MembershipChangeMsg `xml:"MembershipChanges>MembershipChangeMsg,omitempty"`
+	Acknowledgements  []*PostAcknowledgement `xml:"Acknowledgements>PostAcknowledgement,omitempty"`
+}
+
+// xmlSyncMsgUser wraps a User with an ID attribute for XML map serialization.
+type xmlSyncMsgUser struct {
+	ID   string `xml:"id,attr"`
+	User *User  `xml:"User"`
+}
+
+// xmlSyncMsgMentionTransform represents a single mention transform entry.
+type xmlSyncMsgMentionTransform struct {
+	Key   string `xml:"key,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// MarshalXML encodes a SyncMsg to XML, handling the Users map and MentionTransforms map.
+func (sm *SyncMsg) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+
+	// Encode non-map fields via the helper struct.
+	fields := xmlSyncMsgFields{
+		Id:                sm.Id,
+		ChannelId:         sm.ChannelId,
+		Posts:             sm.Posts,
+		Reactions:         sm.Reactions,
+		Statuses:          sm.Statuses,
+		MembershipChanges: sm.MembershipChanges,
+		Acknowledgements:  sm.Acknowledgements,
+	}
+	if err := e.EncodeElement(fields, xml.StartElement{Name: xml.Name{Local: "Fields"}}); err != nil {
+		return err
+	}
+
+	// Encode Users map as <Users><UserEntry id="..."><User>...</User></UserEntry></Users>
+	if len(sm.Users) > 0 {
+		usersStart := xml.StartElement{Name: xml.Name{Local: "Users"}}
+		if err := e.EncodeToken(usersStart); err != nil {
+			return err
+		}
+
+		keys := make([]string, 0, len(sm.Users))
+		for k := range sm.Users {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			entry := xmlSyncMsgUser{ID: k, User: sm.Users[k]}
+			if err := e.EncodeElement(entry, xml.StartElement{Name: xml.Name{Local: "UserEntry"}}); err != nil {
+				return err
+			}
+		}
+
+		if err := e.EncodeToken(usersStart.End()); err != nil {
+			return err
+		}
+	}
+
+	// Encode MentionTransforms as <MentionTransforms><Transform key="..." value="..."/></MentionTransforms>
+	if len(sm.MentionTransforms) > 0 {
+		mtStart := xml.StartElement{Name: xml.Name{Local: "MentionTransforms"}}
+		if err := e.EncodeToken(mtStart); err != nil {
+			return err
+		}
+
+		keys := make([]string, 0, len(sm.MentionTransforms))
+		for k := range sm.MentionTransforms {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			entry := xmlSyncMsgMentionTransform{Key: k, Value: sm.MentionTransforms[k]}
+			if err := e.EncodeElement(entry, xml.StartElement{Name: xml.Name{Local: "Transform"}}); err != nil {
+				return err
+			}
+		}
+
+		if err := e.EncodeToken(mtStart.End()); err != nil {
+			return err
+		}
+	}
+
+	return e.EncodeToken(start.End())
+}
+
+// UnmarshalXML decodes a SyncMsg from XML, handling the Users map and MentionTransforms map.
+func (sm *SyncMsg) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	sm.Users = nil
+	sm.MentionTransforms = nil
+
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			switch t.Name.Local {
+			case "Fields":
+				var fields xmlSyncMsgFields
+				if err := d.DecodeElement(&fields, &t); err != nil {
+					return err
+				}
+				sm.Id = fields.Id
+				sm.ChannelId = fields.ChannelId
+				sm.Posts = fields.Posts
+				sm.Reactions = fields.Reactions
+				sm.Statuses = fields.Statuses
+				sm.MembershipChanges = fields.MembershipChanges
+				sm.Acknowledgements = fields.Acknowledgements
+
+			case "Users":
+				sm.Users = make(map[string]*User)
+				if err := decodeXMLUsers(d, sm); err != nil {
+					return err
+				}
+
+			case "MentionTransforms":
+				sm.MentionTransforms = make(map[string]string)
+				if err := decodeXMLMentionTransforms(d, sm); err != nil {
+					return err
+				}
+
+			default:
+				if err := d.Skip(); err != nil {
+					return err
+				}
+			}
+
+		case xml.EndElement:
+			return nil
+		}
+	}
+}
+
+func decodeXMLUsers(d *xml.Decoder, sm *SyncMsg) error {
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "UserEntry" {
+				var entry xmlSyncMsgUser
+				if err := d.DecodeElement(&entry, &t); err != nil {
+					return err
+				}
+				sm.Users[entry.ID] = entry.User
+			} else {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+			}
+		case xml.EndElement:
+			return nil
+		}
+	}
+}
+
+func decodeXMLMentionTransforms(d *xml.Decoder, sm *SyncMsg) error {
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "Transform" {
+				var entry xmlSyncMsgMentionTransform
+				if err := d.DecodeElement(&entry, &t); err != nil {
+					return err
+				}
+				sm.MentionTransforms[entry.Key] = entry.Value
+			} else {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+			}
+		case xml.EndElement:
+			return nil
+		}
+	}
+}
+
 // SyncResponse represents the response to a synchronization event
 type SyncResponse struct {
-	UsersLastUpdateAt int64    `json:"users_last_update_at"`
-	UserErrors        []string `json:"user_errors"`
-	UsersSyncd        []string `json:"users_syncd"`
+	UsersLastUpdateAt int64    `json:"users_last_update_at" xml:"UsersLastUpdateAt"`
+	UserErrors        []string `json:"user_errors" xml:"UserErrors>Error"`
+	UsersSyncd        []string `json:"users_syncd" xml:"UsersSyncd>UserId"`
 
-	PostsLastUpdateAt int64    `json:"posts_last_update_at"`
-	PostErrors        []string `json:"post_errors"`
+	PostsLastUpdateAt int64    `json:"posts_last_update_at" xml:"PostsLastUpdateAt"`
+	PostErrors        []string `json:"post_errors" xml:"PostErrors>Error"`
 
-	ReactionsLastUpdateAt int64    `json:"reactions_last_update_at"`
-	ReactionErrors        []string `json:"reaction_errors"`
+	ReactionsLastUpdateAt int64    `json:"reactions_last_update_at" xml:"ReactionsLastUpdateAt"`
+	ReactionErrors        []string `json:"reaction_errors" xml:"ReactionErrors>Error"`
 
-	AcknowledgementsLastUpdateAt int64    `json:"acknowledgements_last_update_at"`
-	AcknowledgementErrors        []string `json:"acknowledgement_errors"`
+	AcknowledgementsLastUpdateAt int64    `json:"acknowledgements_last_update_at" xml:"AcknowledgementsLastUpdateAt"`
+	AcknowledgementErrors        []string `json:"acknowledgement_errors" xml:"AcknowledgementErrors>Error"`
 
-	StatusErrors []string `json:"status_errors"` // user IDs for which the status sync failed
+	StatusErrors []string `json:"status_errors" xml:"StatusErrors>Error"` // user IDs for which the status sync failed
 
-	MembershipErrors []string `json:"membership_errors,omitempty"`
+	MembershipErrors []string `json:"membership_errors,omitempty" xml:"MembershipErrors>Error,omitempty"`
 }
 
 // RegisterPluginOpts is passed by plugins to the `RegisterPluginForSharedChannels` plugin API
@@ -349,6 +550,19 @@ type RegisterPluginOpts struct {
 	CreatorID    string // id of the user/bot registering
 	AutoShareDMs bool   // when true, all DMs are automatically shared to this remote
 	AutoInvited  bool   // when true, the plugin is automatically invited and sync'd with all shared channels.
+
+	// SiteURL identifies the remote endpoint for this secure connection. Stored directly as
+	// RemoteCluster.SiteURL. Must be unique across all remote clusters (enforced by the DB
+	// unique index on (SiteURL, RemoteTeamId)).
+	// When empty, defaults to "plugin_<PluginID>" for backward compatibility with single-remote
+	// plugins. When non-empty, the SiteURL must not already be in use by a different plugin or
+	// a server-to-server remote.
+	// Calling RegisterPluginForSharedChannels again with the same SiteURL returns the existing
+	// remoteID and preserves sync cursors (idempotent re-registration).
+	// A plugin registers multiple remotes by calling this method multiple times with different
+	// SiteURLs.
+	// Examples: "nats://nats:4222", "https://matrix.org"
+	SiteURL string
 }
 
 // GetOptionFlags returns a Bitmask of option flags as specified by the boolean options.

--- a/server/public/model/shared_channel_test.go
+++ b/server/public/model/shared_channel_test.go
@@ -4,6 +4,8 @@
 package model
 
 import (
+	"encoding/json"
+	"encoding/xml"
 	"strings"
 	"testing"
 
@@ -63,4 +65,455 @@ func TestSharedChannelPreUpdate(t *testing.T) {
 	o.PreUpdate()
 
 	require.GreaterOrEqual(t, o.UpdateAt, now)
+}
+
+func TestSyncMsgXMLRoundTrip(t *testing.T) {
+	remoteID := NewId()
+	msg := &SyncMsg{
+		Id:        NewId(),
+		ChannelId: NewId(),
+		Users: map[string]*User{
+			"user1": {
+				Id:       NewId(),
+				Username: "testuser1",
+				Email:    "test1@example.com",
+				Props:    StringMap{"key1": "val1"},
+				Timezone: StringMap{"useAutomaticTimezone": "true"},
+			},
+			"user2": {
+				Id:       NewId(),
+				Username: "testuser2",
+				Email:    "test2@example.com",
+			},
+		},
+		Posts: []*Post{
+			{
+				Id:        NewId(),
+				ChannelId: NewId(),
+				UserId:    NewId(),
+				Message:   "hello world",
+				Props:     StringInterface{"from_webhook": "true", "count": float64(42)},
+				RemoteId:  &remoteID,
+			},
+		},
+		Reactions: []*Reaction{
+			{
+				UserId:    NewId(),
+				PostId:    NewId(),
+				EmojiName: "thumbsup",
+				CreateAt:  1000,
+			},
+		},
+		Statuses: []*Status{
+			{
+				UserId: NewId(),
+				Status: StatusOnline,
+			},
+		},
+		MembershipChanges: []*MembershipChangeMsg{
+			{
+				ChannelId:  NewId(),
+				UserId:     NewId(),
+				IsAdd:      true,
+				RemoteId:   NewId(),
+				ChangeTime: 2000,
+			},
+		},
+		Acknowledgements: []*PostAcknowledgement{
+			{
+				UserId:         NewId(),
+				PostId:         NewId(),
+				AcknowledgedAt: 3000,
+				ChannelId:      NewId(),
+			},
+		},
+		MentionTransforms: map[string]string{
+			"@olduser": "@newuser",
+			"@admin":   "@remote_admin",
+		},
+	}
+
+	data, err := xml.MarshalIndent(msg, "", "  ")
+	require.NoError(t, err)
+
+	var decoded SyncMsg
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, msg.Id, decoded.Id)
+	assert.Equal(t, msg.ChannelId, decoded.ChannelId)
+	assert.Len(t, decoded.Users, 2)
+	assert.Equal(t, msg.Users["user1"].Username, decoded.Users["user1"].Username)
+	assert.Equal(t, msg.Users["user2"].Username, decoded.Users["user2"].Username)
+	assert.Len(t, decoded.Posts, 1)
+	assert.Equal(t, msg.Posts[0].Message, decoded.Posts[0].Message)
+	assert.Len(t, decoded.Reactions, 1)
+	assert.Equal(t, msg.Reactions[0].EmojiName, decoded.Reactions[0].EmojiName)
+	assert.Len(t, decoded.Statuses, 1)
+	assert.Equal(t, msg.Statuses[0].Status, decoded.Statuses[0].Status)
+	assert.Len(t, decoded.MembershipChanges, 1)
+	assert.Equal(t, msg.MembershipChanges[0].IsAdd, decoded.MembershipChanges[0].IsAdd)
+	assert.Len(t, decoded.Acknowledgements, 1)
+	assert.Equal(t, msg.Acknowledgements[0].AcknowledgedAt, decoded.Acknowledgements[0].AcknowledgedAt)
+	assert.Equal(t, msg.MentionTransforms, decoded.MentionTransforms)
+}
+
+func TestSyncMsgXMLUsersMap(t *testing.T) {
+	msg := &SyncMsg{
+		Id: NewId(),
+		Users: map[string]*User{
+			"alpha": {Id: "id-alpha", Username: "alpha"},
+			"beta":  {Id: "id-beta", Username: "beta"},
+			"gamma": {Id: "id-gamma", Username: "gamma"},
+		},
+	}
+
+	data, err := xml.Marshal(msg)
+	require.NoError(t, err)
+
+	var decoded SyncMsg
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	require.Len(t, decoded.Users, 3)
+	assert.Equal(t, "alpha", decoded.Users["alpha"].Username)
+	assert.Equal(t, "beta", decoded.Users["beta"].Username)
+	assert.Equal(t, "gamma", decoded.Users["gamma"].Username)
+}
+
+func TestSyncMsgXMLMentionTransforms(t *testing.T) {
+	msg := &SyncMsg{
+		Id: NewId(),
+		MentionTransforms: map[string]string{
+			"@user1": "@remote_user1",
+			"@user2": "@remote_user2",
+		},
+	}
+
+	data, err := xml.Marshal(msg)
+	require.NoError(t, err)
+
+	var decoded SyncMsg
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, msg.MentionTransforms, decoded.MentionTransforms)
+}
+
+func TestSyncMsgXMLEmptyMaps(t *testing.T) {
+	msg := &SyncMsg{
+		Id:        NewId(),
+		ChannelId: NewId(),
+	}
+
+	data, err := xml.Marshal(msg)
+	require.NoError(t, err)
+
+	var decoded SyncMsg
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, msg.Id, decoded.Id)
+	assert.Equal(t, msg.ChannelId, decoded.ChannelId)
+	assert.Nil(t, decoded.Users)
+	assert.Nil(t, decoded.MentionTransforms)
+}
+
+func TestPostXMLRoundTrip(t *testing.T) {
+	remoteID := NewId()
+	post := &Post{
+		Id:        NewId(),
+		CreateAt:  1000,
+		UpdateAt:  2000,
+		UserId:    NewId(),
+		ChannelId: NewId(),
+		Message:   "test message with <xml> special & chars",
+		Props: StringInterface{
+			"from_webhook": "true",
+			"count":        float64(42),
+			"nested":       map[string]any{"a": float64(1), "b": "two"},
+		},
+		FileIds:  StringArray{"file1", "file2"},
+		RemoteId: &remoteID,
+		Metadata: &PostMetadata{}, // should be excluded from XML
+	}
+
+	data, err := xml.MarshalIndent(post, "", "  ")
+	require.NoError(t, err)
+
+	var decoded Post
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, post.Id, decoded.Id)
+	assert.Equal(t, post.Message, decoded.Message)
+	assert.Equal(t, post.CreateAt, decoded.CreateAt)
+	assert.Equal(t, "true", decoded.Props["from_webhook"])
+	assert.Equal(t, float64(42), decoded.Props["count"])
+	assert.Equal(t, post.FileIds, decoded.FileIds)
+	assert.Equal(t, *post.RemoteId, *decoded.RemoteId)
+	assert.Nil(t, decoded.Metadata, "Metadata should be excluded from XML")
+}
+
+func TestUserXMLRoundTrip(t *testing.T) {
+	remoteID := NewId()
+	user := &User{
+		Id:          NewId(),
+		Username:    "testuser",
+		Email:       "test@example.com",
+		FirstName:   "Test",
+		LastName:    "User",
+		Props:       StringMap{"customkey": "customval"},
+		NotifyProps: StringMap{"push": "all", "desktop": "mention"},
+		Timezone:    StringMap{"useAutomaticTimezone": "true", "manualTimezone": "America/New_York"},
+		RemoteId:    &remoteID,
+	}
+
+	data, err := xml.MarshalIndent(user, "", "  ")
+	require.NoError(t, err)
+
+	var decoded User
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, user.Id, decoded.Id)
+	assert.Equal(t, user.Username, decoded.Username)
+	assert.Equal(t, user.Email, decoded.Email)
+	assert.Equal(t, user.Props, decoded.Props)
+	assert.Equal(t, user.NotifyProps, decoded.NotifyProps)
+	assert.Equal(t, user.Timezone, decoded.Timezone)
+	assert.Equal(t, *user.RemoteId, *decoded.RemoteId)
+}
+
+func TestReactionXMLRoundTrip(t *testing.T) {
+	remoteID := NewId()
+	reaction := &Reaction{
+		UserId:    NewId(),
+		PostId:    NewId(),
+		EmojiName: "thumbsup",
+		CreateAt:  1000,
+		UpdateAt:  2000,
+		RemoteId:  &remoteID,
+		ChannelId: NewId(),
+	}
+
+	data, err := xml.Marshal(reaction)
+	require.NoError(t, err)
+
+	var decoded Reaction
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, reaction.UserId, decoded.UserId)
+	assert.Equal(t, reaction.PostId, decoded.PostId)
+	assert.Equal(t, reaction.EmojiName, decoded.EmojiName)
+	assert.Equal(t, reaction.CreateAt, decoded.CreateAt)
+	assert.Equal(t, *reaction.RemoteId, *decoded.RemoteId)
+}
+
+func TestStatusXMLRoundTrip(t *testing.T) {
+	status := &Status{
+		UserId:         NewId(),
+		Status:         StatusOnline,
+		Manual:         true,
+		LastActivityAt: 5000,
+		DNDEndTime:     6000,
+		PrevStatus:     StatusAway, // should be excluded
+	}
+
+	data, err := xml.Marshal(status)
+	require.NoError(t, err)
+
+	var decoded Status
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, status.UserId, decoded.UserId)
+	assert.Equal(t, status.Status, decoded.Status)
+	assert.Equal(t, status.Manual, decoded.Manual)
+	assert.Equal(t, status.DNDEndTime, decoded.DNDEndTime)
+	assert.Empty(t, decoded.PrevStatus, "PrevStatus should be excluded from XML")
+}
+
+func TestPostAcknowledgementXMLRoundTrip(t *testing.T) {
+	remoteID := NewId()
+	ack := &PostAcknowledgement{
+		UserId:         NewId(),
+		PostId:         NewId(),
+		AcknowledgedAt: 3000,
+		ChannelId:      NewId(),
+		RemoteId:       &remoteID,
+	}
+
+	data, err := xml.Marshal(ack)
+	require.NoError(t, err)
+
+	var decoded PostAcknowledgement
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, ack.UserId, decoded.UserId)
+	assert.Equal(t, ack.PostId, decoded.PostId)
+	assert.Equal(t, ack.AcknowledgedAt, decoded.AcknowledgedAt)
+	assert.Equal(t, ack.ChannelId, decoded.ChannelId)
+	assert.Equal(t, *ack.RemoteId, *decoded.RemoteId)
+}
+
+func TestFileInfoXMLRoundTrip(t *testing.T) {
+	remoteID := NewId()
+	fi := &FileInfo{
+		Id:            NewId(),
+		CreatorId:     NewId(),
+		PostId:        NewId(),
+		ChannelId:     NewId(),
+		CreateAt:      1000,
+		UpdateAt:      2000,
+		Name:          "test.txt",
+		Extension:     "txt",
+		Size:          1024,
+		MimeType:      "text/plain",
+		RemoteId:      &remoteID,
+		Path:          "/data/test.txt",
+		ThumbnailPath: "/data/test_thumb.txt",
+		PreviewPath:   "/data/test_preview.txt",
+		Content:       "file content for search",
+	}
+
+	data, err := xml.Marshal(fi)
+	require.NoError(t, err)
+
+	var decoded FileInfo
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, fi.Id, decoded.Id)
+	assert.Equal(t, fi.CreatorId, decoded.CreatorId)
+	assert.Equal(t, fi.Name, decoded.Name)
+	assert.Equal(t, fi.Size, decoded.Size)
+	assert.Equal(t, *fi.RemoteId, *decoded.RemoteId)
+	assert.Empty(t, decoded.Path, "Path should be excluded from XML")
+	assert.Empty(t, decoded.ThumbnailPath, "ThumbnailPath should be excluded from XML")
+	assert.Empty(t, decoded.PreviewPath, "PreviewPath should be excluded from XML")
+	assert.Empty(t, decoded.Content, "Content should be excluded from XML")
+}
+
+func TestStringMapXMLRoundTrip(t *testing.T) {
+	m := StringMap{
+		"key1":  "value1",
+		"key2":  "value2",
+		"empty": "",
+	}
+
+	data, err := xml.Marshal(m)
+	require.NoError(t, err)
+
+	var decoded StringMap
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, m, decoded)
+}
+
+func TestStringInterfaceXMLRoundTrip(t *testing.T) {
+	m := StringInterface{
+		"string_val": "hello",
+		"number_val": float64(42),
+		"bool_val":   true,
+		"null_val":   nil,
+		"nested":     map[string]any{"a": float64(1), "b": "two"},
+	}
+
+	data, err := xml.Marshal(m)
+	require.NoError(t, err)
+
+	var decoded StringInterface
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello", decoded["string_val"])
+	assert.Equal(t, float64(42), decoded["number_val"])
+	assert.Equal(t, true, decoded["bool_val"])
+	assert.Nil(t, decoded["null_val"])
+	nested, ok := decoded["nested"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(1), nested["a"])
+	assert.Equal(t, "two", nested["b"])
+}
+
+func TestXMLDoesNotAffectJSON(t *testing.T) {
+	remoteID := NewId()
+
+	t.Run("SyncMsg", func(t *testing.T) {
+		msg := &SyncMsg{
+			Id:        NewId(),
+			ChannelId: NewId(),
+			Users: map[string]*User{
+				"u1": {Id: NewId(), Username: "u1"},
+			},
+			Posts:             []*Post{{Id: NewId(), Message: "test"}},
+			MentionTransforms: map[string]string{"@a": "@b"},
+		}
+		data, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		var decoded SyncMsg
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, msg.Id, decoded.Id)
+		assert.Equal(t, msg.Users["u1"].Username, decoded.Users["u1"].Username)
+		assert.Equal(t, msg.MentionTransforms, decoded.MentionTransforms)
+	})
+
+	t.Run("Post", func(t *testing.T) {
+		post := &Post{
+			Id:       NewId(),
+			Message:  "test",
+			Props:    StringInterface{"key": "val"},
+			RemoteId: &remoteID,
+			Metadata: &PostMetadata{},
+		}
+		data, err := json.Marshal(post)
+		require.NoError(t, err)
+
+		var decoded Post
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, post.Id, decoded.Id)
+		assert.Equal(t, post.Props["key"], decoded.Props["key"])
+		assert.NotNil(t, decoded.Metadata, "Metadata should be present in JSON")
+	})
+
+	t.Run("User", func(t *testing.T) {
+		user := &User{
+			Id:       NewId(),
+			Username: "test",
+			Props:    StringMap{"k": "v"},
+			Timezone: StringMap{"tz": "utc"},
+		}
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+
+		var decoded User
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, user.Id, decoded.Id)
+		assert.Equal(t, user.Props, decoded.Props)
+		assert.Equal(t, user.Timezone, decoded.Timezone)
+	})
+
+	t.Run("SyncResponse", func(t *testing.T) {
+		sr := &SyncResponse{
+			UsersLastUpdateAt: 1000,
+			UserErrors:        []string{"err1"},
+			PostsLastUpdateAt: 2000,
+		}
+		data, err := json.Marshal(sr)
+		require.NoError(t, err)
+
+		var decoded SyncResponse
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, sr.UsersLastUpdateAt, decoded.UsersLastUpdateAt)
+		assert.Equal(t, sr.UserErrors, decoded.UserErrors)
+	})
 }

--- a/server/public/model/status.go
+++ b/server/public/model/status.go
@@ -23,17 +23,17 @@ const (
 )
 
 type Status struct {
-	UserId         string `json:"user_id"`
-	Status         string `json:"status"`
-	Manual         bool   `json:"manual"`
-	LastActivityAt int64  `json:"last_activity_at"`
-	ActiveChannel  string `json:"active_channel,omitempty" db:"-"`
+	UserId         string `json:"user_id" xml:"UserId"`
+	Status         string `json:"status" xml:"Status"`
+	Manual         bool   `json:"manual" xml:"Manual"`
+	LastActivityAt int64  `json:"last_activity_at" xml:"LastActivityAt"`
+	ActiveChannel  string `json:"active_channel,omitempty" db:"-" xml:"ActiveChannel,omitempty"`
 
 	// DNDEndTime is the time that the user's DND status will expire. Unlike other timestamps in Mattermost, this value
 	// is in seconds instead of milliseconds.
-	DNDEndTime int64 `json:"dnd_end_time"`
+	DNDEndTime int64 `json:"dnd_end_time" xml:"DNDEndTime"`
 
-	PrevStatus string `json:"-"`
+	PrevStatus string `json:"-" xml:"-"`
 }
 
 func (s *Status) ToJSON() ([]byte, error) {

--- a/server/public/model/support_packet.go
+++ b/server/public/model/support_packet.go
@@ -58,9 +58,12 @@ type SupportPacketDiagnostics struct {
 	} `yaml:"database"`
 
 	FileStore struct {
-		Status string `yaml:"file_status"`
-		Error  string `yaml:"erorr,omitempty"`
-		Driver string `yaml:"file_driver"`
+		Status         string `yaml:"file_status"`
+		Error          string `yaml:"erorr,omitempty"`
+		Driver         string `yaml:"file_driver"`
+		FilesystemType string `yaml:"filesystem_type,omitempty"`
+		TotalMB        uint64 `yaml:"total_mb,omitempty"`
+		AvailableMB    uint64 `yaml:"available_mb,omitempty"`
 	} `yaml:"file_store"`
 
 	Websocket struct {

--- a/server/public/model/support_packet.go
+++ b/server/public/model/support_packet.go
@@ -75,6 +75,17 @@ type SupportPacketDiagnostics struct {
 		NumberOfNodes int    `yaml:"number_of_nodes"`
 	} `yaml:"cluster"`
 
+	Notifications struct {
+		Email struct {
+			Status string `yaml:"status"`
+			Error  string `yaml:"error,omitempty"`
+		} `yaml:"email,omitempty"`
+		Push struct {
+			Status string `yaml:"status"`
+			Error  string `yaml:"error,omitempty"`
+		} `yaml:"push,omitempty"`
+	} `yaml:"notifications,omitempty"`
+
 	LDAP struct {
 		Status        string `yaml:"status,omitempty"`
 		Error         string `yaml:"error,omitempty"`
@@ -87,6 +98,7 @@ type SupportPacketDiagnostics struct {
 	} `yaml:"saml"`
 
 	ElasticSearch struct {
+		Status        string   `yaml:"status,omitempty"`
 		Backend       string   `yaml:"backend,omitempty"`
 		ServerVersion string   `yaml:"server_version,omitempty"`
 		ServerPlugins []string `yaml:"server_plugins,omitempty"`

--- a/server/public/model/user.go
+++ b/server/public/model/user.go
@@ -84,41 +84,41 @@ type UserPasswordHasher interface {
 // This struct's serializer methods are auto-generated. If a new field is added/removed,
 // please run make gen-serialized.
 type User struct {
-	Id                     string      `json:"id"`
-	CreateAt               int64       `json:"create_at,omitempty"`
-	UpdateAt               int64       `json:"update_at,omitempty"`
-	DeleteAt               int64       `json:"delete_at"`
-	Username               string      `json:"username"`
-	Password               string      `json:"password,omitempty"`
-	AuthData               *string     `json:"auth_data,omitempty"`
-	AuthService            string      `json:"auth_service"`
-	Email                  string      `json:"email"`
-	EmailVerified          bool        `json:"email_verified,omitempty"`
-	Nickname               string      `json:"nickname"`
-	FirstName              string      `json:"first_name"`
-	LastName               string      `json:"last_name"`
-	Position               string      `json:"position"`
-	Roles                  string      `json:"roles"`
-	AllowMarketing         bool        `json:"allow_marketing,omitempty"`
-	Props                  StringMap   `json:"props,omitempty"`
-	NotifyProps            StringMap   `json:"notify_props,omitempty"`
-	LastPasswordUpdate     int64       `json:"last_password_update,omitempty"`
-	LastPictureUpdate      int64       `json:"last_picture_update,omitempty"`
-	FailedAttempts         int         `json:"failed_attempts,omitempty"`
-	Locale                 string      `json:"locale"`
-	Timezone               StringMap   `json:"timezone"`
-	MfaActive              bool        `json:"mfa_active,omitempty"`
-	MfaSecret              string      `json:"mfa_secret,omitempty"`
-	RemoteId               *string     `json:"remote_id,omitempty"`
-	LastActivityAt         int64       `json:"last_activity_at,omitempty"`
-	IsBot                  bool        `json:"is_bot,omitempty"`
-	BotDescription         string      `json:"bot_description,omitempty"`
-	BotLastIconUpdate      int64       `json:"bot_last_icon_update,omitempty"`
-	TermsOfServiceId       string      `json:"terms_of_service_id,omitempty"`
-	TermsOfServiceCreateAt int64       `json:"terms_of_service_create_at,omitempty"`
-	DisableWelcomeEmail    bool        `json:"disable_welcome_email"`
-	LastLogin              int64       `json:"last_login,omitempty"`
-	MfaUsedTimestamps      StringArray `json:"mfa_used_timestamps,omitempty"`
+	Id                     string      `json:"id" xml:"Id"`
+	CreateAt               int64       `json:"create_at,omitempty" xml:"CreateAt,omitempty"`
+	UpdateAt               int64       `json:"update_at,omitempty" xml:"UpdateAt,omitempty"`
+	DeleteAt               int64       `json:"delete_at" xml:"DeleteAt"`
+	Username               string      `json:"username" xml:"Username"`
+	Password               string      `json:"password,omitempty" xml:"-"`
+	AuthData               *string     `json:"auth_data,omitempty" xml:"-"`
+	AuthService            string      `json:"auth_service" xml:"AuthService"`
+	Email                  string      `json:"email" xml:"Email"`
+	EmailVerified          bool        `json:"email_verified,omitempty" xml:"EmailVerified,omitempty"`
+	Nickname               string      `json:"nickname" xml:"Nickname"`
+	FirstName              string      `json:"first_name" xml:"FirstName"`
+	LastName               string      `json:"last_name" xml:"LastName"`
+	Position               string      `json:"position" xml:"Position"`
+	Roles                  string      `json:"roles" xml:"Roles"`
+	AllowMarketing         bool        `json:"allow_marketing,omitempty" xml:"AllowMarketing,omitempty"`
+	Props                  StringMap   `json:"props,omitempty" xml:"Props,omitempty"`
+	NotifyProps            StringMap   `json:"notify_props,omitempty" xml:"NotifyProps,omitempty"`
+	LastPasswordUpdate     int64       `json:"last_password_update,omitempty" xml:"LastPasswordUpdate,omitempty"`
+	LastPictureUpdate      int64       `json:"last_picture_update,omitempty" xml:"LastPictureUpdate,omitempty"`
+	FailedAttempts         int         `json:"failed_attempts,omitempty" xml:"FailedAttempts,omitempty"`
+	Locale                 string      `json:"locale" xml:"Locale"`
+	Timezone               StringMap   `json:"timezone" xml:"Timezone"`
+	MfaActive              bool        `json:"mfa_active,omitempty" xml:"MfaActive,omitempty"`
+	MfaSecret              string      `json:"mfa_secret,omitempty" xml:"-"`
+	RemoteId               *string     `json:"remote_id,omitempty" xml:"RemoteId,omitempty"`
+	LastActivityAt         int64       `json:"last_activity_at,omitempty" xml:"LastActivityAt,omitempty"`
+	IsBot                  bool        `json:"is_bot,omitempty" xml:"IsBot,omitempty"`
+	BotDescription         string      `json:"bot_description,omitempty" xml:"BotDescription,omitempty"`
+	BotLastIconUpdate      int64       `json:"bot_last_icon_update,omitempty" xml:"BotLastIconUpdate,omitempty"`
+	TermsOfServiceId       string      `json:"terms_of_service_id,omitempty" xml:"TermsOfServiceId,omitempty"`
+	TermsOfServiceCreateAt int64       `json:"terms_of_service_create_at,omitempty" xml:"TermsOfServiceCreateAt,omitempty"`
+	DisableWelcomeEmail    bool        `json:"disable_welcome_email" xml:"DisableWelcomeEmail"`
+	LastLogin              int64       `json:"last_login,omitempty" xml:"LastLogin,omitempty"`
+	MfaUsedTimestamps      StringArray `json:"mfa_used_timestamps,omitempty" xml:"-"`
 }
 
 func (u *User) Auditable() map[string]any {

--- a/server/public/model/websocket_message.go
+++ b/server/public/model/websocket_message.go
@@ -87,6 +87,7 @@ const (
 	WebsocketEventChannelBookmarkUpdated              WebsocketEventType = "channel_bookmark_updated"
 	WebsocketEventChannelBookmarkDeleted              WebsocketEventType = "channel_bookmark_deleted"
 	WebsocketEventChannelBookmarkSorted               WebsocketEventType = "channel_bookmark_sorted"
+	WebsocketEventChannelAccessControlUpdated         WebsocketEventType = "channel_access_control_updated"
 	WebsocketPresenceIndicator                        WebsocketEventType = "presence"
 	WebsocketPostedNotifyAck                          WebsocketEventType = "posted_notify_ack"
 	WebsocketScheduledPostCreated                     WebsocketEventType = "scheduled_post_created"

--- a/server/public/model/xml_helpers.go
+++ b/server/public/model/xml_helpers.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"sort"
+)
+
+// xmlStringMapEntry is the XML representation of a single StringMap entry.
+type xmlStringMapEntry struct {
+	Key   string `xml:"key,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// MarshalXML encodes a StringMap as a sequence of <Entry key="..." value="..."/> elements.
+func (m StringMap) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if m == nil {
+		return e.EncodeElement(struct{}{}, start)
+	}
+
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+
+	// Sort keys for deterministic output.
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		entry := xmlStringMapEntry{Key: k, Value: m[k]}
+		if err := e.EncodeElement(entry, xml.StartElement{Name: xml.Name{Local: "Entry"}}); err != nil {
+			return err
+		}
+	}
+
+	return e.EncodeToken(start.End())
+}
+
+// UnmarshalXML decodes a sequence of <Entry key="..." value="..."/> elements into a StringMap.
+func (m *StringMap) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	*m = make(StringMap)
+
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "Entry" {
+				var entry xmlStringMapEntry
+				if err := d.DecodeElement(&entry, &t); err != nil {
+					return err
+				}
+				(*m)[entry.Key] = entry.Value
+			} else {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+			}
+		case xml.EndElement:
+			return nil
+		}
+	}
+}
+
+// xmlStringInterfaceEntry is the XML representation of a single StringInterface entry.
+// Values are stored as strings. Non-string values are JSON-encoded.
+type xmlStringInterfaceEntry struct {
+	Key      string `xml:"key,attr"`
+	Value    string `xml:"value,attr"`
+	JSONType string `xml:"type,attr,omitempty"` // "json" when the value is JSON-encoded
+}
+
+// MarshalXML encodes a StringInterface as a sequence of <Entry> elements.
+// String values are stored directly. Other types are JSON-encoded with type="json".
+func (m StringInterface) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if m == nil {
+		return e.EncodeElement(struct{}{}, start)
+	}
+
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+
+	// Sort keys for deterministic output.
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := m[k]
+		entry := xmlStringInterfaceEntry{Key: k}
+
+		switch val := v.(type) {
+		case string:
+			entry.Value = val
+		case nil:
+			entry.JSONType = "json"
+			entry.Value = "null"
+		default:
+			b, err := json.Marshal(val)
+			if err != nil {
+				return fmt.Errorf("failed to marshal StringInterface value for key %q: %w", k, err)
+			}
+			entry.JSONType = "json"
+			entry.Value = string(b)
+		}
+
+		if err := e.EncodeElement(entry, xml.StartElement{Name: xml.Name{Local: "Entry"}}); err != nil {
+			return err
+		}
+	}
+
+	return e.EncodeToken(start.End())
+}
+
+// UnmarshalXML decodes a sequence of <Entry> elements into a StringInterface.
+// Entries with type="json" have their values JSON-decoded.
+func (m *StringInterface) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	*m = make(StringInterface)
+
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "Entry" {
+				var entry xmlStringInterfaceEntry
+				if err := d.DecodeElement(&entry, &t); err != nil {
+					return err
+				}
+				if entry.JSONType == "json" {
+					var v any
+					if err := json.Unmarshal([]byte(entry.Value), &v); err != nil {
+						return fmt.Errorf("failed to unmarshal StringInterface JSON value for key %q: %w", entry.Key, err)
+					}
+					(*m)[entry.Key] = v
+				} else {
+					(*m)[entry.Key] = entry.Value
+				}
+			} else {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+			}
+		case xml.EndElement:
+			return nil
+		}
+	}
+}

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -1252,12 +1252,22 @@ type API interface {
 	// Minimum server version: 9.5
 	RegisterPluginForSharedChannels(opts model.RegisterPluginOpts) (remoteID string, err error)
 
-	// UnregisterPluginForSharedChannels unregisters the plugin as a `Remote` for SharedChannels.
-	// The plugin will no longer receive synchronization messages via the `OnSharedChannelsSyncMsg` hook.
+	// UnregisterPluginForSharedChannels unregisters all remotes for this plugin. The plugin will no
+	// longer receive synchronization messages via the `OnSharedChannelsSyncMsg` hook. Used in
+	// OnDeactivate for bulk cleanup.
 	//
 	// @tag SharedChannels
 	// Minimum server version: 9.5
 	UnregisterPluginForSharedChannels(pluginID string) error
+
+	// UnregisterPluginRemoteForSharedChannels unregisters a specific remote by its remoteID.
+	// The remote must belong to the calling plugin (ownership is validated server-side).
+	// The remote will no longer receive synchronization messages. Used for config change
+	// reconciliation when a connection is removed but others remain.
+	//
+	// @tag SharedChannels
+	// Minimum server version: 11.7
+	UnregisterPluginRemoteForSharedChannels(remoteID string) error
 
 	// ShareChannel marks a channel for sharing via shared channels. Note, this does not automatically
 	// invite any remote clusters to the channel - use `InviteRemote` to invite a remote , or this plugin,

--- a/server/public/plugin/api_timer_layer_generated.go
+++ b/server/public/plugin/api_timer_layer_generated.go
@@ -1331,6 +1331,13 @@ func (api *apiTimerLayer) UnregisterPluginForSharedChannels(pluginID string) err
 	return _returnsA
 }
 
+func (api *apiTimerLayer) UnregisterPluginRemoteForSharedChannels(remoteID string) error {
+	startTime := timePkg.Now()
+	_returnsA := api.apiImpl.UnregisterPluginRemoteForSharedChannels(remoteID)
+	api.recordTime(startTime, "UnregisterPluginRemoteForSharedChannels", _returnsA == nil)
+	return _returnsA
+}
+
 func (api *apiTimerLayer) ShareChannel(sc *model.SharedChannel) (*model.SharedChannel, error) {
 	startTime := timePkg.Now()
 	_returnsA, _returnsB := api.apiImpl.ShareChannel(sc)

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -6565,6 +6565,35 @@ func (s *apiRPCServer) UnregisterPluginForSharedChannels(args *Z_UnregisterPlugi
 	return nil
 }
 
+type Z_UnregisterPluginRemoteForSharedChannelsArgs struct {
+	A string
+}
+
+type Z_UnregisterPluginRemoteForSharedChannelsReturns struct {
+	A error
+}
+
+func (g *apiRPCClient) UnregisterPluginRemoteForSharedChannels(remoteID string) error {
+	_args := &Z_UnregisterPluginRemoteForSharedChannelsArgs{remoteID}
+	_returns := &Z_UnregisterPluginRemoteForSharedChannelsReturns{}
+	if err := g.client.Call("Plugin.UnregisterPluginRemoteForSharedChannels", _args, _returns); err != nil {
+		log.Printf("RPC call to UnregisterPluginRemoteForSharedChannels API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) UnregisterPluginRemoteForSharedChannels(args *Z_UnregisterPluginRemoteForSharedChannelsArgs, returns *Z_UnregisterPluginRemoteForSharedChannelsReturns) error {
+	if hook, ok := s.impl.(interface {
+		UnregisterPluginRemoteForSharedChannels(remoteID string) error
+	}); ok {
+		returns.A = hook.UnregisterPluginRemoteForSharedChannels(args.A)
+		returns.A = encodableError(returns.A)
+	} else {
+		return encodableError(fmt.Errorf("API UnregisterPluginRemoteForSharedChannels called but not implemented."))
+	}
+	return nil
+}
+
 type Z_ShareChannelArgs struct {
 	A *model.SharedChannel
 }

--- a/server/public/plugin/plugintest/api.go
+++ b/server/public/plugin/plugintest/api.go
@@ -5493,6 +5493,24 @@ func (_m *API) UnregisterPluginForSharedChannels(pluginID string) error {
 	return r0
 }
 
+// UnregisterPluginRemoteForSharedChannels provides a mock function with given fields: remoteID
+func (_m *API) UnregisterPluginRemoteForSharedChannels(remoteID string) error {
+	ret := _m.Called(remoteID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UnregisterPluginRemoteForSharedChannels")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(remoteID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // UnshareChannel provides a mock function with given fields: channelID
 func (_m *API) UnshareChannel(channelID string) (bool, error) {
 	ret := _m.Called(channelID)

--- a/server/public/pluginapi/audit.go
+++ b/server/public/pluginapi/audit.go
@@ -1,0 +1,26 @@
+package pluginapi
+
+import (
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+)
+
+// AuditService exposes methods to emit audit records through the Mattermost server audit pipeline.
+type AuditService struct {
+	api plugin.API
+}
+
+// Record logs an audit record using the default audit log level.
+//
+// Minimum server version: 10.10
+func (a *AuditService) Record(rec *model.AuditRecord) {
+	a.api.LogAuditRec(rec)
+}
+
+// RecordWithLevel logs an audit record with the given log level.
+//
+// Minimum server version: 10.10
+func (a *AuditService) RecordWithLevel(rec *model.AuditRecord, level mlog.Level) {
+	a.api.LogAuditRecWithLevel(rec, level)
+}

--- a/server/public/pluginapi/audit_test.go
+++ b/server/public/pluginapi/audit_test.go
@@ -1,0 +1,36 @@
+package pluginapi_test
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+)
+
+func TestAuditService(t *testing.T) {
+	t.Run("record", func(t *testing.T) {
+		rec := plugin.MakeAuditRecord("test.event", model.AuditStatusSuccess)
+
+		api := &plugintest.API{}
+		api.On("LogAuditRec", rec).Return()
+		defer api.AssertExpectations(t)
+
+		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client.Audit.Record(rec)
+	})
+
+	t.Run("record with level", func(t *testing.T) {
+		rec := plugin.MakeAuditRecord("test.event", model.AuditStatusFail)
+		level := mlog.LvlAuditCLI
+
+		api := &plugintest.API{}
+		api.On("LogAuditRecWithLevel", rec, level).Return()
+		defer api.AssertExpectations(t)
+
+		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client.Audit.RecordWithLevel(rec, level)
+	})
+}

--- a/server/public/pluginapi/client.go
+++ b/server/public/pluginapi/client.go
@@ -10,6 +10,7 @@ import (
 type Client struct {
 	api plugin.API
 
+	Audit         AuditService
 	Bot           BotService
 	Channel       ChannelService
 	Cluster       ClusterService
@@ -41,6 +42,7 @@ func NewClient(api plugin.API, driver plugin.Driver) *Client {
 	return &Client{
 		api: api,
 
+		Audit:         AuditService{api: api},
 		Bot:           BotService{api: api},
 		Channel:       ChannelService{api: api},
 		Cluster:       ClusterService{api: api},

--- a/webapp/channels/src/actions/websocket_actions.test.jsx
+++ b/webapp/channels/src/actions/websocket_actions.test.jsx
@@ -5,7 +5,7 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import {WebSocketEvents} from '@mattermost/client';
 
-import {CloudTypes} from 'mattermost-redux/action_types';
+import {ChannelTypes, CloudTypes} from 'mattermost-redux/action_types';
 import {fetchMyCategories} from 'mattermost-redux/actions/channel_categories';
 import {fetchAllMyTeamsChannels} from 'mattermost-redux/actions/channels';
 import {getCustomProfileAttributeFields} from 'mattermost-redux/actions/general';
@@ -25,6 +25,8 @@ import {closeRightHandSide} from 'actions/views/rhs';
 import realConfigureStore from 'store';
 import store from 'stores/redux_store';
 
+import {invalidateAccessControlAttributesCache} from 'components/common/hooks/useAccessControlAttributes';
+
 import mergeObjects from 'packages/mattermost-redux/test/merge_objects';
 import configureStore from 'tests/test_store';
 import {getHistory} from 'utils/browser_history';
@@ -32,6 +34,7 @@ import Constants, {ActionTypes, UserStatuses} from 'utils/constants';
 
 import {
     handleChannelUpdatedEvent,
+    handleChannelAccessControlUpdatedEvent,
     handleEvent,
     handleNewPostEvent,
     handleNewPostEvents,
@@ -114,6 +117,11 @@ jest.mock('actions/views/channel', () => ({
 jest.mock('plugins', () => ({
     ...jest.requireActual('plugins'),
     loadPluginsIfNecessary: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('components/common/hooks/useAccessControlAttributes', () => ({
+    EntityType: {Channel: 'channel'},
+    invalidateAccessControlAttributesCache: jest.fn(),
 }));
 
 let mockState = {
@@ -871,6 +879,47 @@ describe('handleChannelUpdatedEvent', () => {
         testStore.dispatch(handleChannelUpdatedEvent(msg));
 
         expect(getHistory().replace).not.toHaveBeenCalled();
+    });
+});
+
+describe('handleChannelAccessControlUpdatedEvent', () => {
+    beforeEach(() => {
+        invalidateAccessControlAttributesCache.mockClear();
+    });
+
+    test('dispatches RECEIVED_CHANNEL with parsed channel and invalidates attribute cache', () => {
+        const testStore = configureStore({});
+        const channel = {
+            id: 'channel-ac-1',
+            team_id: 'team-1',
+            policy_enforced: true,
+        };
+        const msg = {
+            data: {
+                channel: JSON.stringify(channel),
+            },
+        };
+
+        testStore.dispatch(handleChannelAccessControlUpdatedEvent(msg));
+
+        expect(testStore.getActions()).toEqual([
+            {
+                type: ChannelTypes.RECEIVED_CHANNEL,
+                data: channel,
+            },
+        ]);
+        expect(invalidateAccessControlAttributesCache).toHaveBeenCalledTimes(1);
+        expect(invalidateAccessControlAttributesCache).toHaveBeenCalledWith('channel', 'channel-ac-1');
+    });
+
+    test('returns early when msg.data.channel is missing', () => {
+        const testStore = configureStore({});
+        const msg = {data: {}};
+
+        testStore.dispatch(handleChannelAccessControlUpdatedEvent(msg));
+
+        expect(testStore.getActions()).toEqual([]);
+        expect(invalidateAccessControlAttributesCache).not.toHaveBeenCalled();
     });
 });
 

--- a/webapp/channels/src/actions/websocket_actions.ts
+++ b/webapp/channels/src/actions/websocket_actions.ts
@@ -149,6 +149,7 @@ import {getSelectedChannelId, getSelectedPost} from 'selectors/rhs';
 import {isThreadOpen, isThreadManuallyUnread} from 'selectors/views/threads';
 import store from 'stores/redux_store';
 
+import {EntityType, invalidateAccessControlAttributesCache} from 'components/common/hooks/useAccessControlAttributes';
 import DialogRouter from 'components/dialog_router';
 import InfoToast from 'components/info_toast/info_toast';
 import RemovedFromChannelModal from 'components/removed_from_channel_modal';
@@ -514,6 +515,10 @@ export function handleEvent(msg: WebSocketMessage) {
         dispatch(handleChannelBookmarkSorted(msg));
         break;
 
+    case WebSocketEvents.ChannelAccessControlUpdated:
+        dispatch(handleChannelAccessControlUpdatedEvent(msg));
+        break;
+
     case WebSocketEvents.DirectAdded:
         dispatch(handleDirectAddedEvent(msg));
         break;
@@ -783,6 +788,25 @@ export function handleChannelUpdatedEvent(msg: WebSocketMessages.ChannelUpdated)
             }
             getHistory().replace(channelPath);
         }
+    };
+}
+
+export function handleChannelAccessControlUpdatedEvent(msg: WebSocketMessages.ChannelAccessControlUpdated): ThunkActionFunc<void> {
+    return (doDispatch) => {
+        if (!msg.data.channel) {
+            return;
+        }
+
+        const channel = JSON.parse(msg.data.channel) as Channel;
+
+        // Refresh the channel record so consumers see the latest
+        // policy_enforced flag (and any other access-control-derived fields).
+        doDispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: channel});
+
+        // Drop any cached access control attributes for this channel so
+        // consumers (e.g. the channel invite modal banner) refetch the
+        // latest attribute set after a policy change.
+        invalidateAccessControlAttributesCache(EntityType.Channel, channel.id);
     };
 }
 

--- a/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.scss
+++ b/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.scss
@@ -40,6 +40,11 @@
     &__policy-banner {
         .TagGroup {
             margin-top: 12px;
+
+            // Tighten vertical spacing when tags wrap onto multiple rows
+            // (TagGroup defaults to gap: 8px which is too airy in this
+            // banner). Column spacing is preserved.
+            row-gap: 0;
         }
     }
 }

--- a/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.test.tsx
+++ b/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.test.tsx
@@ -502,9 +502,9 @@ describe('components/channel_invite_modal', () => {
         // Modal renders in a portal, so query from document instead of container
         expect(document.querySelector('.AlertBanner')).not.toBeNull();
 
-        // Check that the attribute tags are shown
-        expect(screen.getByText('tag1')).toBeInTheDocument();
-        expect(screen.getByText('tag2')).toBeInTheDocument();
+        // Check that the attribute tags are shown in "Attribute: value" form.
+        expect(screen.getByText('Attribute1: tag1')).toBeInTheDocument();
+        expect(screen.getByText('Attribute1: tag2')).toBeInTheDocument();
     });
 
     test('should not show AlertBanner when policy_enforced is false', () => {

--- a/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.tsx
+++ b/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.tsx
@@ -33,6 +33,7 @@ import GuestTag from 'components/widgets/tag/guest_tag';
 import TagGroup from 'components/widgets/tag/tag_group';
 
 import Constants, {ModalIdentifiers} from 'utils/constants';
+import {formatAttributeName} from 'utils/format_attribute_name';
 import {sortUsersAndGroups} from 'utils/utils';
 
 import GroupOption from './group_option';
@@ -112,14 +113,29 @@ const ChannelInviteModalComponent = (props: Props) => {
         props.channel.policy_enforced,
     );
 
-    // Helper function to format attribute names for tooltips
-    const formatAttributeName = (name: string): string => {
-        // Convert snake_case or camelCase to Title Case with spaces
-        return name.
-            replace(/_/g, ' ').
-            replace(/([A-Z])/g, ' $1').
-            replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substring(1).toLowerCase());
-    };
+    // Memoise the rendered access-control tags so they don't re-render on
+    // every keystroke in the invite text box.
+    const accessControlTags = useMemo(() => {
+        if (structuredAttributes.length === 0) {
+            return null;
+        }
+        return (
+            <TagGroup>
+                {structuredAttributes.flatMap((attribute) =>
+                    attribute.values.map((value) => {
+                        const attributeLabel = formatAttributeName(attribute.name);
+                        return (
+                            <AlertTag
+                                key={`${attribute.name}-${value}`}
+                                tooltipTitle={attributeLabel}
+                                text={`${attributeLabel}: ${value}`}
+                            />
+                        );
+                    }),
+                )}
+            </TagGroup>
+        );
+    }, [structuredAttributes]);
 
     // Helper function to add a user or group to the selected list
     const addValue = useCallback((value: UserProfileValue | GroupValue) => {
@@ -667,19 +683,7 @@ const ChannelInviteModalComponent = (props: Props) => {
                                 />
                             )}
                         >
-                            {structuredAttributes.length > 0 && (
-                                <TagGroup>
-                                    {structuredAttributes.flatMap((attribute) =>
-                                        attribute.values.map((value) => (
-                                            <AlertTag
-                                                key={`${attribute.name}-${value}`}
-                                                tooltipTitle={formatAttributeName(attribute.name)}
-                                                text={value}
-                                            />
-                                        )),
-                                    )}
-                                </TagGroup>
-                            )}
+                            {accessControlTags}
                         </AlertBanner>
                     </div>
                 )}

--- a/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.scss
+++ b/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.scss
@@ -34,6 +34,11 @@
 
             .TagGroup {
                 margin-top: 12px;
+
+                // Tighten vertical spacing when tags wrap onto multiple rows
+                // (TagGroup defaults to gap: 8px which is too airy in this
+                // banner). Column spacing is preserved.
+                row-gap: 0;
             }
         }
     }

--- a/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.test.tsx
+++ b/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.test.tsx
@@ -225,7 +225,9 @@ describe('channel_members_rhs/channel_members_rhs', () => {
         );
 
         expect(screen.getByText('Channel access is restricted by user attributes')).toBeInTheDocument();
-        expect(screen.getByText('tag1')).toBeInTheDocument();
-        expect(screen.getByText('tag2')).toBeInTheDocument();
+
+        // Each tag is rendered as "Attribute: value" for readability.
+        expect(screen.getByText('Attribute1: tag1')).toBeInTheDocument();
+        expect(screen.getByText('Attribute1: tag2')).toBeInTheDocument();
     });
 });

--- a/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.tsx
+++ b/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import debounce from 'lodash/debounce';
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useHistory} from 'react-router-dom';
 
@@ -20,6 +20,7 @@ import AlertTag from 'components/widgets/tag/alert_tag';
 import TagGroup from 'components/widgets/tag/tag_group';
 
 import Constants, {ModalIdentifiers} from 'utils/constants';
+import {formatAttributeName} from 'utils/format_attribute_name';
 
 import type {ModalData} from 'types/actions';
 
@@ -87,14 +88,29 @@ export default function ChannelMembersRHS({
         channel.policy_enforced,
     );
 
-    // Helper function to format attribute names for tooltips
-    const formatAttributeName = (name: string): string => {
-        // Convert snake_case or camelCase to Title Case with spaces
-        return name.
-            replace(/_/g, ' ').
-            replace(/([A-Z])/g, ' $1').
-            replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substring(1).toLowerCase());
-    };
+    // Memoise the rendered access-control tags so they don't re-render on
+    // every unrelated state change in the centre channel.
+    const accessControlTags = useMemo(() => {
+        if (structuredAttributes.length === 0) {
+            return null;
+        }
+        return (
+            <TagGroup>
+                {structuredAttributes.flatMap((attribute) =>
+                    attribute.values.map((value) => {
+                        const attributeLabel = formatAttributeName(attribute.name);
+                        return (
+                            <AlertTag
+                                key={`${attribute.name}-${value}`}
+                                tooltipTitle={attributeLabel}
+                                text={`${attributeLabel}: ${value}`}
+                            />
+                        );
+                    }),
+                )}
+            </TagGroup>
+        );
+    }, [structuredAttributes]);
 
     const searching = searchTerms !== '';
 
@@ -254,19 +270,7 @@ export default function ChannelMembersRHS({
                             defaultMessage: 'Channel access is restricted by user attributes',
                         })}
                     >
-                        {structuredAttributes.length > 0 && (
-                            <TagGroup>
-                                {structuredAttributes.flatMap((attribute) =>
-                                    attribute.values.map((value) => (
-                                        <AlertTag
-                                            key={`${attribute.name}-${value}`}
-                                            tooltipTitle={formatAttributeName(attribute.name)}
-                                            text={value}
-                                        />
-                                    )),
-                                )}
-                            </TagGroup>
-                        )}
+                        {accessControlTags}
                         {loading && <span className='loading-indicator'>{'Loading...'}</span>}
                     </AlertBanner>
                 </div>

--- a/webapp/channels/src/components/common/hooks/useAccessControlAttributes.test.tsx
+++ b/webapp/channels/src/components/common/hooks/useAccessControlAttributes.test.tsx
@@ -7,7 +7,7 @@ import {Provider} from 'react-redux';
 import configureStore from 'redux-mock-store';
 import {thunk} from 'redux-thunk';
 
-import {useAccessControlAttributes, EntityType} from './useAccessControlAttributes';
+import {invalidateAccessControlAttributesCache, useAccessControlAttributes, EntityType} from './useAccessControlAttributes';
 
 // Mock the getChannelAccessControlAttributes action
 jest.mock('mattermost-redux/actions/channels', () => {
@@ -201,5 +201,32 @@ describe('useAccessControlAttributes', () => {
 
         // The action should have been called again
         expect(getChannelAccessControlAttributes).toHaveBeenCalledWith('channel-1');
+    });
+
+    test('invalidateAccessControlAttributesCache forces a refresh on next read', async () => {
+        // Prime the cache with a first fetch.
+        const {result: result1} = renderHook(() => useAccessControlAttributes(EntityType.Channel, 'channel-1', true), {wrapper});
+
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+        });
+        expect(result1.current.structuredAttributes).toEqual([
+            {name: 'department', values: ['engineering', 'marketing']},
+            {name: 'location', values: ['remote']},
+        ]);
+
+        const getChannelAccessControlAttributes = require('mattermost-redux/actions/channels').getChannelAccessControlAttributes;
+        getChannelAccessControlAttributes.mockClear();
+
+        // After invalidating the cache the next mount should hit the action again.
+        invalidateAccessControlAttributesCache(EntityType.Channel, 'channel-1');
+
+        const {result: result2} = renderHook(() => useAccessControlAttributes(EntityType.Channel, 'channel-1', true), {wrapper});
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+        });
+
+        expect(getChannelAccessControlAttributes).toHaveBeenCalledWith('channel-1');
+        expect(result2.current.structuredAttributes).toEqual(result1.current.structuredAttributes);
     });
 });

--- a/webapp/channels/src/components/common/hooks/useAccessControlAttributes.test.tsx
+++ b/webapp/channels/src/components/common/hooks/useAccessControlAttributes.test.tsx
@@ -92,6 +92,28 @@ describe('useAccessControlAttributes', () => {
         expect(result.current.loading).toBe(false);
     });
 
+    test('clears attribute state when hasAccessControl becomes false after data was loaded', async () => {
+        const {result, rerender, unmount} = renderHook(
+            ({hasAC}: {hasAC: boolean}) => useAccessControlAttributes(EntityType.Channel, 'channel-1', hasAC),
+            {initialProps: {hasAC: true}, wrapper},
+        );
+
+        await waitFor(() => {
+            expect(result.current.attributeTags).toEqual(['engineering', 'marketing', 'remote']);
+        });
+
+        rerender({hasAC: false});
+        await act(async () => {
+            await result.current.fetchAttributes();
+        });
+
+        expect(result.current.attributeTags).toEqual([]);
+        expect(result.current.structuredAttributes).toEqual([]);
+
+        unmount();
+        invalidateAccessControlAttributesCache(EntityType.Channel, 'channel-1');
+    });
+
     test('should fetch and process attributes successfully', async () => {
         const {result} = renderHook(() => useAccessControlAttributes(EntityType.Channel, 'channel-1', true), {wrapper});
 
@@ -205,7 +227,7 @@ describe('useAccessControlAttributes', () => {
 
     test('invalidateAccessControlAttributesCache forces a refresh on next read', async () => {
         // Prime the cache with a first fetch.
-        const {result: result1} = renderHook(() => useAccessControlAttributes(EntityType.Channel, 'channel-1', true), {wrapper});
+        const {result: result1, unmount} = renderHook(() => useAccessControlAttributes(EntityType.Channel, 'channel-1', true), {wrapper});
 
         await act(async () => {
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -214,6 +236,11 @@ describe('useAccessControlAttributes', () => {
             {name: 'department', values: ['engineering', 'marketing']},
             {name: 'location', values: ['remote']},
         ]);
+
+        // Unmount the first hook so its listener subscription doesn't trigger
+        // an extra fetch when we invalidate below — this test specifically
+        // verifies that the *next* mount sees fresh data after invalidation.
+        unmount();
 
         const getChannelAccessControlAttributes = require('mattermost-redux/actions/channels').getChannelAccessControlAttributes;
         getChannelAccessControlAttributes.mockClear();
@@ -228,5 +255,61 @@ describe('useAccessControlAttributes', () => {
 
         expect(getChannelAccessControlAttributes).toHaveBeenCalledWith('channel-1');
         expect(result2.current.structuredAttributes).toEqual(result1.current.structuredAttributes);
+    });
+
+    test('should re-fetch when the cache is invalidated for the entity', async () => {
+        renderHook(() => useAccessControlAttributes(EntityType.Channel, 'channel-1', true), {wrapper});
+
+        // Wait for the initial fetch to complete and prime the cache
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        const getChannelAccessControlAttributes = require('mattermost-redux/actions/channels').getChannelAccessControlAttributes;
+        getChannelAccessControlAttributes.mockClear();
+
+        await act(async () => {
+            invalidateAccessControlAttributesCache(EntityType.Channel, 'channel-1');
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        expect(getChannelAccessControlAttributes).toHaveBeenCalledWith('channel-1');
+    });
+
+    test('should not re-fetch when the cache is invalidated for a different entity', async () => {
+        renderHook(() => useAccessControlAttributes(EntityType.Channel, 'channel-1', true), {wrapper});
+
+        // Wait for the initial fetch to complete and prime the cache
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        const getChannelAccessControlAttributes = require('mattermost-redux/actions/channels').getChannelAccessControlAttributes;
+        getChannelAccessControlAttributes.mockClear();
+
+        await act(async () => {
+            invalidateAccessControlAttributesCache(EntityType.Channel, 'channel-2');
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        expect(getChannelAccessControlAttributes).not.toHaveBeenCalled();
+    });
+
+    test('should re-fetch all mounted hooks when cache is fully cleared', async () => {
+        renderHook(() => useAccessControlAttributes(EntityType.Channel, 'channel-1', true), {wrapper});
+
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        const getChannelAccessControlAttributes = require('mattermost-redux/actions/channels').getChannelAccessControlAttributes;
+        getChannelAccessControlAttributes.mockClear();
+
+        await act(async () => {
+            invalidateAccessControlAttributesCache();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        expect(getChannelAccessControlAttributes).toHaveBeenCalledWith('channel-1');
     });
 });

--- a/webapp/channels/src/components/common/hooks/useAccessControlAttributes.ts
+++ b/webapp/channels/src/components/common/hooks/useAccessControlAttributes.ts
@@ -73,14 +73,36 @@ function processAttributeData(data: Record<string, string[]> | undefined | null)
     return {attributeTags, structuredAttributes};
 }
 
+// Listeners that mounted hook instances register to be notified when the
+// module-level cache is invalidated for an entity they care about. Used to
+// trigger a re-fetch in response to server-side policy changes that arrive
+// out-of-band of the hook's normal dependency-driven refresh.
+type InvalidationListener = (entityType: EntityType | undefined, entityId: string | undefined) => void;
+const invalidationListeners = new Set<InvalidationListener>();
+
 /**
- * Invalidates the cached attributes for a single entity. Components that
- * mutate the underlying access policy should call this to ensure the next
- * read fetches fresh data instead of serving up to CACHE_TTL milliseconds of
- * stale state.
+ * Invalidates cached access control attributes for an entity. When both
+ * entityType and entityId are provided, only that entity's cache entry is
+ * dropped; when omitted, the entire module-level cache is cleared. After
+ * dropping the cache entry/entries, all mounted instances of
+ * useAccessControlAttributes that match the invalidated entity (or all of
+ * them, when called without arguments) will immediately re-fetch so that
+ * consumers (e.g. the channel invite modal banner) pick up the new attribute
+ * set without waiting for the cache TTL to expire.
  */
-export function invalidateAccessControlAttributesCache(entityType: EntityType, entityId: string): void {
-    delete attributesCache[`${entityType}:${entityId}`];
+export function invalidateAccessControlAttributesCache(
+    entityType?: EntityType,
+    entityId?: string,
+): void {
+    if (!entityType || !entityId) {
+        for (const key of Object.keys(attributesCache)) {
+            delete attributesCache[key];
+        }
+    } else {
+        delete attributesCache[`${entityType}:${entityId}`];
+    }
+
+    invalidationListeners.forEach((listener) => listener(entityType, entityId));
 }
 
 /**
@@ -109,6 +131,8 @@ export const useAccessControlAttributes = (
 
     const fetchAttributes = useCallback(async (forceRefresh = false) => {
         if (!entityId || !hasAccessControl) {
+            setAttributeTags([]);
+            setStructuredAttributes([]);
             return;
         }
 
@@ -159,6 +183,24 @@ export const useAccessControlAttributes = (
     useEffect(() => {
         fetchAttributes();
     }, [fetchAttributes]);
+
+    // Re-fetch when the cache is invalidated for this entity (e.g. when a
+    // policy change is broadcast over the websocket). Without this, the
+    // hook's input dependencies may not change even though the underlying
+    // attribute set on the server did.
+    useEffect(() => {
+        const listener: InvalidationListener = (invalidatedType, invalidatedId) => {
+            const matchesEntity = !invalidatedType || !invalidatedId ||
+                (invalidatedType === entityType && invalidatedId === entityId);
+            if (matchesEntity) {
+                fetchAttributes(true);
+            }
+        };
+        invalidationListeners.add(listener);
+        return () => {
+            invalidationListeners.delete(listener);
+        };
+    }, [entityType, entityId, fetchAttributes]);
 
     return {
         attributeTags,

--- a/webapp/channels/src/components/common/hooks/useAccessControlAttributes.ts
+++ b/webapp/channels/src/components/common/hooks/useAccessControlAttributes.ts
@@ -15,21 +15,73 @@ export enum EntityType {
     // more entity types will be added here in the future
 }
 
-// Module-level cache for access control attributes
-// The cache stores processed data with a timestamp to implement a TTL (time-to-live)
+// ProcessedAttributes is the shape that components consume: a structured
+// dictionary of attribute -> values (used for the policy banners) plus a flat
+// tag array (kept for backwards compatibility with consumers that only need
+// the values without their owning attribute).
+type ProcessedAttributes = {
+    attributeTags: string[];
+    structuredAttributes: AccessControlAttribute[];
+};
+
+// Module-level cache for access control attributes. The cache stores already
+// processed data with a timestamp to implement a short TTL.
 const attributesCache: Record<string, {
-    processedData: {
-        attributeTags: string[];
-        structuredAttributes: AccessControlAttribute[];
-    };
+    processedData: ProcessedAttributes;
     timestamp: number;
 }> = {};
 
-// Cache TTL in milliseconds (5 minutes)
+// Cache TTL in milliseconds (5 minutes).
 const CACHE_TTL = 5 * 60 * 1000;
 
 // Array of supported entity types for validation
 const SUPPORTED_ENTITY_TYPES = Object.values(EntityType);
+
+const EMPTY_PROCESSED: ProcessedAttributes = {
+    attributeTags: [],
+    structuredAttributes: [],
+};
+
+// processAttributeData converts the server response (a dictionary keyed by
+// attribute name with arrays of literal values) into the structured form
+// consumed by the UI. The dictionary preserves both the attribute name and
+// the values associated with it so each tag can be displayed alongside its
+// originating attribute.
+function processAttributeData(data: Record<string, string[]> | undefined | null): ProcessedAttributes {
+    if (!data) {
+        return EMPTY_PROCESSED;
+    }
+
+    const attributeTags: string[] = [];
+    const structuredAttributes: AccessControlAttribute[] = [];
+
+    // Format: { "attributeName": ["value1", "value2"], "anotherAttribute": ["value3"] }
+    for (const [name, values] of Object.entries(data)) {
+        if (!Array.isArray(values)) {
+            continue;
+        }
+
+        structuredAttributes.push({name, values: [...values]});
+
+        for (const value of values) {
+            if (value !== undefined && value !== null) {
+                attributeTags.push(value);
+            }
+        }
+    }
+
+    return {attributeTags, structuredAttributes};
+}
+
+/**
+ * Invalidates the cached attributes for a single entity. Components that
+ * mutate the underlying access policy should call this to ensure the next
+ * read fetches fresh data instead of serving up to CACHE_TTL milliseconds of
+ * stale state.
+ */
+export function invalidateAccessControlAttributesCache(entityType: EntityType, entityId: string): void {
+    delete attributesCache[`${entityType}:${entityId}`];
+}
 
 /**
  * A hook for fetching access control attributes for an entity
@@ -50,35 +102,9 @@ export const useAccessControlAttributes = (
     const [error, setError] = useState<Error | null>(null);
     const dispatch = useDispatch();
 
-    // Helper function to process attribute data and extract tags
-    const processAttributeData = useCallback((data: Record<string, string[]> | undefined) => {
-        if (!data) {
-            setAttributeTags([]);
-            setStructuredAttributes([]);
-            return;
-        }
-
-        const tags: string[] = [];
-        const attributes: AccessControlAttribute[] = [];
-
-        // Extract values from all properties in the response
-        // Format: { "attributeName": ["value1", "value2"], "anotherAttribute": ["value3"] }
-        Object.entries(data).forEach(([name, values]) => {
-            // Add to structured format
-            if (Array.isArray(values)) {
-                attributes.push({name, values: [...values]});
-
-                // Add to flat tags (existing behavior)
-                values.forEach((value) => {
-                    if (value !== undefined && value !== null) {
-                        tags.push(value);
-                    }
-                });
-            }
-        });
-
-        setAttributeTags(tags);
-        setStructuredAttributes(attributes);
+    const applyProcessed = useCallback((processed: ProcessedAttributes) => {
+        setAttributeTags(processed.attributeTags);
+        setStructuredAttributes(processed.structuredAttributes);
     }, []);
 
     const fetchAttributes = useCallback(async (forceRefresh = false) => {
@@ -86,32 +112,25 @@ export const useAccessControlAttributes = (
             return;
         }
 
-        // Set loading state at the beginning
         setLoading(true);
         setError(null);
 
         try {
-            // Validate entity type first
             if (!SUPPORTED_ENTITY_TYPES.includes(entityType)) {
                 throw new Error(`Unsupported entity type: ${entityType}`);
             }
 
-            // Check cache first (unless forceRefresh is true)
             const cacheKey = `${entityType}:${entityId}`;
             const cachedEntry = attributesCache[cacheKey];
             const now = Date.now();
 
-            // Use cache if it exists and is not too old and forceRefresh is false
-            // But still set loading to false to trigger a state update for tests
+            // Serve from cache when fresh and the caller didn't force a refresh.
             if (!forceRefresh && cachedEntry && (now - cachedEntry.timestamp < CACHE_TTL)) {
-                // Use the cached processed data directly instead of reprocessing
-                setAttributeTags(cachedEntry.processedData.attributeTags);
-                setStructuredAttributes(cachedEntry.processedData.structuredAttributes);
+                applyProcessed(cachedEntry.processedData);
                 setLoading(false);
                 return;
             }
 
-            // Handle different entity types
             let result;
             switch (entityType) {
             case EntityType.Channel:
@@ -122,56 +141,21 @@ export const useAccessControlAttributes = (
                 throw new Error(`Unsupported entity type: ${entityType}`);
             }
 
-            // Check for error in the result
             if (result.error) {
                 throw result.error;
             }
-            const data = result.data;
 
-            // Process the data and store it in cache
-            if (data) {
-                const processedTags: string[] = [];
-                const processedAttributes: AccessControlAttribute[] = [];
-
-                // Process the data once
-                Object.entries(data).forEach(([name, values]) => {
-                    if (Array.isArray(values)) {
-                        processedAttributes.push({name, values: [...values]});
-                        values.forEach((value) => {
-                            if (value !== undefined && value !== null) {
-                                processedTags.push(value);
-                            }
-                        });
-                    }
-                });
-
-                // Store only the processed data
-                attributesCache[cacheKey] = {
-                    processedData: {
-                        attributeTags: processedTags,
-                        structuredAttributes: processedAttributes,
-                    },
-                    timestamp: now,
-                };
-
-                // Set state
-                setAttributeTags(processedTags);
-                setStructuredAttributes(processedAttributes);
-            } else {
-                // Handle the case where data is undefined or null
-                setAttributeTags([]);
-                setStructuredAttributes([]);
-            }
+            const processed = processAttributeData(result.data);
+            attributesCache[cacheKey] = {processedData: processed, timestamp: now};
+            applyProcessed(processed);
         } catch (err) {
             setError(err as Error);
-            setAttributeTags([]);
-            setStructuredAttributes([]);
+            applyProcessed(EMPTY_PROCESSED);
         } finally {
             setLoading(false);
         }
-    }, [entityType, entityId, hasAccessControl, processAttributeData]);
+    }, [entityType, entityId, hasAccessControl, dispatch, applyProcessed]);
 
-    // Fetch attributes when the component mounts or when dependencies change
     useEffect(() => {
         fetchAttributes();
     }, [fetchAttributes]);

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
@@ -30,10 +30,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
     </button>
   </div>
   <div
-    aria-hidden="true"
-    id="root-portal"
-  />
-  <div
     class="MuiModal-root-jIkgkT RTvUA MuiPopover-root-kMgVQh MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
     role="presentation"
   >
@@ -297,10 +293,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
 <body
   style="padding-right: 1024px; overflow: hidden;"
 >
-  <div
-    aria-hidden="true"
-    id="root-portal"
-  />
   <div
     aria-hidden="true"
   >
@@ -592,10 +584,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
 >
   <div
     aria-hidden="true"
-    id="root-portal"
-  />
-  <div
-    aria-hidden="true"
   >
     <button
       aria-controls="SidebarChannelMenu-MenuList-channel_id"
@@ -885,10 +873,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
 >
   <div
     aria-hidden="true"
-    id="root-portal"
-  />
-  <div
-    aria-hidden="true"
   >
     <button
       aria-controls="SidebarChannelMenu-MenuList-channel_id"
@@ -1108,10 +1092,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
 <body
   style="padding-right: 1024px; overflow: hidden;"
 >
-  <div
-    aria-hidden="true"
-    id="root-portal"
-  />
   <div
     aria-hidden="true"
   >
@@ -1369,10 +1349,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
 <body
   style="padding-right: 1024px; overflow: hidden;"
 >
-  <div
-    aria-hidden="true"
-    id="root-portal"
-  />
   <div
     aria-hidden="true"
   >
@@ -1659,10 +1635,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
 <body
   style="padding-right: 1024px; overflow: hidden;"
 >
-  <div
-    aria-hidden="true"
-    id="root-portal"
-  />
   <div
     aria-hidden="true"
   >
@@ -1954,10 +1926,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
 >
   <div
     aria-hidden="true"
-    id="root-portal"
-  />
-  <div
-    aria-hidden="true"
   >
     <button
       aria-controls="SidebarChannelMenu-MenuList-channel_id"
@@ -2247,10 +2215,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
 >
   <div
     aria-hidden="true"
-    id="root-portal"
-  />
-  <div
-    aria-hidden="true"
   >
     <button
       aria-controls="SidebarChannelMenu-MenuList-channel_id"
@@ -2538,10 +2502,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
 <body
   style="padding-right: 1024px; overflow: hidden;"
 >
-  <div
-    aria-hidden="true"
-    id="root-portal"
-  />
   <div
     aria-hidden="true"
   >

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
@@ -32,62 +32,14 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   <div
     aria-hidden="true"
     id="root-portal"
-  >
-    <div
-      data-floating-ui-portal=""
-      id=":r3:"
-    >
-      <div
-        class="tooltipContainer hidden-xs"
-        role="tooltip"
-        style="position: absolute; left: 0px; top: 0px; opacity: 0; transform: translate(-8px, 0px); transition-property: opacity; transition-duration: 150ms;"
-        tabindex="-1"
-      >
-        <div
-          class="tooltipContent"
-        >
-          <span
-            class="tooltipContentTitleContainer"
-          >
-            <span
-              class="tooltipContentTitle"
-            >
-              Channel options
-            </span>
-          </span>
-        </div>
-        <svg
-          aria-hidden="true"
-          height="10"
-          style="position: absolute; pointer-events: none; top: 0px; left: calc(100% - 0px); transform: rotate(-90deg);"
-          viewBox="0 0 10 10"
-          width="10"
-        >
-          <path
-            d="M0,0 H10 L5,6 Q5,6 5,6 Z"
-            stroke="none"
-          />
-          <clippath
-            id=":r4:"
-          >
-            <rect
-              height="10"
-              width="10"
-              x="0"
-              y="0"
-            />
-          </clippath>
-        </svg>
-      </div>
-    </div>
-  </div>
+  />
   <div
-    class="MuiModal-root-jIscme ljbrzK MuiPopover-root-kLIimo MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
+    class="MuiModal-root-jIkgkT RTvUA MuiPopover-root-kMgVQh MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
     role="presentation"
   >
     <div
       aria-hidden="true"
-      class="MuiBackdrop-root-eddran ljsZwq MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kyBuqW kaXbXK MuiModal-backdrop"
+      class="MuiBackdrop-root-edlnby bKKkeP MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kzahUP leuFnJ MuiModal-backdrop"
       id="backdropForMenuComponent"
       style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     />
@@ -96,19 +48,19 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
       tabindex="0"
     />
     <div
-      class="MuiPaper-root-jrNovL xmIEL MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-mFrfA diqnhj MuiPopover-paper"
+      class="MuiPaper-root-jrVkwW iTkKlE MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-neeJt dhYXvw MuiPopover-paper"
       style="opacity: 1; transform: scale(1, 1); transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; top: 0px; left: 0px; transform-origin: 0px 0px;"
       tabindex="-1"
     >
       <ul
         aria-label="Edit channel menu"
-        class="MuiList-root-fLixwv kPjBep MuiList-root MuiList-padding"
+        class="MuiList-root-fKJJSC gDElgH MuiList-root MuiList-padding"
         id="SidebarChannelMenu-MenuList-channel_id"
         role="menu"
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="channelOpenInNewWindow"
           role="menuitem"
           tabindex="0"
@@ -137,10 +89,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="markAsUnread-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -168,7 +120,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="favorite-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -200,7 +152,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="mute-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -229,14 +181,14 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="copyLink-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -265,7 +217,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         </li>
         <li
           aria-haspopup="true"
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="addMembers-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -301,10 +253,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY fMgZOu"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR chOaEk"
           id="leave-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -348,55 +300,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   <div
     aria-hidden="true"
     id="root-portal"
-  >
-    <div
-      data-floating-ui-portal=""
-      id=":r1g:"
-    >
-      <div
-        class="tooltipContainer hidden-xs"
-        role="tooltip"
-        style="position: absolute; left: 0px; top: 0px; opacity: 0; transform: translate(-8px, 0px); transition-property: opacity; transition-duration: 150ms;"
-        tabindex="-1"
-      >
-        <div
-          class="tooltipContent"
-        >
-          <span
-            class="tooltipContentTitleContainer"
-          >
-            <span
-              class="tooltipContentTitle"
-            >
-              Channel options
-            </span>
-          </span>
-        </div>
-        <svg
-          aria-hidden="true"
-          height="10"
-          style="position: absolute; pointer-events: none; top: 0px; left: calc(100% - 0px); transform: rotate(-90deg);"
-          viewBox="0 0 10 10"
-          width="10"
-        >
-          <path
-            d="M0,0 H10 L5,6 Q5,6 5,6 Z"
-            stroke="none"
-          />
-          <clippath
-            id=":r1h:"
-          >
-            <rect
-              height="10"
-              width="10"
-              x="0"
-              y="0"
-            />
-          </clippath>
-        </svg>
-      </div>
-    </div>
-  </div>
+  />
   <div
     aria-hidden="true"
   >
@@ -423,12 +327,12 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
     </button>
   </div>
   <div
-    class="MuiModal-root-jIscme ljbrzK MuiPopover-root-kLIimo MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
+    class="MuiModal-root-jIkgkT RTvUA MuiPopover-root-kMgVQh MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
     role="presentation"
   >
     <div
       aria-hidden="true"
-      class="MuiBackdrop-root-eddran ljsZwq MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kyBuqW kaXbXK MuiModal-backdrop"
+      class="MuiBackdrop-root-edlnby bKKkeP MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kzahUP leuFnJ MuiModal-backdrop"
       id="backdropForMenuComponent"
       style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     />
@@ -437,19 +341,19 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
       tabindex="0"
     />
     <div
-      class="MuiPaper-root-jrNovL xmIEL MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-mFrfA diqnhj MuiPopover-paper"
+      class="MuiPaper-root-jrVkwW iTkKlE MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-neeJt dhYXvw MuiPopover-paper"
       style="opacity: 1; transform: scale(1, 1); transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; top: 0px; left: 0px; transform-origin: 0px 0px;"
       tabindex="-1"
     >
       <ul
         aria-label="Edit channel menu"
-        class="MuiList-root-fLixwv kPjBep MuiList-root MuiList-padding"
+        class="MuiList-root-fKJJSC gDElgH MuiList-root MuiList-padding"
         id="SidebarChannelMenu-MenuList-channel_id"
         role="menu"
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="channelOpenInNewWindow"
           role="menuitem"
           tabindex="0"
@@ -478,10 +382,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="markAsUnread-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -509,7 +413,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="favorite-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -541,7 +445,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="mute-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -570,14 +474,14 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="copyLink-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -606,7 +510,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         </li>
         <li
           aria-haspopup="true"
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="addMembers-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -642,10 +546,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY fMgZOu"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR chOaEk"
           id="leave-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -689,55 +593,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   <div
     aria-hidden="true"
     id="root-portal"
-  >
-    <div
-      data-floating-ui-portal=""
-      id=":r1b:"
-    >
-      <div
-        class="tooltipContainer hidden-xs"
-        role="tooltip"
-        style="position: absolute; left: 0px; top: 0px; opacity: 0; transform: translate(-8px, 0px); transition-property: opacity; transition-duration: 150ms;"
-        tabindex="-1"
-      >
-        <div
-          class="tooltipContent"
-        >
-          <span
-            class="tooltipContentTitleContainer"
-          >
-            <span
-              class="tooltipContentTitle"
-            >
-              Channel options
-            </span>
-          </span>
-        </div>
-        <svg
-          aria-hidden="true"
-          height="10"
-          style="position: absolute; pointer-events: none; top: 0px; left: calc(100% - 0px); transform: rotate(-90deg);"
-          viewBox="0 0 10 10"
-          width="10"
-        >
-          <path
-            d="M0,0 H10 L5,6 Q5,6 5,6 Z"
-            stroke="none"
-          />
-          <clippath
-            id=":r1c:"
-          >
-            <rect
-              height="10"
-              width="10"
-              x="0"
-              y="0"
-            />
-          </clippath>
-        </svg>
-      </div>
-    </div>
-  </div>
+  />
   <div
     aria-hidden="true"
   >
@@ -764,12 +620,12 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
     </button>
   </div>
   <div
-    class="MuiModal-root-jIscme ljbrzK MuiPopover-root-kLIimo MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
+    class="MuiModal-root-jIkgkT RTvUA MuiPopover-root-kMgVQh MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
     role="presentation"
   >
     <div
       aria-hidden="true"
-      class="MuiBackdrop-root-eddran ljsZwq MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kyBuqW kaXbXK MuiModal-backdrop"
+      class="MuiBackdrop-root-edlnby bKKkeP MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kzahUP leuFnJ MuiModal-backdrop"
       id="backdropForMenuComponent"
       style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     />
@@ -778,19 +634,19 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
       tabindex="0"
     />
     <div
-      class="MuiPaper-root-jrNovL xmIEL MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-mFrfA diqnhj MuiPopover-paper"
+      class="MuiPaper-root-jrVkwW iTkKlE MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-neeJt dhYXvw MuiPopover-paper"
       style="opacity: 1; transform: scale(1, 1); transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; top: 0px; left: 0px; transform-origin: 0px 0px;"
       tabindex="-1"
     >
       <ul
         aria-label="Edit channel menu"
-        class="MuiList-root-fLixwv kPjBep MuiList-root MuiList-padding"
+        class="MuiList-root-fKJJSC gDElgH MuiList-root MuiList-padding"
         id="SidebarChannelMenu-MenuList-channel_id"
         role="menu"
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="channelOpenInNewWindow"
           role="menuitem"
           tabindex="0"
@@ -819,10 +675,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="markAsUnread-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -850,7 +706,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="favorite-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -882,7 +738,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="mute-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -911,14 +767,14 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="copyLink-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -947,7 +803,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         </li>
         <li
           aria-haspopup="true"
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="addMembers-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -983,10 +839,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY fMgZOu"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR chOaEk"
           id="leave-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1030,55 +886,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
   <div
     aria-hidden="true"
     id="root-portal"
-  >
-    <div
-      data-floating-ui-portal=""
-      id=":r11:"
-    >
-      <div
-        class="tooltipContainer hidden-xs"
-        role="tooltip"
-        style="position: absolute; left: 0px; top: 0px; opacity: 0; transform: translate(-8px, 0px); transition-property: opacity; transition-duration: 150ms;"
-        tabindex="-1"
-      >
-        <div
-          class="tooltipContent"
-        >
-          <span
-            class="tooltipContentTitleContainer"
-          >
-            <span
-              class="tooltipContentTitle"
-            >
-              Channel options
-            </span>
-          </span>
-        </div>
-        <svg
-          aria-hidden="true"
-          height="10"
-          style="position: absolute; pointer-events: none; top: 0px; left: calc(100% - 0px); transform: rotate(-90deg);"
-          viewBox="0 0 10 10"
-          width="10"
-        >
-          <path
-            d="M0,0 H10 L5,6 Q5,6 5,6 Z"
-            stroke="none"
-          />
-          <clippath
-            id=":r12:"
-          >
-            <rect
-              height="10"
-              width="10"
-              x="0"
-              y="0"
-            />
-          </clippath>
-        </svg>
-      </div>
-    </div>
-  </div>
+  />
   <div
     aria-hidden="true"
   >
@@ -1105,12 +913,12 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
     </button>
   </div>
   <div
-    class="MuiModal-root-jIscme ljbrzK MuiPopover-root-kLIimo MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
+    class="MuiModal-root-jIkgkT RTvUA MuiPopover-root-kMgVQh MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
     role="presentation"
   >
     <div
       aria-hidden="true"
-      class="MuiBackdrop-root-eddran ljsZwq MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kyBuqW kaXbXK MuiModal-backdrop"
+      class="MuiBackdrop-root-edlnby bKKkeP MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kzahUP leuFnJ MuiModal-backdrop"
       id="backdropForMenuComponent"
       style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     />
@@ -1119,19 +927,19 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
       tabindex="0"
     />
     <div
-      class="MuiPaper-root-jrNovL xmIEL MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-mFrfA diqnhj MuiPopover-paper"
+      class="MuiPaper-root-jrVkwW iTkKlE MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-neeJt dhYXvw MuiPopover-paper"
       style="opacity: 1; transform: scale(1, 1); transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; top: 0px; left: 0px; transform-origin: 0px 0px;"
       tabindex="-1"
     >
       <ul
         aria-label="Edit channel menu"
-        class="MuiList-root-fLixwv kPjBep MuiList-root MuiList-padding"
+        class="MuiList-root-fKJJSC gDElgH MuiList-root MuiList-padding"
         id="SidebarChannelMenu-MenuList-channel_id"
         role="menu"
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="channelOpenInNewWindow"
           role="menuitem"
           tabindex="0"
@@ -1160,10 +968,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="markAsUnread-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1191,7 +999,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="favorite-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1223,7 +1031,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="mute-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1252,14 +1060,14 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY fMgZOu"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR chOaEk"
           id="leave-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1303,55 +1111,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
   <div
     aria-hidden="true"
     id="root-portal"
-  >
-    <div
-      data-floating-ui-portal=""
-      id=":r16:"
-    >
-      <div
-        class="tooltipContainer hidden-xs"
-        role="tooltip"
-        style="position: absolute; left: 0px; top: 0px; opacity: 0; transform: translate(-8px, 0px); transition-property: opacity; transition-duration: 150ms;"
-        tabindex="-1"
-      >
-        <div
-          class="tooltipContent"
-        >
-          <span
-            class="tooltipContentTitleContainer"
-          >
-            <span
-              class="tooltipContentTitle"
-            >
-              Channel options
-            </span>
-          </span>
-        </div>
-        <svg
-          aria-hidden="true"
-          height="10"
-          style="position: absolute; pointer-events: none; top: 0px; left: calc(100% - 0px); transform: rotate(-90deg);"
-          viewBox="0 0 10 10"
-          width="10"
-        >
-          <path
-            d="M0,0 H10 L5,6 Q5,6 5,6 Z"
-            stroke="none"
-          />
-          <clippath
-            id=":r17:"
-          >
-            <rect
-              height="10"
-              width="10"
-              x="0"
-              y="0"
-            />
-          </clippath>
-        </svg>
-      </div>
-    </div>
-  </div>
+  />
   <div
     aria-hidden="true"
   >
@@ -1378,12 +1138,12 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
     </button>
   </div>
   <div
-    class="MuiModal-root-jIscme ljbrzK MuiPopover-root-kLIimo MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
+    class="MuiModal-root-jIkgkT RTvUA MuiPopover-root-kMgVQh MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
     role="presentation"
   >
     <div
       aria-hidden="true"
-      class="MuiBackdrop-root-eddran ljsZwq MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kyBuqW kaXbXK MuiModal-backdrop"
+      class="MuiBackdrop-root-edlnby bKKkeP MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kzahUP leuFnJ MuiModal-backdrop"
       id="backdropForMenuComponent"
       style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     />
@@ -1392,19 +1152,19 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
       tabindex="0"
     />
     <div
-      class="MuiPaper-root-jrNovL xmIEL MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-mFrfA diqnhj MuiPopover-paper"
+      class="MuiPaper-root-jrVkwW iTkKlE MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-neeJt dhYXvw MuiPopover-paper"
       style="opacity: 1; transform: scale(1, 1); transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; top: 0px; left: 0px; transform-origin: 0px 0px;"
       tabindex="-1"
     >
       <ul
         aria-label="Edit channel menu"
-        class="MuiList-root-fLixwv kPjBep MuiList-root MuiList-padding"
+        class="MuiList-root-fKJJSC gDElgH MuiList-root MuiList-padding"
         id="SidebarChannelMenu-MenuList-channel_id"
         role="menu"
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="channelOpenInNewWindow"
           role="menuitem"
           tabindex="0"
@@ -1433,10 +1193,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="markAsUnread-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1464,7 +1224,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="favorite-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1496,7 +1256,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="mute-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1525,14 +1285,14 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="copyLink-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1561,7 +1321,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <li
           aria-haspopup="true"
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="addMembers-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1612,55 +1372,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
   <div
     aria-hidden="true"
     id="root-portal"
-  >
-    <div
-      data-floating-ui-portal=""
-      id=":ri:"
-    >
-      <div
-        class="tooltipContainer hidden-xs"
-        role="tooltip"
-        style="position: absolute; left: 0px; top: 0px; opacity: 0; transform: translate(-8px, 0px); transition-property: opacity; transition-duration: 150ms;"
-        tabindex="-1"
-      >
-        <div
-          class="tooltipContent"
-        >
-          <span
-            class="tooltipContentTitleContainer"
-          >
-            <span
-              class="tooltipContentTitle"
-            >
-              Channel options
-            </span>
-          </span>
-        </div>
-        <svg
-          aria-hidden="true"
-          height="10"
-          style="position: absolute; pointer-events: none; top: 0px; left: calc(100% - 0px); transform: rotate(-90deg);"
-          viewBox="0 0 10 10"
-          width="10"
-        >
-          <path
-            d="M0,0 H10 L5,6 Q5,6 5,6 Z"
-            stroke="none"
-          />
-          <clippath
-            id=":rj:"
-          >
-            <rect
-              height="10"
-              width="10"
-              x="0"
-              y="0"
-            />
-          </clippath>
-        </svg>
-      </div>
-    </div>
-  </div>
+  />
   <div
     aria-hidden="true"
   >
@@ -1687,12 +1399,12 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
     </button>
   </div>
   <div
-    class="MuiModal-root-jIscme ljbrzK MuiPopover-root-kLIimo MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
+    class="MuiModal-root-jIkgkT RTvUA MuiPopover-root-kMgVQh MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
     role="presentation"
   >
     <div
       aria-hidden="true"
-      class="MuiBackdrop-root-eddran ljsZwq MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kyBuqW kaXbXK MuiModal-backdrop"
+      class="MuiBackdrop-root-edlnby bKKkeP MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kzahUP leuFnJ MuiModal-backdrop"
       id="backdropForMenuComponent"
       style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     />
@@ -1701,19 +1413,19 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
       tabindex="0"
     />
     <div
-      class="MuiPaper-root-jrNovL xmIEL MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-mFrfA diqnhj MuiPopover-paper"
+      class="MuiPaper-root-jrVkwW iTkKlE MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-neeJt dhYXvw MuiPopover-paper"
       style="opacity: 1; transform: scale(1, 1); transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; top: 0px; left: 0px; transform-origin: 0px 0px;"
       tabindex="-1"
     >
       <ul
         aria-label="Edit channel menu"
-        class="MuiList-root-fLixwv kPjBep MuiList-root MuiList-padding"
+        class="MuiList-root-fKJJSC gDElgH MuiList-root MuiList-padding"
         id="SidebarChannelMenu-MenuList-channel_id"
         role="menu"
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="channelOpenInNewWindow"
           role="menuitem"
           tabindex="0"
@@ -1742,10 +1454,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="markAsUnread-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1773,7 +1485,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="unfavorite-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1802,7 +1514,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="mute-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1831,14 +1543,14 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="copyLink-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1867,7 +1579,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <li
           aria-haspopup="true"
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="addMembers-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1903,10 +1615,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY fMgZOu"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR chOaEk"
           id="leave-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -1950,55 +1662,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
   <div
     aria-hidden="true"
     id="root-portal"
-  >
-    <div
-      data-floating-ui-portal=""
-      id=":rn:"
-    >
-      <div
-        class="tooltipContainer hidden-xs"
-        role="tooltip"
-        style="position: absolute; left: 0px; top: 0px; opacity: 0; transform: translate(-8px, 0px); transition-property: opacity; transition-duration: 150ms;"
-        tabindex="-1"
-      >
-        <div
-          class="tooltipContent"
-        >
-          <span
-            class="tooltipContentTitleContainer"
-          >
-            <span
-              class="tooltipContentTitle"
-            >
-              Channel options
-            </span>
-          </span>
-        </div>
-        <svg
-          aria-hidden="true"
-          height="10"
-          style="position: absolute; pointer-events: none; top: 0px; left: calc(100% - 0px); transform: rotate(-90deg);"
-          viewBox="0 0 10 10"
-          width="10"
-        >
-          <path
-            d="M0,0 H10 L5,6 Q5,6 5,6 Z"
-            stroke="none"
-          />
-          <clippath
-            id=":ro:"
-          >
-            <rect
-              height="10"
-              width="10"
-              x="0"
-              y="0"
-            />
-          </clippath>
-        </svg>
-      </div>
-    </div>
-  </div>
+  />
   <div
     aria-hidden="true"
   >
@@ -2025,12 +1689,12 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
     </button>
   </div>
   <div
-    class="MuiModal-root-jIscme ljbrzK MuiPopover-root-kLIimo MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
+    class="MuiModal-root-jIkgkT RTvUA MuiPopover-root-kMgVQh MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
     role="presentation"
   >
     <div
       aria-hidden="true"
-      class="MuiBackdrop-root-eddran ljsZwq MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kyBuqW kaXbXK MuiModal-backdrop"
+      class="MuiBackdrop-root-edlnby bKKkeP MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kzahUP leuFnJ MuiModal-backdrop"
       id="backdropForMenuComponent"
       style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     />
@@ -2039,19 +1703,19 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
       tabindex="0"
     />
     <div
-      class="MuiPaper-root-jrNovL xmIEL MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-mFrfA diqnhj MuiPopover-paper"
+      class="MuiPaper-root-jrVkwW iTkKlE MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-neeJt dhYXvw MuiPopover-paper"
       style="opacity: 1; transform: scale(1, 1); transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; top: 0px; left: 0px; transform-origin: 0px 0px;"
       tabindex="-1"
     >
       <ul
         aria-label="Edit channel menu"
-        class="MuiList-root-fLixwv kPjBep MuiList-root MuiList-padding"
+        class="MuiList-root-fKJJSC gDElgH MuiList-root MuiList-padding"
         id="SidebarChannelMenu-MenuList-channel_id"
         role="menu"
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="channelOpenInNewWindow"
           role="menuitem"
           tabindex="0"
@@ -2080,10 +1744,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="markAsUnread-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2111,7 +1775,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="favorite-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2143,7 +1807,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="unmute-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2172,14 +1836,14 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="copyLink-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2208,7 +1872,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <li
           aria-haspopup="true"
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="addMembers-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2244,10 +1908,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY fMgZOu"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR chOaEk"
           id="leave-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2291,55 +1955,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
   <div
     aria-hidden="true"
     id="root-portal"
-  >
-    <div
-      data-floating-ui-portal=""
-      id=":rs:"
-    >
-      <div
-        class="tooltipContainer hidden-xs"
-        role="tooltip"
-        style="position: absolute; left: 0px; top: 0px; opacity: 0; transform: translate(-8px, 0px); transition-property: opacity; transition-duration: 150ms;"
-        tabindex="-1"
-      >
-        <div
-          class="tooltipContent"
-        >
-          <span
-            class="tooltipContentTitleContainer"
-          >
-            <span
-              class="tooltipContentTitle"
-            >
-              Channel options
-            </span>
-          </span>
-        </div>
-        <svg
-          aria-hidden="true"
-          height="10"
-          style="position: absolute; pointer-events: none; top: 0px; left: calc(100% - 0px); transform: rotate(-90deg);"
-          viewBox="0 0 10 10"
-          width="10"
-        >
-          <path
-            d="M0,0 H10 L5,6 Q5,6 5,6 Z"
-            stroke="none"
-          />
-          <clippath
-            id=":rt:"
-          >
-            <rect
-              height="10"
-              width="10"
-              x="0"
-              y="0"
-            />
-          </clippath>
-        </svg>
-      </div>
-    </div>
-  </div>
+  />
   <div
     aria-hidden="true"
   >
@@ -2366,12 +1982,12 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
     </button>
   </div>
   <div
-    class="MuiModal-root-jIscme ljbrzK MuiPopover-root-kLIimo MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
+    class="MuiModal-root-jIkgkT RTvUA MuiPopover-root-kMgVQh MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
     role="presentation"
   >
     <div
       aria-hidden="true"
-      class="MuiBackdrop-root-eddran ljsZwq MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kyBuqW kaXbXK MuiModal-backdrop"
+      class="MuiBackdrop-root-edlnby bKKkeP MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kzahUP leuFnJ MuiModal-backdrop"
       id="backdropForMenuComponent"
       style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     />
@@ -2380,19 +1996,19 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
       tabindex="0"
     />
     <div
-      class="MuiPaper-root-jrNovL xmIEL MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-mFrfA diqnhj MuiPopover-paper"
+      class="MuiPaper-root-jrVkwW iTkKlE MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-neeJt dhYXvw MuiPopover-paper"
       style="opacity: 1; transform: scale(1, 1); transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; top: 0px; left: 0px; transform-origin: 0px 0px;"
       tabindex="-1"
     >
       <ul
         aria-label="Edit channel menu"
-        class="MuiList-root-fLixwv kPjBep MuiList-root MuiList-padding"
+        class="MuiList-root-fKJJSC gDElgH MuiList-root MuiList-padding"
         id="SidebarChannelMenu-MenuList-channel_id"
         role="menu"
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="channelOpenInNewWindow"
           role="menuitem"
           tabindex="0"
@@ -2421,10 +2037,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="markAsUnread-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2452,7 +2068,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="favorite-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2484,7 +2100,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="mute-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2513,14 +2129,14 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="copyLink-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2549,7 +2165,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <li
           aria-haspopup="true"
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="addMembers-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2585,10 +2201,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY fMgZOu"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR chOaEk"
           id="leave-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2632,55 +2248,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
   <div
     aria-hidden="true"
     id="root-portal"
-  >
-    <div
-      data-floating-ui-portal=""
-      id=":rd:"
-    >
-      <div
-        class="tooltipContainer hidden-xs"
-        role="tooltip"
-        style="position: absolute; left: 0px; top: 0px; opacity: 0; transform: translate(-8px, 0px); transition-property: opacity; transition-duration: 150ms;"
-        tabindex="-1"
-      >
-        <div
-          class="tooltipContent"
-        >
-          <span
-            class="tooltipContentTitleContainer"
-          >
-            <span
-              class="tooltipContentTitle"
-            >
-              Channel options
-            </span>
-          </span>
-        </div>
-        <svg
-          aria-hidden="true"
-          height="10"
-          style="position: absolute; pointer-events: none; top: 0px; left: calc(100% - 0px); transform: rotate(-90deg);"
-          viewBox="0 0 10 10"
-          width="10"
-        >
-          <path
-            d="M0,0 H10 L5,6 Q5,6 5,6 Z"
-            stroke="none"
-          />
-          <clippath
-            id=":re:"
-          >
-            <rect
-              height="10"
-              width="10"
-              x="0"
-              y="0"
-            />
-          </clippath>
-        </svg>
-      </div>
-    </div>
-  </div>
+  />
   <div
     aria-hidden="true"
   >
@@ -2707,12 +2275,12 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
     </button>
   </div>
   <div
-    class="MuiModal-root-jIscme ljbrzK MuiPopover-root-kLIimo MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
+    class="MuiModal-root-jIkgkT RTvUA MuiPopover-root-kMgVQh MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
     role="presentation"
   >
     <div
       aria-hidden="true"
-      class="MuiBackdrop-root-eddran ljsZwq MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kyBuqW kaXbXK MuiModal-backdrop"
+      class="MuiBackdrop-root-edlnby bKKkeP MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kzahUP leuFnJ MuiModal-backdrop"
       id="backdropForMenuComponent"
       style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     />
@@ -2721,19 +2289,19 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
       tabindex="0"
     />
     <div
-      class="MuiPaper-root-jrNovL xmIEL MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-mFrfA diqnhj MuiPopover-paper"
+      class="MuiPaper-root-jrVkwW iTkKlE MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-neeJt dhYXvw MuiPopover-paper"
       style="opacity: 1; transform: scale(1, 1); transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; top: 0px; left: 0px; transform-origin: 0px 0px;"
       tabindex="-1"
     >
       <ul
         aria-label="Edit channel menu"
-        class="MuiList-root-fLixwv kPjBep MuiList-root MuiList-padding"
+        class="MuiList-root-fKJJSC gDElgH MuiList-root MuiList-padding"
         id="SidebarChannelMenu-MenuList-channel_id"
         role="menu"
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="channelOpenInNewWindow"
           role="menuitem"
           tabindex="0"
@@ -2762,10 +2330,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="markAsUnread-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2793,7 +2361,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="favorite-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2825,7 +2393,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="mute-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2854,14 +2422,14 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="copyLink-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2890,7 +2458,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <li
           aria-haspopup="true"
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="addMembers-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2926,10 +2494,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY fMgZOu"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR chOaEk"
           id="leave-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -2973,55 +2541,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
   <div
     aria-hidden="true"
     id="root-portal"
-  >
-    <div
-      data-floating-ui-portal=""
-      id=":r8:"
-    >
-      <div
-        class="tooltipContainer hidden-xs"
-        role="tooltip"
-        style="position: absolute; left: 0px; top: 0px; opacity: 0; transform: translate(-8px, 0px); transition-property: opacity; transition-duration: 150ms;"
-        tabindex="-1"
-      >
-        <div
-          class="tooltipContent"
-        >
-          <span
-            class="tooltipContentTitleContainer"
-          >
-            <span
-              class="tooltipContentTitle"
-            >
-              Channel options
-            </span>
-          </span>
-        </div>
-        <svg
-          aria-hidden="true"
-          height="10"
-          style="position: absolute; pointer-events: none; top: 0px; left: calc(100% - 0px); transform: rotate(-90deg);"
-          viewBox="0 0 10 10"
-          width="10"
-        >
-          <path
-            d="M0,0 H10 L5,6 Q5,6 5,6 Z"
-            stroke="none"
-          />
-          <clippath
-            id=":r9:"
-          >
-            <rect
-              height="10"
-              width="10"
-              x="0"
-              y="0"
-            />
-          </clippath>
-        </svg>
-      </div>
-    </div>
-  </div>
+  />
   <div
     aria-hidden="true"
   >
@@ -3048,12 +2568,12 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
     </button>
   </div>
   <div
-    class="MuiModal-root-jIscme ljbrzK MuiPopover-root-kLIimo MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
+    class="MuiModal-root-jIkgkT RTvUA MuiPopover-root-kMgVQh MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
     role="presentation"
   >
     <div
       aria-hidden="true"
-      class="MuiBackdrop-root-eddran ljsZwq MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kyBuqW kaXbXK MuiModal-backdrop"
+      class="MuiBackdrop-root-edlnby bKKkeP MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop-kzahUP leuFnJ MuiModal-backdrop"
       id="backdropForMenuComponent"
       style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     />
@@ -3062,19 +2582,19 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
       tabindex="0"
     />
     <div
-      class="MuiPaper-root-jrNovL xmIEL MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-mFrfA diqnhj MuiPopover-paper"
+      class="MuiPaper-root-jrVkwW iTkKlE MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation8 MuiPopover-paper-neeJt dhYXvw MuiPopover-paper"
       style="opacity: 1; transform: scale(1, 1); transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; top: 0px; left: 0px; transform-origin: 0px 0px;"
       tabindex="-1"
     >
       <ul
         aria-label="Edit channel menu"
-        class="MuiList-root-fLixwv kPjBep MuiList-root MuiList-padding"
+        class="MuiList-root-fKJJSC gDElgH MuiList-root MuiList-padding"
         id="SidebarChannelMenu-MenuList-channel_id"
         role="menu"
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="channelOpenInNewWindow"
           role="menuitem"
           tabindex="0"
@@ -3103,10 +2623,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="markAsRead-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -3134,7 +2654,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="favorite-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -3166,7 +2686,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
           </div>
         </li>
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="mute-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -3195,14 +2715,14 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="copyLink-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -3231,7 +2751,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <li
           aria-haspopup="true"
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR koIPww"
           id="addMembers-channel_id"
           role="menuitem"
           tabindex="-1"
@@ -3267,10 +2787,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         </li>
         <hr
           aria-orientation="vertical"
-          class="MuiDivider-root-ermPAM jKcMpH MuiDivider-root MuiDivider-fullWidth"
+          class="MuiDivider-root-erLDeF cViEdA MuiDivider-root MuiDivider-fullWidth"
         />
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY fMgZOu"
+          class="MuiButtonBase-root-JvZdr dKFJFs MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXqYNm kIRdVO MuiMenuItem-root MuiMenuItem-gutters sc-gswNZR chOaEk"
           id="leave-channel_id"
           role="menuitem"
           tabindex="-1"

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
@@ -29,6 +29,13 @@ jest.mock('utils/popouts/popout_windows', () => ({
     isChannelPopoutWindow: jest.fn(() => false),
 }));
 
+// Avoid Floating UI tooltip portals in #root-portal — they mount inconsistently under jsdom
+// and make full-document snapshots flaky (tooltip DOM vs. empty portal).
+jest.mock('components/with_tooltip', () => ({
+    __esModule: true,
+    default: ({children}: {children: React.ReactNode}) => <>{children}</>,
+}));
+
 describe('components/sidebar/sidebar_channel/sidebar_channel_menu', () => {
     const testChannel = TestHelper.getChannelMock();
     const testCategory = TestHelper.getCategoryMock();

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
@@ -7,7 +7,7 @@ import type {ChannelType} from '@mattermost/types/channels';
 
 import {CategoryTypes} from 'mattermost-redux/constants/channel_categories';
 
-import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
+import {renderWithContext, screen, userEvent, waitFor, within} from 'tests/react_testing_utils';
 import Constants from 'utils/constants';
 import {canPopout, isChannelPopoutWindow} from 'utils/popouts/popout_windows';
 import {TestHelper} from 'utils/test_helper';
@@ -67,6 +67,18 @@ describe('components/sidebar/sidebar_channel/sidebar_channel_menu', () => {
         const menuButton = screen.getByRole('button', {name: /channel options/i});
         await user.click(menuButton);
         await screen.findByRole('menu', {name: 'Edit channel menu'});
+
+        // Tooltip-on-hover is opened by `userEvent.click` before the click reaches
+        // the button; the menu opening then dismisses it via a fade-out transition.
+        // Wait for the tooltip portal child to fully unmount so snapshots are
+        // deterministic and don't capture the in-flight fade-out (which is
+        // sensitive to timer scheduling and CI load).
+        const portal = document.getElementById('root-portal');
+        if (portal) {
+            await waitFor(() => {
+                expect(within(portal).queryByRole('tooltip', {hidden: true})).not.toBeInTheDocument();
+            });
+        }
     };
 
     test('should match snapshot and contain correct buttons', async () => {

--- a/webapp/channels/src/utils/format_attribute_name.test.ts
+++ b/webapp/channels/src/utils/format_attribute_name.test.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {formatAttributeName} from './format_attribute_name';
+
+describe('formatAttributeName', () => {
+    test('snake_case to title case', () => {
+        expect(formatAttributeName('user_role')).toBe('User Role');
+    });
+
+    test('camelCase to title case', () => {
+        expect(formatAttributeName('userRole')).toBe('User Role');
+    });
+
+    test('leading uppercase does not leave a leading space in output', () => {
+        expect(formatAttributeName('Program')).toBe('Program');
+    });
+
+    test('preserves acronym runs before a capitalized word', () => {
+        expect(formatAttributeName('ABACPolicy')).toBe('Abac Policy');
+    });
+
+    test('preserves trailing acronym after camelCase prefix', () => {
+        expect(formatAttributeName('userID')).toBe('User Id');
+    });
+});

--- a/webapp/channels/src/utils/format_attribute_name.ts
+++ b/webapp/channels/src/utils/format_attribute_name.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/**
+ * Convert snake_case or camelCase attribute keys to Title Case with spaces
+ * (e.g. "user_role" → "User Role"). Splits camelCase on word boundaries only:
+ * lowercase→uppercase and acronym runs followed by a capitalized word, so
+ * acronyms like "ABACPolicy" or "userID" are not split per letter.
+ * trim() removes accidental leading/trailing spaces from replacements.
+ */
+export function formatAttributeName(name: string): string {
+    return name.
+        replace(/_/g, ' ').
+        replace(/([a-z])([A-Z])/g, '$1 $2').
+        replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2').
+        replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substring(1).toLowerCase()).
+        trim();
+}

--- a/webapp/platform/client/src/websocket_events.ts
+++ b/webapp/platform/client/src/websocket_events.ts
@@ -79,6 +79,7 @@ export const enum WebSocketEvents {
     ChannelBookmarkUpdated = 'channel_bookmark_updated',
     ChannelBookmarkDeleted = 'channel_bookmark_deleted',
     ChannelBookmarkSorted = 'channel_bookmark_sorted',
+    ChannelAccessControlUpdated = 'channel_access_control_updated',
     PresenceIndicator = 'presence',
     PostedNotifyAck = 'posted_notify_ack', // This isn't currently used by the web app
     ScheduledPostCreated = 'scheduled_post_created',

--- a/webapp/platform/client/src/websocket_message.ts
+++ b/webapp/platform/client/src/websocket_message.ts
@@ -47,6 +47,8 @@ export type WebSocketMessage = (
     Messages.ChannelBookmarkDeleted |
     Messages.ChannelBookmarkSorted |
 
+    Messages.ChannelAccessControlUpdated |
+
     Messages.Team |
     Messages.UpdateTeamScheme |
     Messages.UserAddedToTeam |

--- a/webapp/platform/client/src/websocket_messages.ts
+++ b/webapp/platform/client/src/websocket_messages.ts
@@ -261,6 +261,12 @@ export type ChannelBookmarkSorted = BaseWebSocketMessage<WebSocketEvents.Channel
     bookmarks: JsonEncodedValue<ChannelBookmarkWithFileInfo[]>;
 }>;
 
+// Channel access control messages
+
+export type ChannelAccessControlUpdated = BaseWebSocketMessage<WebSocketEvents.ChannelAccessControlUpdated, {
+    channel: JsonEncodedValue<Channel>;
+}>;
+
 // Team and team member messages
 
 export type Team =


### PR DESCRIPTION
2026-04-28자 upstream(mattermost/mattermost) 커밋 10건을 `/speckit-sync`로 선별 반영했다. 남은 미반영 커밋 750 → 740.

## cherry-pick 7건

- `45ec78b5` [MM-68457] Expose audit logging API via pluginapi.Client (#36232) — `pluginapi.Client`에 `Audit` 서비스 추가(+64/−0 순수 추가). 플러그인이 표준 API로 감사 로그를 남길 수 있다.
- `81d4fe37` MM-68339: Add XML struct tags and multi-remote registration for shared channels plugin API (#36126) — SyncMsg 모델에 xml 태그 추가(JSON 직렬화 무영향), 플러그인당 remote 1개 제약 해제. 파생 파일(retrylayer·timerlayer·mocks·client_rpc_generated·plugintest)과 테스트가 커밋에 모두 포함돼 CLEAN 반영.
- `fdaea9de` MM-68339: slugify RemoteCluster.Name in plugin registration (#36309) — **순서를 앞당겨 반영**. 위 커밋이 upstream master CI를 깨뜨린 것을 upstream 자신이 고친 짝 수정이다(아래 참조).
- `2283b51b` MM-67974: Add disk space info to Support Packet for local file store (#36300) — 로컬 파일 스토어일 때 디스크 용량·파일시스템 종류를 진단에 추가. `memory_{darwin,linux,other}.go`와 같은 플랫폼 분기 패턴.
- `c85601dc` [MM-67979] [MM-67980] Add SMTP and push proxy connectivity status to support packet diagnostics (#35837) — `notifications.email/push` 연결 상태 프로브 추가. 프로브 중 실제 발송은 하지 않는다.
- `bd8fc922` MM-68526: Harden remote cluster patch response (#36288) — **보안 수정**. PATCH 응답과 감사 로그에 `Token`·`RemoteToken`이 노출되던 것을 `Sanitize()` 호출로 차단. GET 경로는 이미 정제되고 있어 PATCH만 뚫려 있었다.
- `c79c3831` MM-68264: return error on bot username conflict (#36064) — 봇 이름과 같은 일반 사용자 계정이 있을 때 그 사용자의 ID를 플러그인에 넘겨주던 조용한 오동작을 에러로 바꾼다.

## adapt 2건

둘 다 유일한 충돌이 `sidebar_channel_menu.test.tsx.snap`이었다. 충돌 내용이 React 자동생성 ID 차이(`:r1n:` vs `:r1g:`)뿐이고 두 커밋 모두 그 스냅샷에서 대량 삭제를 하므로, 파일을 지우고 우리 트리 기준으로 재생성해 해소했다.

- `5c43e4b1` [MM-68459] Implement dictionary style end user indicators for membership policies (#36240) — 속성 키를 Title Case로 표시(`formatAttributeName` 신규), 채널 배너 속성 조회를 `"*"` 대신 `AccessControlPolicyActionMembership`로 명시. 툴팁 페이드아웃으로 인한 플레이키 스냅샷 테스트 수정 포함.
- `85dc0851` [MM-68535] Invalidate channel cache after policy assignment (#36292) — 신규 WS 이벤트 `channel_access_control_updated`로 정책 변경 시 클라이언트 속성 캐시를 무효화. `SearchUsersNotInChannel`의 ABAC 경로에서 `sanitizeProfiles`가 빠져 있던 것도 함께 수정. signals가 보고한 `useAccessControlAttributes` 충돌 2건은 같은 세션에서 `5c43e4b1`을 먼저 반영해 사라졌다(브랜치 HEAD 기준 merge-tree로 확인).

## exclude 1건 (ledger 부록에 사유 기록)

- `2b7b398a` [MM-68102] Add Classification Markings admin console page (#35934) — 제외한 `48f2fd08`(Integrated Boards MVP) property 시스템 v2 계보 10번째. 등급 데이터를 PropertyField/PropertyValue로 저장하는데 `server/channels/api4/properties.go`가 우리 트리에 없고, 우리 `PropertyField` 타입엔 `object_type`이 없다. upstream 기준으로도 `ClassificationMarkings` 플래그 뒤에 숨어 기본 비활성.

## 도중에 잡은 문제

`81d4fe37` 반영 직후 검증에서 테스트 6건이 실패했다. `RegisterPluginForSharedChannels`가 표시명(`"my remote"`)을 슬러그 정규식 `^[a-zA-Z0-9.\-_]+$`로 검증되는 `Name`에 그대로 대입하는 것이 원인이다. upstream 자신도 이 커밋으로 master CI를 깨뜨렸고 `fdaea9de`(#36309)로 고쳤다 — 해당 커밋 메시지가 "The tests didn't run in the PR's final CI shard and the issue surfaced post-merge"라고 밝히고 있다. 짝 수정을 앞당겨 반영해 6건 전부 통과시켰다. 사이에 낀 5건(`2283b51b`·`5c43e4b1`·`c85601dc`·`bd8fc922`·`c79c3831`)은 remote cluster와 무관해 의존성 문제가 없다.

## 검증

| 게이트 | 결과 |
|---|---|
| webapp `check-types` | 신규 오류 0 (master 기준선 117건 ⊃ 현재 29건) |
| webapp `check` (lint) | 오류 46개 파일 중 세션 변경 파일 0건 (기존 백로그) |
| webapp 테스트 | 스냅샷 11/11 ×2, 접촉 컴포넌트 71/71, WS·훅 61/61 통과 |
| server 빌드·vet | 클린 |
| server 테스트 | `pluginapi` 4패키지, `public/model` 전체, `channels/app`(remote/shared/EnsureBot/access control), `channels/api4`(remote cluster·access control) 통과 |
| `channels/app/platform` | 신규 서브테스트 실패는 전부 기존 macOS `/dev/fd` 문제 1건씩뿐 — 자체 단언 실패 0 |
| server `make check-style` | `NotificationHistory` 미구현으로 `vet` 실패 — master에서 동일 실패하는 기존 문제 |
| `i18n-check-empty` (CI 차단) | EXIT=0 |

## 후속 (이 PR 범위 밖)

- **i18n 신규 1건** — `81d4fe37`이 추가한 `model.cluster.is_valid.site_url.app_error`가 server ko.json 미번역 (498 → 499)
- **i18n 기존 누적** — webapp ko.json 미번역 161키, server ko.json 고아 58키·영문 원문 변경 7키, `texteditor.rewrite.placeholder.rewriting` 드리프트
- **리브랜드** — `c79c3831`이 옮긴 봇 충돌 로그 문구에 미적용분 잔존(`'mattermost user convert'`, `"restart the Mattermost server"`, `mattermost.com/pl/default-bot-accounts`). 이 커밋은 문구를 바꾸지 않아 상태가 나빠지진 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)