### PR TITLE
fix: storetest.Store에 누락된 NotificationHistory 접근자 추가

### DIFF
--- a/server/channels/store/storetest/store.go
+++ b/server/channels/store/storetest/store.go
@@ -74,6 +74,7 @@ type Store struct {
 	RecapStore                      mocks.RecapStore
 	ReadReceiptStore                mocks.ReadReceiptStore
 	TemporaryPostStore              mocks.TemporaryPostStore
+	NotificationHistoryStore        mocks.NotificationHistoryStore
 }
 
 func (s *Store) Logger() mlog.LoggerIFace                      { return s.logger }
@@ -179,6 +180,9 @@ func (s *Store) ReadReceipt() store.ReadReceiptStore {
 func (s *Store) TemporaryPost() store.TemporaryPostStore {
 	return &s.TemporaryPostStore
 }
+func (s *Store) NotificationHistory() store.NotificationHistoryStore {
+	return &s.NotificationHistoryStore
+}
 func (s *Store) GetSchemaDefinition() (*model.SupportPacketDatabaseSchema, error) {
 	return &model.SupportPacketDatabaseSchema{
 		Tables: []model.DatabaseTable{},
@@ -234,5 +238,6 @@ func (s *Store) AssertExpectations(t mock.TestingT) bool {
 		&s.RecapStore,
 		&s.ReadReceiptStore,
 		&s.TemporaryPostStore,
+		&s.NotificationHistoryStore,
 	)
 }


### PR DESCRIPTION
d429d6f781(feat: 알림 히스토리 기능 추가 #167)이 store.Store 인터페이스에
NotificationHistory()를 추가하면서 테스트 더블 둘 중 하나만 갱신했다.
mockery가 생성하는 storetest/mocks/Store.go에는 들어갔지만, 수기로 관리하는
storetest/store.go에는 필드·접근자가 빠졌다.

그 결과 storetest.Store를 쓰는 테스트 패키지들이 *storetest.Store does not
implement store.Store (missing method NotificationHistory)로 컴파일되지
않았다 — channels/jobs, channels/jobs/delete_dms_preferences_migration,
delete_empty_drafts_migration, delete_orphan_drafts_migration,
enterprise/message_export/shared.

make check-style이 vet 단계에서 이 오류로 중단돼 왔고, 그 뒤의 golangci-lint는
아예 실행되지 못했다.

다른 스토어와 동일한 패턴으로 세 곳을 채웠다 — struct 필드,
NotificationHistory() 접근자, AssertExpectations 등록.

검증:
- go vet ./channels/jobs/... ./enterprise/message_export/shared/... 통과
- go test 위 패키지 전부 통과 (FAIL 0)
- gofmt 차이 없음, golangci-lint가 이 파일에 지적 0건
