### PR TITLE
chore: golangci-lint 지적 13건 해소 (make check-style 전면 통과)

### DIFF
--- a/server/channels/api4/post.go
+++ b/server/channels/api4/post.go
@@ -269,8 +269,7 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	filterUserIdsParam := r.URL.Query().Get("filterUserIds")
 	var filterUserIds []string
 	if filterUserIdsParam != "" {
-		userIds := strings.Split(filterUserIdsParam, ",")
-		for _, userId := range userIds {
+		for userId := range strings.SplitSeq(filterUserIdsParam, ",") {
 			userId = strings.TrimSpace(userId)
 			if userId != "" {
 				if !model.IsValidId(userId) {
@@ -344,8 +343,8 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	clientPostList := c.App.PreparePostListForClient(c.AppContext, list)
 
 	// Filter bot messages based on query parameter
-	if err := c.App.FilterBotMessagesFromPostList(c.AppContext, clientPostList, showBotMessages); err != nil {
-		c.Err = err
+	if filterErr := c.App.FilterBotMessagesFromPostList(c.AppContext, clientPostList, showBotMessages); filterErr != nil {
+		c.Err = filterErr
 		return
 	}
 
@@ -410,8 +409,7 @@ func getPostsForChannelAroundLastUnread(c *Context, w http.ResponseWriter, r *ht
 	filterUserIdsParam := r.URL.Query().Get("filterUserIds")
 	var filterUserIds []string
 	if filterUserIdsParam != "" {
-		userIds := strings.Split(filterUserIdsParam, ",")
-		for _, userId := range userIds {
+		for userId := range strings.SplitSeq(filterUserIdsParam, ",") {
 			userId = strings.TrimSpace(userId)
 			if userId != "" {
 				if !model.IsValidId(userId) {
@@ -447,8 +445,8 @@ func getPostsForChannelAroundLastUnread(c *Context, w http.ResponseWriter, r *ht
 	clientPostList := c.App.PreparePostListForClient(c.AppContext, postList)
 
 	// Filter bot messages based on query parameter
-	if err := c.App.FilterBotMessagesFromPostList(c.AppContext, clientPostList, showBotMessages); err != nil {
-		c.Err = err
+	if filterErr := c.App.FilterBotMessagesFromPostList(c.AppContext, clientPostList, showBotMessages); filterErr != nil {
+		c.Err = filterErr
 		return
 	}
 
@@ -929,8 +927,8 @@ func getPostThread(c *Context, w http.ResponseWriter, r *http.Request) {
 	clientPostList := c.App.PreparePostListForClient(c.AppContext, list)
 
 	// Filter bot messages based on query parameter
-	if err := c.App.FilterBotMessagesFromPostList(c.AppContext, clientPostList, showBotMessages); err != nil {
-		c.Err = err
+	if filterErr := c.App.FilterBotMessagesFromPostList(c.AppContext, clientPostList, showBotMessages); filterErr != nil {
+		c.Err = filterErr
 		return
 	}
 

--- a/server/channels/api4/user.go
+++ b/server/channels/api4/user.go
@@ -1167,8 +1167,8 @@ func searchUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 		if props.Limit == model.UserSearchDefaultLimit {
 			props.Limit = 100 // 기본 100명으로 제한
 		}
-	} 
-	
+	}
+
 	if props.TeamId == "" && props.NotInChannelId != "" {
 		c.SetInvalidParam("team_id")
 		return

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -778,7 +778,7 @@ func (a *App) AddUsersToGroupChannel(rctx request.CTX, channel *model.Channel, u
 			}
 
 			if _, nErr := a.Srv().Store().Channel().SaveMember(rctx, newMember); nErr != nil {
-				var appErr *model.AppError
+				var saveAppErr *model.AppError
 				var cErr *store.ErrConflict
 				switch {
 				case errors.As(nErr, &cErr):
@@ -786,8 +786,8 @@ func (a *App) AddUsersToGroupChannel(rctx request.CTX, channel *model.Channel, u
 					case "ChannelMembers":
 						continue
 					}
-				case errors.As(nErr, &appErr):
-					return nil, appErr
+				case errors.As(nErr, &saveAppErr):
+					return nil, saveAppErr
 				default:
 					return nil, model.NewAppError("AddUsersToGroupChannel", "api.channel.add_user.to.channel.failed.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 				}

--- a/server/channels/app/org_role.go
+++ b/server/channels/app/org_role.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"regexp"
 	"strings"
@@ -147,7 +148,7 @@ func (a *App) CreatePositionDefinition(actorUserID string, input *model.Position
 		err  error
 	)
 
-	for collisionIndex := 0; collisionIndex < orgRoleCodeRetryLimit; collisionIndex++ {
+	for collisionIndex := range orgRoleCodeRetryLimit {
 		input.Code = generateOrgRoleCodeCandidate(baseCode, collisionIndex)
 		item, err = ss.CreatePositionDefinition(input)
 		if err == nil {
@@ -286,7 +287,7 @@ func (a *App) CreateOrgUnit(actorUserID string, input *model.OrgUnit) (*model.Or
 		err  error
 	)
 
-	for collisionIndex := 0; collisionIndex < orgRoleCodeRetryLimit; collisionIndex++ {
+	for collisionIndex := range orgRoleCodeRetryLimit {
 		input.Code = generateOrgRoleCodeCandidate(baseCode, collisionIndex)
 		item, err = ss.CreateOrgUnit(input)
 		if err == nil {
@@ -630,9 +631,7 @@ func (a *App) syncUserOrgProfileToProps(rctx request.CTX, item *model.UserOrgPro
 	}
 
 	newProps := model.StringMap{}
-	for k, v := range user.Props {
-		newProps[k] = v
-	}
+	maps.Copy(newProps, user.Props)
 	newProps[userPropOrgUnitIDs] = strings.Join(orgUnitIDs, ",")
 	newProps[userPropPositionCodes] = strings.Join(positionCodes, ",")
 	newProps[userPropIsCEO] = fmt.Sprintf("%t", isCEO)

--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -784,14 +784,14 @@ func (s *SqlPostStore) Get(rctx request.CTX, id string, opts model.GetPostsOptio
 					sq.Eq{"DeleteAt": 0},
 				}).Suffix(")"),
 			).
-		From("Posts p, replycount").
-		Where(sq.And{
-			sq.Or{
-				sq.Eq{"p.Id": rootId},
-				sq.Eq{"p.RootId": rootId},
-			},
-			sq.Eq{"p.DeleteAt": 0},
-		})
+			From("Posts p, replycount").
+			Where(sq.And{
+				sq.Or{
+					sq.Eq{"p.Id": rootId},
+					sq.Eq{"p.RootId": rootId},
+				},
+				sq.Eq{"p.DeleteAt": 0},
+			})
 
 		var sort string
 		if opts.Direction != "" {
@@ -1946,7 +1946,7 @@ func (s *SqlPostStore) getParentsPosts(channelId string, offset int, limit int, 
 	userIdSubQueryCondition := ""
 	userIdQueryCondition := ""
 	params := []any{channelId}
-	
+
 	if len(filterUserIds) > 0 {
 		placeholders := make([]string, len(filterUserIds))
 		for i := range filterUserIds {
@@ -1962,11 +1962,11 @@ func (s *SqlPostStore) getParentsPosts(channelId string, offset int, limit int, 
 		}
 		userIdQueryCondition = " AND q2.UserId IN (" + strings.Join(placeholders2, ",") + ")"
 	}
-	
+
 	if includeDeleted {
 		deleteAtQueryCondition, deleteAtSubQueryCondition = "", ""
 	}
-	
+
 	params = append(params, limit, offset, channelId)
 
 	postColumnsQ2 := strings.Join(postSliceColumnsWithName("q2"), ", ")

--- a/server/public/model/notification.go
+++ b/server/public/model/notification.go
@@ -98,12 +98,12 @@ type NotificationHistoryList struct {
 
 // NotificationHistoryCounts는 알림 개수 정보입니다.
 type NotificationHistoryCounts struct {
-	TotalCount    int64 `json:"total_count"`
-	UnreadCount   int64 `json:"unread_count"`
-	MentionCount  int64 `json:"mention_count"`
-	DMCount       int64 `json:"dm_count"`
-	ThreadCount   int64 `json:"thread_count"`
-	UrgentCount   int64 `json:"urgent_count"`
+	TotalCount   int64 `json:"total_count"`
+	UnreadCount  int64 `json:"unread_count"`
+	MentionCount int64 `json:"mention_count"`
+	DMCount      int64 `json:"dm_count"`
+	ThreadCount  int64 `json:"thread_count"`
+	UrgentCount  int64 `json:"urgent_count"`
 }
 
 // GetNotificationHistoryOptions는 알림 조회 옵션입니다.
@@ -152,6 +152,6 @@ func (n *NotificationHistory) ToJSON() string {
 }
 
 func (n *NotificationHistory) DeepCopy() *NotificationHistory {
-	copy := *n
-	return &copy
+	nCopy := *n
+	return &nCopy
 }


### PR DESCRIPTION
storetest.Store의 NotificationHistory 누락(66439b6627)으로 make check-style이
vet 단계에서 중단돼 왔고, 그 뒤의 golangci-lint는 실행조차 되지 못했다. vet이
뚫리면서 그동안 가려져 있던 지적 13건이 드러나 함께 정리한다. 전부 okrbest
자체 코드이며 upstream과 무관하다.

gofmt (3):
- channels/api4/user.go: 검색 결과 제한 블록의 trailing whitespace
- channels/store/sqlstore/post_store.go: 빌더 체인 들여쓰기, trailing whitespace
- public/model/notification.go: NotificationHistoryCounts 필드 정렬

revive (1):
- public/model/notification.go: DeepCopy의 지역변수 copy가 내장함수를 가림
  → nCopy로 변경. 같은 파일 계열의 cCopy(channel.go)·pnCopy(push_notification.go)
    관례를 따랐다.

modernize (5):
- channels/api4/post.go 2곳: strings.Split + range → strings.SplitSeq
- channels/app/org_role.go 2곳: 3절 for → range over int
- channels/app/org_role.go 1곳: m[k]=v 루프 → maps.Copy

govet shadow (4):
- channels/api4/post.go 3곳: FilterBotMessagesFromPostList 호출부의 err가
  바깥 err를 가림 → filterErr로 분리
- channels/app/channel.go 1곳: AddUsersToGroupChannel에서 errors.As 대상
  appErr가 727행 appErr를 가림 → saveAppErr로 분리. 이 함수는 upstream에
  없는 자체 함수라 개명해도 cherry-pick 충돌 위험이 없다.

전부 동작 불변 리팩터다. 검증:
- make check-style → 0 issues (vet + golangci-lint 모두 통과)
- go test ./public/model/... 통과
- channels/app 조직도·그룹채널 테스트 통과
- channels/api4 포스트 조회·검색 테스트 통과
- channels/store/sqlstore 포스트 테스트 통과
